### PR TITLE
Add links between readme and web documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,18 +96,13 @@ Via your project's Sass manifest file:
 Via your project's JavaScript manifest file:
 
 ```js
-import {
-  utility,
-  Checkbox,
-  Dismissible,
-  Drawer,
-  Modal
-} from "vrembem"
+// Import all under the vb namespace
+import * as vb from "vrembem";
+const drawer = new vb.Drawer({ autoInit: true });
 
-new Checkbox({ autoInit: true })
-new Dismissible({ autoInit: true })
-new Drawer({ autoInit: true })
-new Modal({ autoInit: true })
+// Or import individual components
+import { Drawer } from "vrembem";
+const drawer = new Drawer({ autoInit: true });
 ```
 
 ## Packages

--- a/docs/_layouts/article.html
+++ b/docs/_layouts/article.html
@@ -26,6 +26,7 @@ layout: default
               </a>
             {% endif %}
           </p>
+          <p><a href="https://github.com/{{ site.repository }}/tree/master/packages/{{ page.usage.npm }}" class="link text_size_sm">Source Code</a></p>
         </div>
         {% endif %}
 

--- a/docs/_packages/vrembem.md
+++ b/docs/_packages/vrembem.md
@@ -1,7 +1,7 @@
 ---
 layout: article
 title: Vrembem
-description: "A complete collection of all Vrembem packages into a single comprehensive library for convenience."
+description: "A complete collection of all Vrembem components into a single comprehensive library for convenience."
 category: compound
 usage:
   npm: "vrembem"
@@ -11,7 +11,9 @@ usage:
 
 {% include flag.html heading="Sass" %}
 
+<div class="type" markdown="1">
 To include all Vrembem components into your styles, just import the vrembem package in your Sass manifest file.
+</div>
 
 <div class="demo">
 <div class="demo__code" markdown="1">
@@ -21,38 +23,58 @@ To include all Vrembem components into your styles, just import the vrembem pack
 </div>
 </div>
 
+<div class="type" markdown="1">
+All component variables, functions and mixins are forwarded under their respective namespace and can be customized:
+</div>
+
+<div class="demo">
+<div class="demo__code" markdown="1">
+```scss
+@use "vrembem" with (
+  $button-padding: 1rem 2rem
+);
+```
+</div>
+</div>
+
+<div class="type" markdown="1">
+Customize core variables which all components inherit from. The example below will prefix all components with a prefix:
+</div>
+
+<div class="demo">
+<div class="demo__code" markdown="1">
+```scss
+@use "@vrembem/core" with (
+  $prefix-block: "vb-"
+);
+@use "vrembem";
+```
+</div>
+</div>
+
 {% include flag.html heading="JavaScript" %}
 
-First we need to import the JavaScript component's we'd like to use.
+<div class="type" markdown="1">
+Import and initialize the components you'll need:
+</div>
 
 <div class="demo">
 <div class="demo__code" markdown="1">
 ```js
-import {
-  utility,
-  Checkbox,
-  Dismissible,
-  Drawer,
-  Modal
-} from "vrembem"
+// Import all under the vb namespace
+import * as vb from "vrembem";
+const drawer = new vb.Drawer({ autoInit: true });
+
+// Or import individual components
+import { Drawer } from "vrembem";
+const drawer = new Drawer({ autoInit: true });
 ```
 </div>
 </div>
 
-Then we can create an instance of each script. In this example, we set them to auto initialize.
-
-<div class="demo">
-<div class="demo__code" markdown="1">
-```js
-new Checkbox({ autoInit: true })
-new Dismissible({ autoInit: true })
-new Drawer({ autoInit: true })
-new Modal({ autoInit: true })
-```
+<div class="type" markdown="1">
+Components also make available the `init` function for initializing or re-initializing.
 </div>
-</div>
-
-We can also manually initialize components using their `init` function.
 
 <div class="demo">
 <div class="demo__code" markdown="1">
@@ -63,4 +85,29 @@ modal.init()
 </div>
 </div>
 
-*Note that `utility` does not need to be instantiated since it's just a set of helpful utility functions.*
+<div class="type" markdown="1">
+> Note that `utility` component does not need to be initialized since it's just a set of helpful utility functions.
+</div>
+
+{% include flag.html heading="Markup" %}
+
+<div class="type" markdown="1">
+Include the component's markup into your project. Use the [online documentation](https://vrembem.com) for more information, code examples and available modifiers.
+</div>
+
+<div class="demo">
+<div class="demo__code" markdown="1">
+```html
+<div class="drawer__wrapper">
+  <aside data-drawer="[unique-id]" class="drawer">
+    <div class="drawer__item">
+      <button data-drawer-close>...</button>
+    </div>
+  </aside>
+  <div class="drawer__main">
+    <button data-drawer-toggle="[unique-id]">...</button>
+  </div>
+</div>
+```
+</div>
+</div>

--- a/packages/arrow/README.md
+++ b/packages/arrow/README.md
@@ -3,3 +3,5 @@
 A directional triangle drawn with CSS.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Farrow.svg)](https://www.npmjs.com/package/%40vrembem%2Farrow)
+
+[Documentation](https://vrembem.com/packages/arrow)

--- a/packages/arrow/package.json
+++ b/packages/arrow/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/arrow",
   "description": "A directional triangle drawn with CSS.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "arrow"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/base/README.md
+++ b/packages/base/README.md
@@ -3,3 +3,5 @@
 Includes useful default styles and base components for common HTML elements.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Fbase.svg)](https://www.npmjs.com/package/%40vrembem%2Fbase)
+
+[Documentation](https://vrembem.com/packages/base)

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/base",
   "description": "Includes useful default styles and base components for common HTML elements.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "base"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/breadcrumb/README.md
+++ b/packages/breadcrumb/README.md
@@ -3,3 +3,5 @@
 The breadcrumb component is a navigation component that shows the hierarchical path to a users current location.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Fbreadcrumb.svg)](https://www.npmjs.com/package/%40vrembem%2Fbreadcrumb)
+
+[Documentation](https://vrembem.com/packages/breadcrumb)

--- a/packages/breadcrumb/package.json
+++ b/packages/breadcrumb/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/breadcrumb",
   "description": "The breadcrumb component is a navigation component that shows the hierarchical path to a users current location.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "breadcrumb"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/button-group/README.md
+++ b/packages/button-group/README.md
@@ -3,3 +3,5 @@
 A component for displaying groups of buttons.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Fbutton-group.svg)](https://www.npmjs.com/package/%40vrembem%2Fbutton-group)
+
+[Documentation](https://vrembem.com/packages/button-group)

--- a/packages/button-group/package.json
+++ b/packages/button-group/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/button-group",
   "description": "A component for displaying groups of buttons.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "button-group"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -3,3 +3,5 @@
 Buttons are a simple component that allow users to take actions.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Fbutton.svg)](https://www.npmjs.com/package/%40vrembem%2Fbutton)
+
+[Documentation](https://vrembem.com/packages/button)

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/button",
   "description": "Buttons are a simple component that allow users to take actions.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "button"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/card/README.md
+++ b/packages/card/README.md
@@ -3,3 +3,5 @@
 The cards component provides a flexible and extensive content container with multiple variants and options.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Fcard.svg)](https://www.npmjs.com/package/%40vrembem%2Fcard)
+
+[Documentation](https://vrembem.com/packages/card)

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/card",
   "description": "The cards component provides a flexible and extensive content container with multiple variants and options.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "card"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/checkbox/README.md
+++ b/packages/checkbox/README.md
@@ -3,3 +3,5 @@
 Checkboxes allow the user to select multiple options from a set.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Fcheckbox.svg)](https://www.npmjs.com/package/%40vrembem%2Fcheckbox)
+
+[Documentation](https://vrembem.com/packages/checkbox)

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/checkbox",
   "description": "Checkboxes allow the user to select multiple options from a set.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "checkbox"
+  ],
   "main": "dist/scripts.cjs.js",
   "module": "index.js",
   "browser": "dist/scripts.js",

--- a/packages/container/README.md
+++ b/packages/container/README.md
@@ -3,3 +3,5 @@
 A component for giving content a max width and centered within it's parent.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Fcontainer.svg)](https://www.npmjs.com/package/%40vrembem%2Fcontainer)
+
+[Documentation](https://vrembem.com/packages/container)

--- a/packages/container/package.json
+++ b/packages/container/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/container",
   "description": "A component for giving content a max width and centered within it's parent.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "container"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3,3 +3,5 @@
 The core variables, functions and mixins for Vrembem components.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Fcore.svg)](https://www.npmjs.com/package/%40vrembem%2Fcore)
+
+[Documentation](https://vrembem.com/packages/core)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/core",
   "description": "The core variables, functions and mixins for Vrembem components.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "core"
+  ],
   "main": "dist/scripts.cjs.js",
   "module": "index.js",
   "browser": "dist/scripts.js",

--- a/packages/dialog/README.md
+++ b/packages/dialog/README.md
@@ -3,3 +3,5 @@
 A component that facilitates a conversation between the system and the user. They often request information or an action from the user.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Fdialog.svg)](https://www.npmjs.com/package/%40vrembem%2Fdialog)
+
+[Documentation](https://vrembem.com/packages/dialog)

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/dialog",
   "description": "A component that facilitates a conversation between the system and the user. They often request information or an action from the user.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "dialog"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/dismissible/README.md
+++ b/packages/dismissible/README.md
@@ -3,3 +3,5 @@
 A component for removing an element from the DOM or hiding it with a CSS class.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Fdismissible.svg)](https://www.npmjs.com/package/%40vrembem%2Fdismissible)
+
+[Documentation](https://vrembem.com/packages/dismissible)

--- a/packages/dismissible/package.json
+++ b/packages/dismissible/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/dismissible",
   "description": "A component for removing an element from the DOM or hiding it with a CSS class.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "dismissible"
+  ],
   "main": "dist/scripts.cjs.js",
   "module": "index.js",
   "browser": "dist/scripts.js",

--- a/packages/drawer/README.md
+++ b/packages/drawer/README.md
@@ -3,3 +3,5 @@
 A container component that slides in from the left or right. Typically containing menus, search or other content.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Fdrawer.svg)](https://www.npmjs.com/package/%40vrembem%2Fdrawer)
+
+[Documentation](https://vrembem.com/packages/drawer)

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/drawer",
   "description": "A container component that slides in from the left or right. Typically containing menus, search or other content.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "drawer"
+  ],
   "main": "dist/scripts.cjs.js",
   "module": "index.js",
   "browser": "dist/scripts.js",

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -3,3 +3,5 @@
 A component that is initially hidden and revealed upon user interaction either through a click or hover event. Dropdown components typically display lists of possible actions or navigation.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Fdropdown.svg)](https://www.npmjs.com/package/%40vrembem%2Fdropdown)
+
+[Documentation](https://vrembem.com/packages/dropdown)

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/dropdown",
   "description": "A component that is initially hidden and revealed upon user interaction either through a click or hover event. Dropdown components typically display lists of possible actions or navigation.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "dropdown"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -3,3 +3,5 @@
 A flexbox based grid system component.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Fgrid.svg)](https://www.npmjs.com/package/%40vrembem%2Fgrid)
+
+[Documentation](https://vrembem.com/packages/grid)

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/grid",
   "description": "A flexbox based grid system component.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "grid"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/icon-action/README.md
+++ b/packages/icon-action/README.md
@@ -3,3 +3,5 @@
 A component for displaying simple action buttons using icons.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Ficon-action.svg)](https://www.npmjs.com/package/%40vrembem%2Ficon-action)
+
+[Documentation](https://vrembem.com/packages/input-action)

--- a/packages/icon-action/package.json
+++ b/packages/icon-action/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/icon-action",
   "description": "A component for displaying simple action buttons using icons.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "icon-action"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/icon/README.md
+++ b/packages/icon/README.md
@@ -3,3 +3,5 @@
 The icon component provides a consistent way to style icons.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Ficon.svg)](https://www.npmjs.com/package/%40vrembem%2Ficon)
+
+[Documentation](https://vrembem.com/packages/icon)

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/icon",
   "description": "The icon component provides a consistent way to style icons.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "icon"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/input/README.md
+++ b/packages/input/README.md
@@ -3,3 +3,5 @@
 A component for displaying form input elements.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Finput.svg)](https://www.npmjs.com/package/%40vrembem%2Finput)
+
+[Documentation](https://vrembem.com/packages/input)

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/input",
   "description": "A component for displaying form input elements.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "input"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/level/README.md
+++ b/packages/level/README.md
@@ -3,3 +3,5 @@
 A simple flexbox based layout component.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Flevel.svg)](https://www.npmjs.com/package/%40vrembem%2Flevel)
+
+[Documentation](https://vrembem.com/packages/level)

--- a/packages/level/package.json
+++ b/packages/level/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/level",
   "description": "A simple flexbox based layout component.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "level"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/media/README.md
+++ b/packages/media/README.md
@@ -3,3 +3,5 @@
 The media component is used for displaying groups of content with a corresponding media asset, such as an image, avatar or icon.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Fmedia.svg)](https://www.npmjs.com/package/%40vrembem%2Fmedia)
+
+[Documentation](https://vrembem.com/packages/media)

--- a/packages/media/package.json
+++ b/packages/media/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/media",
   "description": "The media component is used for displaying groups of content with a corresponding media asset, such as an image, avatar or icon.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "media"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/menu/README.md
+++ b/packages/menu/README.md
@@ -3,3 +3,5 @@
 Menus represent groups of links, actions or tools that a user can interact with.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Fmenu.svg)](https://www.npmjs.com/package/%40vrembem%2Fmenu)
+
+[Documentation](https://vrembem.com/packages/menu)

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/menu",
   "description": "Menus represent groups of links, actions or tools that a user can interact with.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "menu"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -3,3 +3,5 @@
 A component for changing the mode of a page to complete a critical task. This is usually used in conjunction with the dialog component to make modal dialogs.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Fmodal.svg)](https://www.npmjs.com/package/%40vrembem%2Fmodal)
+
+[Documentation](https://vrembem.com/packages/modal)

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/modal",
   "description": "A component for changing the mode of a page to complete a critical task. This is usually used in conjunction with the dialog component to make modal dialogs.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "modal"
+  ],
   "main": "dist/scripts.cjs.js",
   "module": "index.js",
   "browser": "dist/scripts.js",

--- a/packages/notice/README.md
+++ b/packages/notice/README.md
@@ -3,3 +3,5 @@
 A component for highlighting (optionally dismissible) messages to the user.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Fnotice.svg)](https://www.npmjs.com/package/%40vrembem%2Fnotice)
+
+[Documentation](https://vrembem.com/packages/notice)

--- a/packages/notice/package.json
+++ b/packages/notice/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/notice",
   "description": "A component for highlighting (optionally dismissible) messages to the user.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "notice"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/panel/README.md
+++ b/packages/panel/README.md
@@ -3,3 +3,5 @@
 Panels are a compositional container component that allows you to wrap and theme groups of content.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Fpanel.svg)](https://www.npmjs.com/package/%40vrembem%2Fpanel)
+
+[Documentation](https://vrembem.com/packages/panel)

--- a/packages/panel/package.json
+++ b/packages/panel/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/panel",
   "description": "Panels are a compositional container component that allows you to wrap and theme groups of content.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "panel"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/radio/README.md
+++ b/packages/radio/README.md
@@ -3,3 +3,5 @@
 Radios allow the user to select a single option from a set.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Fradio.svg)](https://www.npmjs.com/package/%40vrembem%2Fradio)
+
+[Documentation](https://vrembem.com/packages/radio)

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/radio",
   "description": "Radios allow the user to select a single option from a set.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "radio"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/section/README.md
+++ b/packages/section/README.md
@@ -3,3 +3,5 @@
 A container component for wrapping distinct sections of a page.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Fsection.svg)](https://www.npmjs.com/package/%40vrembem%2Fsection)
+
+[Documentation](https://vrembem.com/packages/section)

--- a/packages/section/package.json
+++ b/packages/section/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/section",
   "description": "A container component for wrapping distinct sections of a page.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "section"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/span/README.md
+++ b/packages/span/README.md
@@ -3,3 +3,5 @@
 A multi-purpose component for setting width, max-width and flex basis based on a column set.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Fspan.svg)](https://www.npmjs.com/package/%40vrembem%2Fspan)
+
+[Documentation](https://vrembem.com/packages/span)

--- a/packages/span/package.json
+++ b/packages/span/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/span",
   "description": "A multi-purpose component for setting width, max-width and flex basis based on a column set.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "span"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/switch/README.md
+++ b/packages/switch/README.md
@@ -3,3 +3,5 @@
 Switches are a binary form element used to toggle between two options.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Fswitch.svg)](https://www.npmjs.com/package/%40vrembem%2Fswitch)
+
+[Documentation](https://vrembem.com/packages/switch)

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/switch",
   "description": "Switches are a binary form element used to toggle between two options.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "switch"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/table/README.md
+++ b/packages/table/README.md
@@ -3,3 +3,5 @@
 A table component for displaying HTML tables.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Ftable.svg)](https://www.npmjs.com/package/%40vrembem%2Ftable)
+
+[Documentation](https://vrembem.com/packages/table)

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/table",
   "description": "A table component for displaying HTML tables.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "table"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -3,3 +3,5 @@
 Text labels that appear when a user hovers over, focuses on or touches an element.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Ftooltip.svg)](https://www.npmjs.com/package/%40vrembem%2Ftooltip)
+
+[Documentation](https://vrembem.com/packages/tooltip)

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/tooltip",
   "description": "Text labels that appear when a user hovers over, focuses on or touches an element.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "tooltip"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/utility/README.md
+++ b/packages/utility/README.md
@@ -3,3 +3,5 @@
 The utility component provides a set of atomic classes that specialize in a single function.
 
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Futility.svg)](https://www.npmjs.com/package/%40vrembem%2Futility)
+
+[Documentation](https://vrembem.com/packages/utility)

--- a/packages/utility/package.json
+++ b/packages/utility/package.json
@@ -2,6 +2,13 @@
   "name": "@vrembem/utility",
   "description": "The utility component provides a set of atomic classes that specialize in a single function.",
   "version": "1.5.1",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "utility"
+  ],
   "style": "index.scss",
   "scripts": {
     "build": "npm-run-all clean styles",

--- a/packages/vrembem/README.md
+++ b/packages/vrembem/README.md
@@ -1,5 +1,73 @@
 # Vrembem
 
-A complete collection of all Vrembem packages into a single comprehensive library for convenience.
+A complete collection of all Vrembem components into a single comprehensive library for convenience.
 
 [![npm version](https://img.shields.io/npm/v/vrembem.svg)](https://www.npmjs.com/package/vrembem)
+
+[Documentation](https://vrembem.com/packages/vrembem)
+
+## Installation
+
+```
+npm install vrembem
+```
+
+## Usage
+
+### Sass
+
+To include all Vrembem components into your styles, just import the vrembem package in your Sass manifest file.
+
+```scss
+@use "vrembem";
+```
+
+All component variables, functions and mixins are forwarded under their respective namespace and can be customized:
+
+```scss
+@use "vrembem" with (
+  $button-padding: 1rem 2rem
+);
+```
+
+Customize core variables which all components inherit from. The example below will prefix all components with a prefix:
+
+```scss
+@use "@vrembem/core" with (
+  $prefix-block: "vb-"
+);
+@use "vrembem";
+```
+
+### JavaScript
+
+Import and initialize the components you'll need:
+
+```js
+// Import all under the vb namespace
+import * as vb from "vrembem";
+const drawer = new vb.Drawer({ autoInit: true });
+
+// Or import individual components
+import { Drawer } from "vrembem";
+const drawer = new Drawer({ autoInit: true });
+```
+
+> Note that `utility` component does not need to be initialized since it's just a set of helpful utility functions.
+
+### Markup
+
+Include the component's markup into your project. Use the [online documentation](https://vrembem.com) for more information, code examples and available modifiers.
+
+```html
+<div class="drawer__wrapper">
+  <aside data-drawer="[unique-id]" class="drawer">
+    <div class="drawer__item">
+      <button data-drawer-close>...</button>
+    </div>
+  </aside>
+  <div class="drawer__main">
+    <button data-drawer-toggle="[unique-id]">...</button>
+  </div>
+</div>
+```

--- a/packages/vrembem/package.json
+++ b/packages/vrembem/package.json
@@ -2,6 +2,13 @@
   "name": "vrembem",
   "description": "A CSS component library based on the BEM methodology.",
   "version": "1.5.2",
+  "license": "MIT",
+  "keywords": [
+    "BEM",
+    "front-end",
+    "component",
+    "library"
+  ],
   "main": "dist/scripts.cjs.js",
   "module": "index.js",
   "browser": "dist/scripts.js",


### PR DESCRIPTION
## Problem

There's currently a big disconnect between GitHub source code and the online documentation.

## Solution

This PR adds documentation links in component `README.md` files and source code links from online documentation pages. Also adds better `README.md` documentation for `vrembem` all-in-one package. Also includes improvements to package.json by adding keywords and license fields.