### PR TITLE
Fix repository directory value

### DIFF
--- a/packages/vrembem/package.json
+++ b/packages/vrembem/package.json
@@ -20,7 +20,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sebnitu/vrembem.git",
-    "directory": "packages/all"
+    "directory": "packages/vrembem"
   },
   "dependencies": {
     "@vrembem/arrow": "^1.5.1",


### PR DESCRIPTION
## Problem

The wrong value is set for the repository directory causing broken commit links in dependabot PRs.

## Solution

This PR changes the repository directory to the correct value.