### PR TITLE
Fix reference links in button-group docs

### DIFF
--- a/docs/_packages/button-group.md
+++ b/docs/_packages/button-group.md
@@ -94,7 +94,7 @@ A modifier to allow a button-group to span the full width of it's container. Val
 
 ## button-group_gap_[key]
 
-Adjusts the gap spacing based on the provided key. Gap key output is based on the values in [`$gap-map`](#gap-scale) variable map.
+Adjusts the gap spacing based on the provided key. Gap key output is based on the values in [`$gap-map`](#gap-map) variable map.
 
 {% include demo_open.html %}
 <div class="button-group button-group_gap_xs">
@@ -240,7 +240,7 @@ Adds a breakpoint for when button-group elements should be stacked vertically. V
       <tr>
         <td data-mobile-label="Var"><code class="code text-nowrap">$gap-map</code></td>
         <td data-mobile-label="Default">
-          <a class="link text-nowrap" href="#gap-scale"><code class="code color-secondary">Sass Map</code> Ref &darr;</a>
+          <a class="link text-nowrap" href="#gap-map"><code class="code color-secondary">Sass Map</code> Ref &darr;</a>
         </td>
         <td data-mobile-label="Desc">Used to output gap modifiers.</td>
       </tr>

--- a/packages/button-group/README.md
+++ b/packages/button-group/README.md
@@ -68,7 +68,7 @@ A modifier to allow a button-group to span the full width of it's container. Val
 
 ### `button-group_gap_[key]`
 
-Adjusts the gap spacing based on the provided key. Gap key output is based on the values in [`$gap-map`](#gap-scale) variable map.
+Adjusts the gap spacing based on the provided key. Gap key output is based on the values in [`$gap-map`](#gap-map) variable map.
 
 ```html
 <div class="button-group button-group_gap_xs">
@@ -134,7 +134,7 @@ Adds a breakpoint for when button-group elements should be stacked vertically. V
 | `$border-radius`         | `core.$border-radius`                          | Sets the border-radius styles of buttons when button-group adjusts them.                                               |
 | `$gap`                   | `0.5em`                                        | The default gap spacing for the button-group component.                                                                |
 | `$gap-join`              | `-1px`                                         | The gap spacing used for the `button-group_join` modifier.                                                             |
-| `$gap-map`               | [`Sass Map` Ref &darr;](#gap-scale)            | Used to output gap modifiers.                                                                                          |
+| `$gap-map`               | [`Sass Map` Ref &darr;](#gap-map)              | Used to output gap modifiers.                                                                                          |
 
 #### `$breakpoints`
 


### PR DESCRIPTION
## Problem

There were some broken reference links in the button-group documentation.

## Solution

This PR fixes the references to `gap-scale` to now correctly reference `gap-map` instead.
