### PR TITLE
Fix autoInit description typo in docs

### DIFF
--- a/docs/_packages/checkbox.md
+++ b/docs/_packages/checkbox.md
@@ -295,7 +295,7 @@ $icon-indeterminate: 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000
       <tr>
         <td data-mobile-label="Key"><code class="code text_nowrap">autoInit</code></td>
         <td data-mobile-label="Default"><code class="code color_secondary text_nowrap">false</code></td>
-        <td data-mobile-label="Desc">Automatically instantiates the instance.</td>
+        <td data-mobile-label="Desc">Automatically initializes the instance.</td>
       </tr>
       <tr>
         <td data-mobile-label="Key"><code class="code text_nowrap">stateAttr</code></td>

--- a/docs/_packages/drawer.md
+++ b/docs/_packages/drawer.md
@@ -452,7 +452,7 @@ Drawers can slide in from the left or right using the position modifiers:
       <tr>
         <td data-mobile-label="Key"><code class="code text-nowrap">autoInit</code></td>
         <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">false</code></td>
-        <td data-mobile-label="Desc">Automatically instantiates the instance.</td>
+        <td data-mobile-label="Desc">Automatically initializes the instance.</td>
       </tr>
 
       <!-- Data attributes -->

--- a/docs/_packages/modal.md
+++ b/docs/_packages/modal.md
@@ -507,7 +507,7 @@ Adjusts the size of modals. This modifier provides two options, `modal_size_sm` 
       <tr>
         <td data-mobile-label="Key"><code class="code text-nowrap">autoInit</code></td>
         <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">false</code></td>
-        <td data-mobile-label="Desc">Automatically instantiates the instance.</td>
+        <td data-mobile-label="Desc">Automatically initializes the instance.</td>
       </tr>
 
       <!-- Data attributes -->

--- a/packages/checkbox/README.md
+++ b/packages/checkbox/README.md
@@ -108,7 +108,7 @@ $icon-indeterminate: 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000
 
 | Key          | Default          | Description                                                        |
 | ------------ | ---------------- | ------------------------------------------------------------------ |
-| `autoInit`   | `false`          | Automatically instantiates the instance.                           |
+| `autoInit`   | `false`          | Automatically initializes the instance.                            |
 | `stateAttr`  | `'aria-checked'` | Attribute to check mixed state against.                            |
 | `StateValue` | `'mixed'`        | The mixed value to check for. Applied as the value of `stateAttr`. |
 

--- a/packages/drawer/README.md
+++ b/packages/drawer/README.md
@@ -235,7 +235,7 @@ Drawers can slide in from the left or right using the position modifiers:
 
 | Key                 | Default               | Description                                                                                          |
 | ------------------- | --------------------- | ---------------------------------------------------------------------------------------------------- |
-| `autoInit`          | `false`               | Automatically instantiates the instance.                                                             |
+| `autoInit`          | `false`               | Automatically initializes the instance.                                                              |
 | `dataDrawer`        | `'drawer'`            | Data attribute for a drawer.                                                                         |
 | `dataDialog`        | `'drawer-dialog'`     | Data attribute for a drawer dialog.                                                                  |
 | `dataToggle`        | `'drawer-toggle'`     | Data attribute for a drawer toggle trigger.                                                          |

--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -194,7 +194,7 @@ Adjusts the size of modals. This modifier provides two options, `modal_size_sm` 
 
 | Key                 | Default                     | Description                                                                                                                                                           |
 | ------------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `autoInit`          | `false`                     | Automatically instantiates the instance.                                                                                                                              |
+| `autoInit`          | `false`                     | Automatically initializes the instance.                                                                                                                               |
 | `dataModal`         | `'modal'`                   | Data attribute for a modal.                                                                                                                                           |
 | `dataDialog`        | `'modal-dialog'`            | Data attribute for a modal. dialog                                                                                                                                    |
 | `dataOpen`          | `'modal-open'`              | Data attribute for a modal open trigger.                                                                                                                              |


### PR DESCRIPTION
## Problem

There's a typo in the docs where it says "instantiates" where it should actually be "initializes".

## Solution

In the documentation that describes the `autoInit` option, fixed typo that says it "Automatically instantiates..." to say "Automatically initializes..." instead.
