### PR TITLE
feat: add output vars to utility component

### DIFF
--- a/docs/_packages/utility.md
+++ b/docs/_packages/utility.md
@@ -9,6 +9,82 @@ usage:
   scss: true
 ---
 
+## Intro
+
+Once loaded, the utility component provides a number of classes that can be used independently or to supplement other loaded components.
+
+```html
+<!-- Using utility classes independently -->
+<div class="padding background-shade border radius">
+  <p class="text-bold text-align-center">...</p>
+</div>
+
+<!-- Using utility classes with other components -->
+<div class="grid flex-justify-center">
+  <div class="grid__item span-auto">...</div>
+  <div class="grid__item span-auto">...</div>
+</div>
+```
+
+Each utility has a corresponding `$output-[module]` and `$class-[module]` variable that determines whether or not the module is output and it's class name. Output variable inherits their default value from `$output`.
+
+```scss
+// Will disable the output of the color module
+@use "@vrembem/utility" with (
+  $output-color: false
+);
+
+// Will disable all modules, but enables the color module
+@use "@vrembem/utility" with (
+  $output: false,
+  $output-color: true
+);
+```
+
+### Global Variables
+
+Setting these variables will apply to all utility modules.
+
+<div class="scroll-box">
+  <table class="table table_style_bordered table_zebra table_hover table_responsive_lg">
+    <thead>
+      <tr>
+        <th>Variable</th>
+        <th>Default</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$prefix-utility</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">null</code></td>
+        <td data-mobile-label="Desc">String to prefix all utility classes with.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$output</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">true</code></td>
+        <td data-mobile-label="Desc">Toggles the default output of all modules.</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+### Modules
+
+The utility component consists of a number of modules with their own set of specific customizable class and output variables.
+
+- [`background`](#background)
+- [`border`](#border)
+- [`radius`](#radius)
+- [`elevate`](#elevate)
+- [`color`](#color)
+- [`display`](#display)
+- [`flex`](#flex)
+- [`margin`](#margin)
+- [`padding`](#padding)
+- [`span`](#span)
+- [`text`](#text)
+
 ## background
 
 Applies background color property. Most options include light, lighter, dark and darker variants.
@@ -1002,11 +1078,6 @@ Adds ellipsis styles to an element that will display an ellipsis (...) for text 
         <td data-mobile-label="Desc">String to use for the class name of the padding utility.</td>
       </tr>
       <tr>
-        <td data-mobile-label="Var"><code class="code text-nowrap">$class-spacing</code></td>
-        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">spacing</code></td>
-        <td data-mobile-label="Desc">String to use for the class name of the spacing utility.</td>
-      </tr>
-      <tr>
         <td data-mobile-label="Var"><code class="code text-nowrap">$class-span</code></td>
         <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">span</code></td>
         <td data-mobile-label="Desc">String to use for the class name of the span utility.</td>
@@ -1019,15 +1090,7 @@ Adds ellipsis styles to an element that will display an ellipsis (...) for text 
 
       <tr>
         <td data-mobile-label="Var"><code class="code text-nowrap">$breakpoints</code></td>
-        <td data-mobile-label="Default">
-          <code class="code color-secondary text-nowrap">
-            "xs": 480px,<br>
-            "sm": 620px,<br>
-            "md": 760px,<br>
-            "lg": 990px,<br>
-            "xl": 1380px
-          </code>
-        </td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">core.$breakpoints</code></td>
         <td data-mobile-label="Desc">The breakpoints map some utilities use to build their styles.</td>
       </tr>
       <tr>
@@ -1051,22 +1114,13 @@ Adds ellipsis styles to an element that will display an ellipsis (...) for text 
       </tr>
       <tr>
         <td data-mobile-label="Var"><code class="code text-nowrap">$spacing</code></td>
-        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">1rem</code></td>
-        <td data-mobile-label="Desc">The default value used for the <code class="code">spacing</code> utility.</td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">core.$spacing</code></td>
+        <td data-mobile-label="Desc">The default value used for utilities that handle spacing.</td>
       </tr>
       <tr>
         <td data-mobile-label="Var"><code class="code text-nowrap">$spacing-map</code></td>
-        <td data-mobile-label="Default">
-          <code class="code color-secondary text-nowrap">
-            "none": 0,<br>
-            "xs": 0.25rem,<br>
-            "sm": 0.5rem,<br>
-            "md": 1rem,<br>
-            "lg": 1.5rem,<br>
-            "xl": 2rem
-          </code>
-        </td>
-        <td data-mobile-label="Desc">Map of variations to output for the <code class="code">spacing</code> utility.</td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">core.$spacing-map</code></td>
+        <td data-mobile-label="Desc">Map of variations to output for utilities that handle spacing.</td>
       </tr>
     </tbody>
   </table>

--- a/packages/utility/README.md
+++ b/packages/utility/README.md
@@ -35,6 +35,34 @@ Once loaded, the utility component provides a number of classes that can be used
 </div>
 ```
 
+Each utility has a corresponding `$output-[module]` and `$class-[module]` variable that determines whether or not the module is output and it's class name. Output variable inherits their default value from `$output`.
+
+```scss
+// Will disable the output of the color module
+@use "@vrembem/utility" with (
+  $output-color: false
+);
+
+// Will disable all modules, but enables the color module
+@use "@vrembem/utility" with (
+  $output: false,
+  $output-color: true
+);
+```
+
+#### Global Variables
+
+Setting these variables will apply to all utility modules.
+
+Variable | Default | Description
+---|---|---
+`$prefix-utility` | `null` | String to prefix all utility classes with.
+`$output` | `true` | Toggles the default output of all modules.
+
+## Modules
+
+The utility component consists of a number of modules with their own set of specific customizable class and output variables.
+
 - [`background`](#background)
 - [`border`](#border)
 - [`radius`](#radius)
@@ -46,17 +74,6 @@ Once loaded, the utility component provides a number of classes that can be used
 - [`padding`](#padding)
 - [`span`](#span)
 - [`text`](#text)
-
-Each utility has a corresponding `$class-[property]` variable that determines the class name used in output. Setting it's value to `null` will omit their style output.
-
-```scss
-// Excludes the `color` utilities from being output
-@use "@vrembem/utility" with (
-  $class-color: null
-);
-```
-
-## Available Utilities
 
 ### `background`
 
@@ -403,11 +420,10 @@ Variable | Default | Description
 `$class-flex` | `"flex"` | String to use for the class name of the flex utility.
 `$class-margin` | `"margin"` | String to use for the class name of the margin utility.
 `$class-padding` | `"padding"` | String to use for the class name of the padding utility.
-`$class-spacing` | `"spacing"` | String to use for the class name of the spacing utility.
 `$class-span` | `"span"` | String to use for the class name of the span utility.
 `$class-text` | `"text"` | String to use for the class name of the text utility.
-`$breakpoints` | [Source](https://github.com/sebnitu/vrembem/blob/08eb7b3b55e9c55ed0027e8d9cee3d24b2ac86d6/packages/core/src/css/_variables.scss#L14-L20) | The breakpoints map some utilities use to build their styles.
+`$breakpoints` | `core.$breakpoints` | The breakpoints map some utilities use to build their styles.
 `$columns` | `12` | The columns value to use for `span` component sizing.
 `$display-properties` | [Source](https://github.com/sebnitu/vrembem/blob/08eb7b3b55e9c55ed0027e8d9cee3d24b2ac86d6/packages/utility/src/_variables.scss#L24-L31) | Used to determine which display properties to output as utilities.
-`$spacing` | `1rem` | The default value used for the `spacing` utility.
-`$spacing-map` | [Source](https://github.com/sebnitu/vrembem/blob/08eb7b3b55e9c55ed0027e8d9cee3d24b2ac86d6/packages/utility/src/_variables.scss#L34-L41) | Map of variations to output for the `spacing` utility.
+`$spacing` | `core.$spacing` | The default value used for utilities that handle spacing.
+`$spacing-map` | `core.$spacing-map` | Map of variations to output for utilities that handle spacing.

--- a/packages/utility/index.scss
+++ b/packages/utility/index.scss
@@ -1,5 +1,4 @@
 @forward "./src/variables";
-@forward "./src/mixins";
 @forward "./src/background";
 @forward "./src/border";
 @forward "./src/border-radius";

--- a/packages/utility/src/_background.scss
+++ b/packages/utility/src/_background.scss
@@ -4,7 +4,7 @@
 $_u: var.$prefix-utility;
 $_c: var.$class-background;
 
-@if (var.$class-background) {
+@if (var.$output-background) {
   .#{$_u}#{$_c}-black {
     background-color: core.$black !important;
   }

--- a/packages/utility/src/_border-radius.scss
+++ b/packages/utility/src/_border-radius.scss
@@ -4,7 +4,7 @@
 $_u: var.$prefix-utility;
 $_c: var.$class-border-radius;
 
-@if (var.$class-border-radius) {
+@if (var.$output-border-radius) {
   .#{$_u}#{$_c} {
     border-radius: core.$border-radius !important;
   }

--- a/packages/utility/src/_border.scss
+++ b/packages/utility/src/_border.scss
@@ -4,7 +4,7 @@
 $_u: var.$prefix-utility;
 $_c: var.$class-border;
 
-@if (var.$class-border) {
+@if (var.$output-border) {
   .#{$_u}#{$_c} {
     border: core.$border !important;
   }

--- a/packages/utility/src/_box-shadow.scss
+++ b/packages/utility/src/_box-shadow.scss
@@ -4,7 +4,7 @@
 $_u: var.$prefix-utility;
 $_c: var.$class-box-shadow;
 
-@if (var.$class-box-shadow) {
+@if (var.$output-box-shadow) {
   .#{$_u}#{$_c} {
     box-shadow: core.$box-shadow !important;
   }

--- a/packages/utility/src/_color.scss
+++ b/packages/utility/src/_color.scss
@@ -4,7 +4,7 @@
 $_u: var.$prefix-utility;
 $_c: var.$class-color;
 
-@if (var.$class-color) {
+@if (var.$output-color) {
   .#{$_u}#{$_c} {
     color: core.$color !important;
   }

--- a/packages/utility/src/_display.scss
+++ b/packages/utility/src/_display.scss
@@ -4,7 +4,7 @@
 $_u: var.$prefix-utility;
 $_c: var.$class-display;
 
-@if (var.$class-display) {
+@if (var.$output-display) {
   @each $property in var.$display-properties {
     .#{$_u}#{$_c}-#{$property} {
       display: $property !important;

--- a/packages/utility/src/_flex.scss
+++ b/packages/utility/src/_flex.scss
@@ -3,7 +3,7 @@
 $_u: var.$prefix-utility;
 $_c: var.$class-flex;
 
-@if (var.$class-flex) {
+@if (var.$output-flex) {
   .#{$_u}#{$_c} {
     display: flex !important;
   }

--- a/packages/utility/src/_margin.scss
+++ b/packages/utility/src/_margin.scss
@@ -3,7 +3,7 @@
 $_u: var.$prefix-utility;
 $_c: var.$class-margin;
 
-@if (var.$class-margin) {
+@if (var.$output-margin) {
   .#{$_u}#{$_c} {
     margin: var.$spacing;
   }

--- a/packages/utility/src/_mixins.scss
+++ b/packages/utility/src/_mixins.scss
@@ -1,1 +1,0 @@
-@use "@vrembem/core";

--- a/packages/utility/src/_padding.scss
+++ b/packages/utility/src/_padding.scss
@@ -3,7 +3,7 @@
 $_u: var.$prefix-utility;
 $_c: var.$class-padding;
 
-@if (var.$class-padding) {
+@if (var.$output-padding) {
   .#{$_u}#{$_c} {
     padding: var.$spacing;
   }

--- a/packages/utility/src/_span.scss
+++ b/packages/utility/src/_span.scss
@@ -4,7 +4,7 @@
 $_u: var.$prefix-utility;
 $_c: var.$class-span;
 
-@if (var.$class-span) {
+@if (var.$output-span) {
   @for $i from 1 through var.$columns {
     .#{$_u}#{$_c}-#{$i} {
       flex: 0 0 (100% * ($i/var.$columns));

--- a/packages/utility/src/_text.scss
+++ b/packages/utility/src/_text.scss
@@ -4,7 +4,7 @@
 $_u: var.$prefix-utility;
 $_c: var.$class-text;
 
-@if (var.$class-text) {
+@if (var.$output-text) {
   .#{$_u}#{$_c}-size-sm {
     font-size: core.$font-size-sm !important;
   }

--- a/packages/utility/src/_variables.scss
+++ b/packages/utility/src/_variables.scss
@@ -2,6 +2,19 @@
 
 $prefix-utility: null !default;
 
+$output: true !default;
+$output-background: $output !default;
+$output-border: $output !default;
+$output-border-radius: $output !default;
+$output-box-shadow: $output !default;
+$output-color: $output !default;
+$output-display: $output !default;
+$output-flex: $output !default;
+$output-margin: $output !default;
+$output-padding: $output !default;
+$output-span: $output !default;
+$output-text: $output !default;
+
 $class-background: "background" !default;
 $class-border: "border" !default;
 $class-border-radius: "radius" !default;
@@ -24,6 +37,5 @@ $display-properties: (
   inline-block,
   none
 ) !default;
-
 $spacing: core.$spacing !default;
 $spacing-map: core.$spacing-map !default;


### PR DESCRIPTION
## Problem

There's currently no way to disable the output of specific modules in the utility component.

## Solution

This PR introduces the `$output` and `$output-[module]` which allow a developer to disable all output and only enable the ones they specifically want to use, or just disable a few they don't need.

**Example**

```scss
// Will disable the output of the color module
@use "@vrembem/utility" with (
  $output-color: false
);

// Will disable all modules, but enables the color module
@use "@vrembem/utility" with (
  $output: false,
  $output-color: true
);
```