### PR TITLE
Add the new gap and gap-map variables to core

### DIFF
--- a/packages/core/src/css/_variables.scss
+++ b/packages/core/src/css/_variables.scss
@@ -69,6 +69,19 @@ $danger: palette.$red-500 !default;
 $danger-dark: palette.$red-700 !default;
 $danger-darker: palette.$red-900 !default;
 
+// Gap
+// ---
+
+$gap: 1em !default;
+$gap-map: (
+  "none": 0,
+  "xs": 0.25em,
+  "sm": 0.5em,
+  "md": 1em,
+  "lg": 1.5em,
+  "xl": 2em
+) !default;
+
 // Spacing
 // ---
 


### PR DESCRIPTION
## What changed?

This PR adds the `$gap` and `$gap-map` variables which will be used in a future refactor that removes `$spacing` vars.