### PR TITLE
Fix horizontal scrolling in docs

### DIFF
--- a/docs/_packages/arrow.md
+++ b/docs/_packages/arrow.md
@@ -57,33 +57,35 @@ usage:
 {% include flag.html heading="menu > arrow" %}
 
 {% include demo_open.html %}
-<ul class="menu menu_wrap">
-  <li class="menu__item">
-    <a class="menu__link" href="#">
-      <span>Create</span>
-      <span class="arrow"></span>
-    </a>
-  </li>
-  <li class="menu__item">
-    <a class="menu__link is-active" href="#">
-      <span class="arrow arrow_up"></span>
-      <span>Update</span>
-    </a>
-  </li>
-  <li class="menu__item">
-    <a class="menu__link is-disabled" href="#">
-      <span>Delete</span>
-      <span class="arrow arrow_right"></span>
-    </a>
-  </li>
-  <li class="menu__sep"></li>
-  <li class="menu__item">
-    <a class="menu__link" href="#">
-      <span class="arrow arrow_left"></span>
-      <span>Logout</span>
-    </a>
-  </li>
-</ul>
+<div class="scroll-box">
+  <ul class="menu menu_wrap">
+    <li class="menu__item">
+      <a class="menu__link" href="#">
+        <span>Create</span>
+        <span class="arrow"></span>
+      </a>
+    </li>
+    <li class="menu__item">
+      <a class="menu__link is-active" href="#">
+        <span class="arrow arrow_up"></span>
+        <span>Update</span>
+      </a>
+    </li>
+    <li class="menu__item">
+      <a class="menu__link is-disabled" href="#">
+        <span>Delete</span>
+        <span class="arrow arrow_right"></span>
+      </a>
+    </li>
+    <li class="menu__sep"></li>
+    <li class="menu__item">
+      <a class="menu__link" href="#">
+        <span class="arrow arrow_left"></span>
+        <span>Logout</span>
+      </a>
+    </li>
+  </ul>
+</div>
 {% include demo_switch.html %}
 ```html
 <ul class="menu">

--- a/docs/_packages/checkbox.md
+++ b/docs/_packages/checkbox.md
@@ -75,3 +75,71 @@ new Checkbox({ autoInit: true })
 </label>
 ```
 {% include demo_close.html %}
+
+{% include flag.html heading="Checkbox Settings" %}
+
+<div class="scroll-box">
+  <table class="table table_zebra">
+    <thead>
+      <tr class="border_top_0">
+        <th>Key</th>
+        <th>Default</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code class="code text_nowrap">autoInit</code></td>
+        <td><code class="code text_nowrap">false</code></td>
+        <td>Automatically instantiates the instance</td>
+      </tr>
+
+      <tr>
+        <td><code class="code text_nowrap">stateAttr</code></td>
+        <td><code class="code text_nowrap">"aria-checked"</code></td>
+        <td>Attribute to check mixed against</td>
+      </tr>
+
+      <tr>
+        <td><code class="code text_nowrap">stateValue</code></td>
+        <td><code class="code text_nowrap">"mixed"</code></td>
+        <td>Mixed value to check for</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+{% include flag.html heading="Checkbox API" %}
+
+<div class="scroll-box">
+  <table class="table table_zebra">
+    <thead>
+      <tr class="border_top_0">
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code class="code text_nowrap">checkbox.init()</code></td>
+        <td>Initializes the checkbox instance</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">checkbox.destroy()</code></td>
+        <td>Destroys and cleans up the checkbox instantiation</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">checkbox.setAriaState(el, value)</code></td>
+        <td>Sets the attribute value for mixed checkboxes</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">checkbox.removeAriaState(el)</code></td>
+        <td>Removes the mixed checkbox attribute</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">checkbox.setIndeterminate(el)</code></td>
+        <td>Sets the checkbox to an indeterminate (mixed) state</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/docs/_packages/core.md
+++ b/docs/_packages/core.md
@@ -66,41 +66,43 @@ core.removeClass(el, "some-class");
 
 Available named exports:
 
-<table class="table table_zebra">
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code class="code text_nowrap">addClass</code></td>
-      <td>Adds a class or classes to an element or NodeList</td>
-    </tr>
-    <tr>
-      <td><code class="code text_nowrap">camelCase</code></td>
-      <td>Takes a hyphen cased string and converts it to camel case</td>
-    </tr>
-    <tr>
-      <td><code class="code text_nowrap">hasClass</code></td>
-      <td>Checks an element or NodeList whether they contain a class or classes</td>
-    </tr>
-    <tr>
-      <td><code class="code text_nowrap">hyphenCase</code></td>
-      <td>Takes a camel cased string and converts it to hyphen case</td>
-    </tr>
-    <tr>
-      <td><code class="code text_nowrap">removeClass</code></td>
-      <td>Remove a class or classes from an element or NodeList</td>
-    </tr>
-    <tr>
-      <td><code class="code text_nowrap">toggleClass</code></td>
-      <td>Toggle a class or classes on an element or NodeList</td>
-    </tr>
-    <tr>
-      <td><code class="code text_nowrap">variables</code></td>
-      <td>Exposes CSS variables in JavaScript</td>
-    </tr>
-  </tbody>
-</table>
+<div class="scroll-box">
+  <table class="table table_zebra">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code class="code text_nowrap">addClass</code></td>
+        <td>Adds a class or classes to an element or NodeList</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">camelCase</code></td>
+        <td>Takes a hyphen cased string and converts it to camel case</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">hasClass</code></td>
+        <td>Checks an element or NodeList whether they contain a class or classes</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">hyphenCase</code></td>
+        <td>Takes a camel cased string and converts it to hyphen case</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">removeClass</code></td>
+        <td>Remove a class or classes from an element or NodeList</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">toggleClass</code></td>
+        <td>Toggle a class or classes on an element or NodeList</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">variables</code></td>
+        <td>Exposes CSS variables in JavaScript</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/docs/_packages/dismissible.md
+++ b/docs/_packages/dismissible.md
@@ -121,52 +121,64 @@ Dismissible uses two data attributes to utilize it's functionality. The first is
 
 {% include flag.html heading="Dismissible Settings" %}
 
-<table class="table table_zebra">
-  <thead>
-    <tr class="border_top_0">
-      <th>Key</th>
-      <th>Default</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code class="code text_nowrap">autoInit</code></td>
-      <td><code class="code text_nowrap">false</code></td>
-      <td>Automatically instantiates the instance</td>
-    </tr>
-
-    <!-- Data attributes -->
-    <tr>
-      <td><code class="code text_nowrap">dataTrigger</code></td>
-      <td><code class="code text_nowrap">"dismiss"</code></td>
-      <td>Data attribute for a dismiss trigger</td>
-    </tr>
-    <tr>
-      <td><code class="code text_nowrap">dataTarget</code></td>
-      <td><code class="code text_nowrap">"dismissible"</code></td>
-      <td>Data attribute for a dismissible element</td>
-    </tr>
-  </tbody>
-</table>
+<div class="scroll-box">
+  <table class="table table_zebra">
+    <thead>
+      <tr class="border_top_0">
+        <th>Key</th>
+        <th>Default</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code class="code text_nowrap">autoInit</code></td>
+        <td><code class="code text_nowrap">false</code></td>
+        <td>Automatically instantiates the instance</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">dataTrigger</code></td>
+        <td><code class="code text_nowrap">"dismiss"</code></td>
+        <td>Data attribute for a dismiss trigger</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">dataTarget</code></td>
+        <td><code class="code text_nowrap">"dismissible"</code></td>
+        <td>Data attribute for a dismissible element</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">classHide</code></td>
+        <td><code class="code text_nowrap">"display_none"</code></td>
+        <td>The class to apply for hiding an element</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">method</code></td>
+        <td><code class="code text_nowrap">"hide"</code></td>
+        <td>The method of dismissing an element. Either "hide" or "remove".</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 {% include flag.html heading="Dismissible API" %}
 
-<table class="table table_zebra">
-  <thead>
-    <tr class="border_top_0">
-      <th>Name</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code class="code text_nowrap">modal.init()</code></td>
-      <td>Initializes the dismissible instance</td>
-    </tr>
-    <tr>
-      <td><code class="code text_nowrap">modal.destroy()</code></td>
-      <td>Destroys and cleans up the dismissible instantiation</td>
-    </tr>
-  </tbody>
-</table>
+<div class="scroll-box">
+  <table class="table table_zebra">
+    <thead>
+      <tr class="border_top_0">
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code class="code text_nowrap">dismissible.init()</code></td>
+        <td>Initializes the dismissible instance</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">dismissible.destroy()</code></td>
+        <td>Destroys and cleans up the dismissible instantiation</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/docs/_packages/drawer.md
+++ b/docs/_packages/drawer.md
@@ -327,130 +327,134 @@ By default, the state of a drawer is saved to local storage and applied persiste
 
 {% include flag.html heading="Drawer Settings" %}
 
-<table class="table table_zebra">
-  <thead>
-    <tr class="border_top_0">
-      <th>Key</th>
-      <th>Default</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
+<div class="scroll-box">
+  <table class="table table_zebra">
+    <thead>
+      <tr class="border_top_0">
+        <th>Key</th>
+        <th>Default</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code class="code text_nowrap">autoInit</code></td>
+        <td><code class="code text_nowrap">false</code></td>
+        <td>Automatically instantiates the instance</td>
+      </tr>
+
+      <!-- Data attributes -->
+      <tr>
+        <td><code class="code text_nowrap">dataDrawer</code></td>
+        <td><code class="code text_nowrap">"drawer"</code></td>
+        <td>Data attribute for a drawer</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">dataToggle</code></td>
+        <td><code class="code text_nowrap">"drawer-toggle"</code></td>
+        <td>Data attribute for a drawer toggle trigger</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">dataClose</code></td>
+        <td><code class="code text_nowrap">"drawer-close"</code></td>
+        <td>Data attribute for a drawer close trigger</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">dataBreakpoint</code></td>
+        <td><code class="code text_nowrap">"drawer-breakpoint"</code></td>
+        <td>Data attribute for setting a drawer's breakpoint</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">dataFocus</code></td>
+        <td><code class="code text_nowrap">"drawer-focus"</code></td>
+        <td>Data attribute for setting a drawer's focus element</td>
+      </tr>
+    </tbody>
+
+    <!-- State classes -->
     <tr>
-      <td><code class="code text_nowrap">autoInit</code></td>
-      <td><code class="code text_nowrap">false</code></td>
-      <td>Automatically instantiates the instance</td>
+      <td><code class="code text_nowrap">stateOpen</code></td>
+      <td><code class="code text_nowrap">"is-open"</code></td>
+      <td>Class used for open state</td>
+    </tr>
+    <tr>
+      <td><code class="code text_nowrap">stateOpening</code></td>
+      <td><code class="code text_nowrap">"is-opening"</code></td>
+      <td>Class used for transitioning to open state</td>
+    </tr>
+    <tr>
+      <td><code class="code text_nowrap">stateClosing</code></td>
+      <td><code class="code text_nowrap">"is-closing"</code></td>
+      <td>Class used for transitioning to closed state</td>
+    </tr>
+    <tr>
+      <td><code class="code text_nowrap">stateClosed</code></td>
+      <td><code class="code text_nowrap">"is-closed"</code></td>
+      <td>Class used for closed state (is ommitted in application)</td>
     </tr>
 
-    <!-- Data attributes -->
+    <!-- Classes -->
     <tr>
-      <td><code class="code text_nowrap">dataDrawer</code></td>
-      <td><code class="code text_nowrap">"drawer"</code></td>
-      <td>Data attribute for a drawer</td>
+      <td><code class="code text_nowrap">classModal</code></td>
+      <td><code class="code text_nowrap">"drawer_modal"</code></td>
+      <td>Class used for toggling the drawer modal state</td>
     </tr>
-    <tr>
-      <td><code class="code text_nowrap">dataToggle</code></td>
-      <td><code class="code text_nowrap">"drawer-toggle"</code></td>
-      <td>Data attribute for a drawer toggle trigger</td>
-    </tr>
-    <tr>
-      <td><code class="code text_nowrap">dataClose</code></td>
-      <td><code class="code text_nowrap">"drawer-close"</code></td>
-      <td>Data attribute for a drawer close trigger</td>
-    </tr>
-    <tr>
-      <td><code class="code text_nowrap">dataBreakpoint</code></td>
-      <td><code class="code text_nowrap">"drawer-breakpoint"</code></td>
-      <td>Data attribute for setting a drawer's breakpoint</td>
-    </tr>
-    <tr>
-      <td><code class="code text_nowrap">dataFocus</code></td>
-      <td><code class="code text_nowrap">"drawer-focus"</code></td>
-      <td>Data attribute for setting a drawer's focus element</td>
-    </tr>
-  </tbody>
 
-  <!-- State classes -->
-  <tr>
-    <td><code class="code text_nowrap">stateOpen</code></td>
-    <td><code class="code text_nowrap">"is-open"</code></td>
-    <td>Class used for open state</td>
-  </tr>
-  <tr>
-    <td><code class="code text_nowrap">stateOpening</code></td>
-    <td><code class="code text_nowrap">"is-opening"</code></td>
-    <td>Class used for transitioning to open state</td>
-  </tr>
-  <tr>
-    <td><code class="code text_nowrap">stateClosing</code></td>
-    <td><code class="code text_nowrap">"is-closing"</code></td>
-    <td>Class used for transitioning to closed state</td>
-  </tr>
-  <tr>
-    <td><code class="code text_nowrap">stateClosed</code></td>
-    <td><code class="code text_nowrap">"is-closed"</code></td>
-    <td>Class used for closed state (is ommitted in application)</td>
-  </tr>
-
-  <!-- Classes -->
-  <tr>
-    <td><code class="code text_nowrap">classModal</code></td>
-    <td><code class="code text_nowrap">"drawer_modal"</code></td>
-    <td>Class used for toggling the drawer modal state</td>
-  </tr>
-
-  <!-- Feature toggles -->
-  <tr>
-    <td><code class="code text_nowrap">breakpoint</code></td>
-    <td><code class="code text_nowrap">core.breakpoint</code></td>
-    <td>An object with key/value pairs defining a breakpoint set</td>
-  </tr>
-  <tr>
-    <td><code class="code text_nowrap">focus</code></td>
-    <td><code class="code text_nowrap">true</code></td>
-    <td>Toggles the focus handling feature</td>
-  </tr>
-  <tr>
-    <td><code class="code text_nowrap">saveState</code></td>
-    <td><code class="code text_nowrap">true</code></td>
-    <td>Toggles the save state feature</td>
-  </tr>
-  <tr>
-    <td><code class="code text_nowrap">saveKey</code></td>
-    <td><code class="code text_nowrap">"DrawerState"</code></td>
-    <td>Defines the localStorage key where drawer states are saved</td>
-  </tr>
-</table>
+    <!-- Feature toggles -->
+    <tr>
+      <td><code class="code text_nowrap">breakpoint</code></td>
+      <td><code class="code text_nowrap">core.breakpoint</code></td>
+      <td>An object with key/value pairs defining a breakpoint set</td>
+    </tr>
+    <tr>
+      <td><code class="code text_nowrap">focus</code></td>
+      <td><code class="code text_nowrap">true</code></td>
+      <td>Toggles the focus handling feature</td>
+    </tr>
+    <tr>
+      <td><code class="code text_nowrap">saveState</code></td>
+      <td><code class="code text_nowrap">true</code></td>
+      <td>Toggles the save state feature</td>
+    </tr>
+    <tr>
+      <td><code class="code text_nowrap">saveKey</code></td>
+      <td><code class="code text_nowrap">"DrawerState"</code></td>
+      <td>Defines the localStorage key where drawer states are saved</td>
+    </tr>
+  </table>
+</div>
 
 {% include flag.html heading="Drawer API" %}
 
-<table class="table table_zebra">
-  <thead>
-    <tr class="border_top_0">
-      <th>Name</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code class="code text_nowrap">drawer.init()</code></td>
-      <td>Initializes the drawer instance</td>
-    </tr>
-    <tr>
-      <td><code class="code text_nowrap">drawer.destroy()</code></td>
-      <td>Destroys and cleans up the drawer instantiation</td>
-    </tr>
-    <tr>
-      <td><code class="code text_nowrap">drawer.toggle(drawerKey, callback)</code></td>
-      <td>Toggles a drawer provided the drawer key and optional callback</td>
-    </tr>
-    <tr>
-      <td><code class="code text_nowrap">drawer.open(drawerKey, callback)</code></td>
-      <td>Opens a drawer provided the drawer key and optional callback</td>
-    </tr>
-    <tr>
-      <td><code class="code text_nowrap">drawer.close(drawerKey, callback)</code></td>
-      <td>Closes a drawer provided the drawer key and optional callback</td>
-    </tr>
-  </tbody>
-</table>
+<div class="scroll-box">
+  <table class="table table_zebra">
+    <thead>
+      <tr class="border_top_0">
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code class="code text_nowrap">drawer.init()</code></td>
+        <td>Initializes the drawer instance</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">drawer.destroy()</code></td>
+        <td>Destroys and cleans up the drawer instantiation</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">drawer.toggle(drawerKey, callback)</code></td>
+        <td>Toggles a drawer provided the drawer key and optional callback</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">drawer.open(drawerKey, callback)</code></td>
+        <td>Opens a drawer provided the drawer key and optional callback</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">drawer.close(drawerKey, callback)</code></td>
+        <td>Closes a drawer provided the drawer key and optional callback</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/docs/_packages/modal.md
+++ b/docs/_packages/modal.md
@@ -163,107 +163,111 @@ Required modals can not be closed without an explicit action. That means clickin
 
 {% include flag.html heading="Modal settings" %}
 
-<table class="table table_zebra">
-  <thead>
-    <tr class="border_top_0">
-      <th>Key</th>
-      <th>Default</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
+<div class="scroll-box">
+  <table class="table table_zebra">
+    <thead>
+      <tr class="border_top_0">
+        <th>Key</th>
+        <th>Default</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code class="code text_nowrap">autoInit</code></td>
+        <td><code class="code text_nowrap">false</code></td>
+        <td>Automatically instantiates the instance</td>
+      </tr>
+
+      <!-- Data attributes -->
+      <tr>
+        <td><code class="code text_nowrap">dataModal</code></td>
+        <td><code class="code text_nowrap">"modal"</code></td>
+        <td>Data attribute for a modal</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">dataOpen</code></td>
+        <td><code class="code text_nowrap">"modal-open"</code></td>
+        <td>Data attribute for a modal open trigger</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">dataClose</code></td>
+        <td><code class="code text_nowrap">"modal-close"</code></td>
+        <td>Data attribute for a modal close trigger</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">dataFocus</code></td>
+        <td><code class="code text_nowrap">"modal-focus"</code></td>
+        <td>Data attribute for setting a modal's focus element</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">dataRequired</code></td>
+        <td><code class="code text_nowrap">"modal-required"</code></td>
+        <td>Data attribute for making a modal required</td>
+      </tr>
+    </tbody>
+
+    <!-- State classes -->
     <tr>
-      <td><code class="code text_nowrap">autoInit</code></td>
-      <td><code class="code text_nowrap">false</code></td>
-      <td>Automatically instantiates the instance</td>
+      <td><code class="code text_nowrap">stateOpen</code></td>
+      <td><code class="code text_nowrap">"is-open"</code></td>
+      <td>Class used for open state</td>
+    </tr>
+    <tr>
+      <td><code class="code text_nowrap">stateOpening</code></td>
+      <td><code class="code text_nowrap">"is-opening"</code></td>
+      <td>Class used for transitioning to open state</td>
+    </tr>
+    <tr>
+      <td><code class="code text_nowrap">stateClosing</code></td>
+      <td><code class="code text_nowrap">"is-closing"</code></td>
+      <td>Class used for transitioning to closed state</td>
+    </tr>
+    <tr>
+      <td><code class="code text_nowrap">stateClosed</code></td>
+      <td><code class="code text_nowrap">"is-closed"</code></td>
+      <td>Class used for closed state (is ommitted in application)</td>
     </tr>
 
-    <!-- Data attributes -->
+    <!-- Feature toggles -->
     <tr>
-      <td><code class="code text_nowrap">dataModal</code></td>
-      <td><code class="code text_nowrap">"modal"</code></td>
-      <td>Data attribute for a modal</td>
+      <td><code class="code text_nowrap">focus</code></td>
+      <td><code class="code text_nowrap">true</code></td>
+      <td>Toggles the focus handling feature</td>
     </tr>
-    <tr>
-      <td><code class="code text_nowrap">dataOpen</code></td>
-      <td><code class="code text_nowrap">"modal-open"</code></td>
-      <td>Data attribute for a modal open trigger</td>
-    </tr>
-    <tr>
-      <td><code class="code text_nowrap">dataClose</code></td>
-      <td><code class="code text_nowrap">"modal-close"</code></td>
-      <td>Data attribute for a modal close trigger</td>
-    </tr>
-    <tr>
-      <td><code class="code text_nowrap">dataFocus</code></td>
-      <td><code class="code text_nowrap">"modal-focus"</code></td>
-      <td>Data attribute for setting a modal's focus element</td>
-    </tr>
-    <tr>
-      <td><code class="code text_nowrap">dataRequired</code></td>
-      <td><code class="code text_nowrap">"modal-required"</code></td>
-      <td>Data attribute for making a modal required</td>
-    </tr>
-  </tbody>
-
-  <!-- State classes -->
-  <tr>
-    <td><code class="code text_nowrap">stateOpen</code></td>
-    <td><code class="code text_nowrap">"is-open"</code></td>
-    <td>Class used for open state</td>
-  </tr>
-  <tr>
-    <td><code class="code text_nowrap">stateOpening</code></td>
-    <td><code class="code text_nowrap">"is-opening"</code></td>
-    <td>Class used for transitioning to open state</td>
-  </tr>
-  <tr>
-    <td><code class="code text_nowrap">stateClosing</code></td>
-    <td><code class="code text_nowrap">"is-closing"</code></td>
-    <td>Class used for transitioning to closed state</td>
-  </tr>
-  <tr>
-    <td><code class="code text_nowrap">stateClosed</code></td>
-    <td><code class="code text_nowrap">"is-closed"</code></td>
-    <td>Class used for closed state (is ommitted in application)</td>
-  </tr>
-
-  <!-- Feature toggles -->
-  <tr>
-    <td><code class="code text_nowrap">focus</code></td>
-    <td><code class="code text_nowrap">true</code></td>
-    <td>Toggles the focus handling feature</td>
-  </tr>
-</table>
+  </table>
+</div>
 
 {% include flag.html heading="Modal API" %}
 
-<table class="table table_zebra">
-  <thead>
-    <tr class="border_top_0">
-      <th>Name</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code class="code text_nowrap">modal.init()</code></td>
-      <td>Initializes the modal instance</td>
-    </tr>
-    <tr>
-      <td><code class="code text_nowrap">modal.destroy()</code></td>
-      <td>Destroys and cleans up the modal instantiation</td>
-    </tr>
-    <tr>
-      <td><code class="code text_nowrap">modal.open(modalKey, callback)</code></td>
-      <td>Opens a modal provided the modal key and optional callback</td>
-    </tr>
-    <tr>
-      <td><code class="code text_nowrap">modal.close(returnFocus, callback)</code></td>
-      <td>Closes a modal and returns focus to trigger element with optional callback</td>
-    </tr>
-  </tbody>
-</table>
+<div class="scroll-box">
+  <table class="table table_zebra">
+    <thead>
+      <tr class="border_top_0">
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code class="code text_nowrap">modal.init()</code></td>
+        <td>Initializes the modal instance</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">modal.destroy()</code></td>
+        <td>Destroys and cleans up the modal instantiation</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">modal.open(modalKey, callback)</code></td>
+        <td>Opens a modal provided the modal key and optional callback</td>
+      </tr>
+      <tr>
+        <td><code class="code text_nowrap">modal.close(returnFocus, callback)</code></td>
+        <td>Closes a modal and returns focus to trigger element with optional callback</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 <!-- modals -->
 <div>


### PR DESCRIPTION
## Problem

There are some docs pages that have horizontal scrolling on mobile.

## Solution

This PR introduces a fix by wrapping large tables in the `scroll-box` base component so that there's only scrolling for the table or component themselves instead of causing the page to have horizontal scrolling.