### PR TITLE
Fix docs usage commands and examples

### DIFF
--- a/docs/_includes/usage.md
+++ b/docs/_includes/usage.md
@@ -14,7 +14,7 @@ npm install @vrembem/{{ page.usage.npm }}
 
 {% if page.usage.scss and page.title != "Core" %}
 ```scss
-@import "vrembem/{{ page.usage.scss }}/index";
+@import "@vrembem/{{ page.usage.scss }}/index";
 ```
 {% endif %}
 

--- a/docs/_includes/usage.md
+++ b/docs/_includes/usage.md
@@ -8,19 +8,19 @@
 
 {% if page.usage.npm %}
 ```
-npm install {{ page.usage.npm }}
+npm install @vrembem/{{ page.usage.npm }}
 ```
 {% endif %}
 
 {% if page.usage.scss and page.title != "Core" %}
 ```scss
-@import "{{ page.usage.scss }}";
+@import "vrembem/{{ page.usage.scss }}/index";
 ```
 {% endif %}
 
 {% if page.usage.js and page.title != "Core" %}
 ```js
-import { {{ page.title }} } from "{{ page.usage.js }}"
+import { {{ page.title }} } from "@vrembem/{{ page.usage.js }}"
 ```
 {% endif %}
 

--- a/docs/_layouts/article.html
+++ b/docs/_layouts/article.html
@@ -16,8 +16,8 @@ layout: default
         <div class="grid__item span_6 spacing">
           <p>{{ page.description }}</p>
           <p>
-            <a href="https://www.npmjs.com/package/{{ page.usage.npm }}" target="_blank">
-              <img src="https://img.shields.io/npm/v/{{ page.usage.npm }}.svg" alt="npm version" />
+            <a href="https://www.npmjs.com/package/@vrembem/{{ page.usage.npm }}" target="_blank">
+              <img src="https://img.shields.io/npm/v/@vrembem/{{ page.usage.npm }}.svg" alt="npm version" />
             </a>
           </p>
         </div>

--- a/docs/_packages/arrow.md
+++ b/docs/_packages/arrow.md
@@ -4,8 +4,8 @@ title: Arrow
 description: "A directional triangle drawn with CSS."
 category: simple
 usage:
-  npm: "@vrembem/arrow"
-  scss: "@vrembem/arrow/index"
+  npm: "arrow"
+  scss: "arrow"
 ---
 
 {% include flag.html heading="arrow" %}

--- a/docs/_packages/base.md
+++ b/docs/_packages/base.md
@@ -4,8 +4,8 @@ title: Base
 description: "Includes useful default styles and base components for common HTML elements."
 category: simple
 usage:
-  npm: "@vrembem/base"
-  scss: "@vrembem/base/index"
+  npm: "base"
+  scss: "base"
 ---
 
 {% include flag.html heading="Heading" %}

--- a/docs/_packages/breadcrumb.md
+++ b/docs/_packages/breadcrumb.md
@@ -4,8 +4,8 @@ title: Breadcrumb
 description: "The breadcrumb component is a navigation component that shows the hierarchical path to a users current location."
 category: compound
 usage:
-  npm: "@vrembem/breadcrumb"
-  scss: "vrembem/breadcrumb/index"
+  npm: "breadcrumb"
+  scss: "breadcrumb"
 ---
 
 {% include flag.html heading="breadcrumb" %}

--- a/docs/_packages/button-group.md
+++ b/docs/_packages/button-group.md
@@ -4,8 +4,8 @@ title: Button-group
 description: "A component for displaying groups of buttons."
 category: compound
 usage:
-  npm: "@vrembem/button-group"
-  scss: "vrembem/button-group/index"
+  npm: "button-group"
+  scss: "button-group"
 ---
 
 {% include flag.html heading="button-group" %}

--- a/docs/_packages/button.md
+++ b/docs/_packages/button.md
@@ -4,8 +4,8 @@ title: Button
 description: "Buttons are a simple component that allow users to take actions."
 category: simple
 usage:
-  npm: "@vrembem/button"
-  scss: "vrembem/button/index"
+  npm: "button"
+  scss: "button"
 ---
 
 {% include flag.html heading="button" %}

--- a/docs/_packages/card.md
+++ b/docs/_packages/card.md
@@ -4,8 +4,8 @@ title: Card
 description: "The cards component provides a flexible and extensive content container with multiple variants and options."
 category: compound
 usage:
-  npm: "@vrembem/card"
-  scss: "vrembem/card/index"
+  npm: "card"
+  scss: "card"
 ---
 
 {% include flag.html heading="card" %}

--- a/docs/_packages/checkbox.md
+++ b/docs/_packages/checkbox.md
@@ -4,8 +4,8 @@ title: Checkbox
 description: "Checkboxes allow the user to select multiple options from a set."
 category: simple
 usage:
-  npm: "@vrembem/checkbox"
-  scss: "@vrembem/checkbox/index"
+  npm: "checkbox"
+  scss: "checkbox"
 ---
 
 {% include flag.html heading="checkbox" %}

--- a/docs/_packages/container.md
+++ b/docs/_packages/container.md
@@ -4,8 +4,8 @@ title: "Container"
 description: "A component for giving content a max width and centered within it's parent."
 category: layout
 usage:
-  npm: "@vrembem/container"
-  scss: "vrembem/container/index"
+  npm: "container"
+  scss: "container"
 ---
 
 {% include flag.html heading="container" %}

--- a/docs/_packages/core.md
+++ b/docs/_packages/core.md
@@ -4,9 +4,9 @@ title: Core
 description: "The core variables, functions and mixins for Vrembem components."
 category: simple
 usage:
-  npm: "@vrembem/core"
-  scss: "@vrembem/core/index"
-  js: "@vrembem/core"
+  npm: "core"
+  scss: "core"
+  js: "core"
 ---
 
 {% include flag.html heading="Sass" %}
@@ -16,7 +16,7 @@ To make use of global Vrembem functions, mixins and variables, it is recommended
 <div class="demo">
 <div class="demo__code" markdown="1">
 ```scss
-@import "@vrembem/core/index";
+@import "@vrembem/core";
 ```
 </div>
 </div>

--- a/docs/_packages/dialog.md
+++ b/docs/_packages/dialog.md
@@ -4,8 +4,8 @@ title: Dialog
 description: "A component that facilitates a conversation between the system and the user. They often request information or an action from the user."
 category: compound
 usage:
-  npm: "@vrembem/dialog"
-  scss: "vrembem/dialog/index"
+  npm: "dialog"
+  scss: "dialog"
 ---
 
 {% include flag.html heading="dialog + dialog__body" %}

--- a/docs/_packages/dismissible.md
+++ b/docs/_packages/dismissible.md
@@ -4,8 +4,8 @@ title: Dismissible
 description: "A component for removing an element from the DOM or hiding it with a CSS class."
 category: simple
 usage:
-  npm: "@vrembem/dismissible"
-  js: "@vrembem/dismissible"
+  npm: "dismissible"
+  js: "dismissible"
 ---
 
 {% include flag.html heading="dismissible" %}

--- a/docs/_packages/drawer.md
+++ b/docs/_packages/drawer.md
@@ -4,9 +4,9 @@ title: Drawer
 description: "A container component that slides in from the left or right. Typically containing menus, search or other content."
 category: compound
 usage:
-  npm: "@vrembem/drawer"
-  scss: "@vrembem/drawer/index"
-  js: "@vrembem/drawer"
+  npm: "drawer"
+  scss: "drawer"
+  js: "drawer"
 ---
 
 {% include flag.html heading="drawer" %}

--- a/docs/_packages/dropdown.md
+++ b/docs/_packages/dropdown.md
@@ -4,8 +4,8 @@ title: Dropdown
 description: "A component that is initially hidden and revealed upon user interaction either through a click or hover event. Dropdown components typically display lists of possible actions or navigation."
 category: compound
 usage:
-  npm: "@vrembem/dropdown"
-  scss: "vrembem/dropdown/index"
+  npm: "dropdown"
+  scss: "dropdown"
 ---
 
 {% include flag.html heading="dropdown" %}

--- a/docs/_packages/grid.md
+++ b/docs/_packages/grid.md
@@ -4,8 +4,8 @@ title: "Grid"
 description: "A flexbox based grid system component."
 category: layout
 usage:
-  npm: "@vrembem/grid"
-  scss: "vrembem/grid/index"
+  npm: "grid"
+  scss: "grid"
 ---
 
 {% include flag.html heading="grid + grid__item" %}

--- a/docs/_packages/icon-action.md
+++ b/docs/_packages/icon-action.md
@@ -4,8 +4,8 @@ title: Icon-action
 description: "A component for displaying simple action buttons using icons."
 category: simple
 usage:
-  npm: "@vrembem/icon-action"
-  scss: "vrembem/icon-action/index"
+  npm: "icon-action"
+  scss: "icon-action"
 ---
 
 {% include flag.html heading="icon-action" %}

--- a/docs/_packages/icon.md
+++ b/docs/_packages/icon.md
@@ -4,8 +4,8 @@ title: Icon
 description: "A component for displaying glyphs that convey meaning through iconography."
 category: simple
 usage:
-  npm: "@vrembem/icon"
-  scss: "vrembem/icon/index"
+  npm: "icon"
+  scss: "icon"
 ---
 
 <div class="notice notice_state_info" data-dismissible>

--- a/docs/_packages/input.md
+++ b/docs/_packages/input.md
@@ -4,8 +4,8 @@ title: Input
 description: "A component for displaying form input elements."
 category: simple
 usage:
-  npm: "@vrembem/input"
-  scss: "vrembem/input/index"
+  npm: "input"
+  scss: "input"
 ---
 
 {% include flag.html heading="input" %}

--- a/docs/_packages/level.md
+++ b/docs/_packages/level.md
@@ -4,8 +4,8 @@ title: "Level"
 description: "A simple flexbox based layout component."
 category: layout
 usage:
-  npm: "@vrembem/level"
-  scss: "vrembem/level/index"
+  npm: "level"
+  scss: "level"
 ---
 
 {% include flag.html heading="level" %}

--- a/docs/_packages/media.md
+++ b/docs/_packages/media.md
@@ -4,8 +4,8 @@ title: Media
 description: "The media component is used for displaying groups of content with a corresponding media asset, such as an image, avatar or icon."
 category: compound
 usage:
-  npm: "@vrembem/media"
-  scss: "vrembem/media/index"
+  npm: "media"
+  scss: "media"
 ---
 
 {% include flag.html heading="media" %}

--- a/docs/_packages/menu.md
+++ b/docs/_packages/menu.md
@@ -4,8 +4,8 @@ title: Menu
 description: "Menus represent groups of links, actions or tools that a user can interact with."
 category: compound
 usage:
-  npm: "@vrembem/menu"
-  scss: "vrembem/menu/index"
+  npm: "menu"
+  scss: "menu"
 ---
 
 {% include flag.html heading="menu" %}

--- a/docs/_packages/modal.md
+++ b/docs/_packages/modal.md
@@ -4,9 +4,9 @@ title: Modal
 description: "A component for changing the mode of a page to complete a critical task. This is usually used in conjunction with the dialog component to make modal dialogs."
 category: compound
 usage:
-  npm: "@vrembem/modal"
-  scss: "vrembem/modal/index"
-  js: "@vrembem/modal"
+  npm: "modal"
+  scss: "modal"
+  js: "modal"
 ---
 
 {% include flag.html heading="modal" %}

--- a/docs/_packages/notice.md
+++ b/docs/_packages/notice.md
@@ -4,8 +4,8 @@ title: Notice
 description: "A component for highlighting messages to the user."
 category: compound
 usage:
-  npm: "@vrembem/notice"
-  scss: "vrembem/notice/index"
+  npm: "notice"
+  scss: "notice"
 ---
 
 {% include flag.html heading="notice" %}

--- a/docs/_packages/panel.md
+++ b/docs/_packages/panel.md
@@ -4,8 +4,8 @@ title: Panel
 description: "Panels are a compositional container component that allows you to wrap and theme groups of content."
 category: layout
 usage:
-  npm: "@vrembem/panel"
-  scss: "vrembem/panel/index"
+  npm: "panel"
+  scss: "panel"
 ---
 
 {% include flag.html heading="panel" %}

--- a/docs/_packages/radio.md
+++ b/docs/_packages/radio.md
@@ -4,8 +4,8 @@ title: Radio Button
 description: "Radios allow the user to select a single option from a set."
 category: simple
 usage:
-  npm: "@vrembem/radio"
-  scss: "@vrembem/radio/index"
+  npm: "radio"
+  scss: "radio"
 ---
 
 {% include flag.html heading="radio" %}

--- a/docs/_packages/section.md
+++ b/docs/_packages/section.md
@@ -7,8 +7,8 @@ title: "Section"
 description: "A container component for wrapping distinct sections of a page."
 category: layout
 usage:
-  npm: "@vrembem/section"
-  scss: "vrembem/section/index"
+  npm: "section"
+  scss: "section"
 ---
 
 {% include section_open.html %}

--- a/docs/_packages/span.md
+++ b/docs/_packages/span.md
@@ -4,8 +4,8 @@ title: "Span"
 description: "A multi-purpose component for setting width, max-width and flex basis based on a column set."
 category: layout
 usage:
-  npm: "@vrembem/span"
-  scss: "vrembem/span/index"
+  npm: "span"
+  scss: "span"
 ---
 
 {% include flag.html heading="span_auto" %}

--- a/docs/_packages/switch.md
+++ b/docs/_packages/switch.md
@@ -4,8 +4,8 @@ title: "Switch"
 description: "Switches are a binary form element used to toggle between two options."
 category: simple
 usage:
-  npm: "@vrembem/switch"
-  scss: "vrembem/switch/index"
+  npm: "switch"
+  scss: "switch"
 ---
 
 {% include flag.html heading="switch" %}

--- a/docs/_packages/table.md
+++ b/docs/_packages/table.md
@@ -4,8 +4,8 @@ title: Table
 description: "A table component for displaying HTML tables."
 category: simple
 usage:
-  npm: "@vrembem/table"
-  scss: "@vrembem/table/index"
+  npm: "table"
+  scss: "table"
 ---
 
 {% include flag.html heading="table" %}

--- a/docs/_packages/tooltip.md
+++ b/docs/_packages/tooltip.md
@@ -4,8 +4,8 @@ title: Tooltip
 description: "Text labels that appear when a user hovers over, focuses on or touches an element."
 category: simple
 usage:
-  npm: "@vrembem/tooltip"
-  scss: "vrembem/tooltip/index"
+  npm: "tooltip"
+  scss: "tooltip"
 ---
 
 {% include flag.html heading="[data-tooltip]" %}

--- a/docs/_packages/utility.md
+++ b/docs/_packages/utility.md
@@ -4,8 +4,8 @@ title: Utility
 description: "The utility component provides a set of atomic classes that specialize in a single function."
 category: simple
 usage:
-  npm: "@vrembem/utility"
-  scss: "@vrembem/utility/index"
+  npm: "utility"
+  scss: "utility"
 ---
 
 {% include flag.html heading="background" %}


### PR DESCRIPTION
### Problem:

There was a lot of duplication with the usage template and how it was displaying the commands for using a component. There was also a typo with the SCSS import example which left out the needed `@` prefix.

### Solution:

This PR fixes the SCSS import typo and removes a lot of the repeated elements of usage into the template and out of the package files.