### PR TITLE
Add README docs for switch component

### DIFF
--- a/docs/_packages/switch.md
+++ b/docs/_packages/switch.md
@@ -11,6 +11,8 @@ usage:
 
 ## switch
 
+Switch form controls are composed using a set of `<span>` elements alongside the native `<input type="checkbox">` element which should be given the `switch__native` class and come before the remaining presentational `<span>` elements.
+
 {% include demo_open.html %}
   {% include switch.html checked="" %}
   {% include switch.html %}
@@ -28,6 +30,8 @@ usage:
 {% include demo_close.html %}
 
 ## switch + label
+
+For switch with labels, just wrap the switch component along with label text using the `<label>` element.
 
 {% include demo_open.html %}
 <p>
@@ -57,3 +61,44 @@ usage:
 </label>
 ```
 {% include demo_close.html %}
+
+## Sass variables
+
+<div class="scroll-box">
+  <table class="table table_style_bordered table_zebra table_hover table_responsive_lg">
+    <thead>
+      <tr>
+        <th>Variable</th>
+        <th>Default</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <!-- Prefixes -->
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$prefix-block</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">null</code></td>
+        <td data-mobile-label="Desc">String to prefix blocks with.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$prefix-element</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">"__"</code></td>
+        <td data-mobile-label="Desc">String to prefix elements with.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$prefix-modifier</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">"_"</code></td>
+        <td data-mobile-label="Desc">String to prefix modifiers with.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$prefix-modifier-value</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">"_"</code></td>
+        <td data-mobile-label="Desc">String to prefix modifier values with.</td>
+      </tr>
+      <!-- General -->
+      <!-- switch__background -->
+      <!-- switch__track -->
+      <!-- switch__thumb -->
+    </tbody>
+  </table>
+</div>

--- a/docs/_packages/switch.md
+++ b/docs/_packages/switch.md
@@ -96,9 +96,179 @@ For switch with labels, just wrap the switch component along with label text usi
         <td data-mobile-label="Desc">String to prefix modifier values with.</td>
       </tr>
       <!-- General -->
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$color</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">core.$primary</code></td>
+        <td data-mobile-label="Desc">Sets the base color theme for the switch component.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$size</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">2.5em</code></td>
+        <td data-mobile-label="Desc">Sets the width and height of the <code class="code">switch__background</code> element.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$transition-duration</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">core.$transition-duration</code></td>
+        <td data-mobile-label="Desc">Sets the transition-duration property for the <code class="code">switch__thumb</code> element.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$transition-timing-function</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">core.$transition-timing-function</code></td>
+        <td data-mobile-label="Desc">Sets the transition-timing-function property for the <code class="code">switch__thumb</code> element.</td>
+      </tr>
       <!-- switch__background -->
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$background</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">transparent</code></td>
+        <td data-mobile-label="Desc">Sets the background-color property for the <code class="code">switch__background</code> element.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$background-hover</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">rgba(core.$black, 0.03)</code></td>
+        <td data-mobile-label="Desc">Sets the background-color property on <code class="code">:hover</code> state.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$background-focus</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">rgba(core.$black, 0.03)</code></td>
+        <td data-mobile-label="Desc">Sets the background-color property on <code class="code">:focus</code> state.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$background-active</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">rgba(core.$black, 0.06)</code></td>
+        <td data-mobile-label="Desc">Sets the background-color property on <code class="code">:active</code> state.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$background-checked</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">null</code></td>
+        <td data-mobile-label="Desc">Sets the background-color property on <code class="code">:checked</code> state.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$background-border-radius</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">core.$border-radius-circle</code></td>
+        <td data-mobile-label="Desc">Sets the border-radius property for the <code class="code">switch__background</code> element.</td>
+      </tr>
       <!-- switch__track -->
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$track-size</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">20px</code></td>
+        <td data-mobile-label="Desc">Sets the width and height of the <code class="code">switch__track</code> element.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$track-background</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">core.$gray-200</code></td>
+        <td data-mobile-label="Desc">Sets the background-color property for the <code class="code">switch__track</code> element.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$track-background-hover</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">null</code></td>
+        <td data-mobile-label="Desc">Sets the background-color property on <code class="code">:hover</code> state.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$track-background-focus</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">null</code></td>
+        <td data-mobile-label="Desc">Sets the background-color property on <code class="code">:focus</code> state.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$track-background-active</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">null</code></td>
+        <td data-mobile-label="Desc">Sets the background-color property on <code class="code">:active</code> state.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$track-background-checked</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">core.$primary-lighter</code></td>
+        <td data-mobile-label="Desc">Sets the background-color property on <code class="code">:checked</code> state.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$track-border-color</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">core.$gray-400</code></td>
+        <td data-mobile-label="Desc">Sets the border-color property for the <code class="code">switch__track</code> element.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$track-border-color-hover</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">null</code></td>
+        <td data-mobile-label="Desc">Sets the border-color property on <code class="code">:hover</code> state.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$track-border-color-focus</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">null</code></td>
+        <td data-mobile-label="Desc">Sets the border-color property on <code class="code">:focus</code> state.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$track-border-color-active</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">null</code></td>
+        <td data-mobile-label="Desc">Sets the border-color property on <code class="code">:active</code> state.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$track-border-color-checked</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">$color</code></td>
+        <td data-mobile-label="Desc">Sets the border-color property on <code class="code">:checked</code> state.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$track-border-width</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">2px</code></td>
+        <td data-mobile-label="Desc">Sets the border-width property for the <code class="code">switch__track</code> element.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$track-border-radius</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">core.$border-radius-circle</code></td>
+        <td data-mobile-label="Desc">Sets the border-radius property for the <code class="code">switch__track</code> element.</td>
+      </tr>
       <!-- switch__thumb -->
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$thumb-size</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">16px</code></td>
+        <td data-mobile-label="Desc">Sets the width and height of the <code class="code">switch__thumb</code> element.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$thumb-background</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">core.$white</code></td>
+        <td data-mobile-label="Desc">Sets the background-color property for the <code class="code">switch__thumb</code> element.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$thumb-background-hover</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">null</code></td>
+        <td data-mobile-label="Desc">Sets the background-color property on <code class="code">:hover</code> state.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$thumb-background-focus</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">null</code></td>
+        <td data-mobile-label="Desc">Sets the background-color property on <code class="code">:focus</code> state.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$thumb-background-active</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">null</code></td>
+        <td data-mobile-label="Desc">Sets the background-color property on <code class="code">:active</code> state.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$thumb-background-checked</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">null</code></td>
+        <td data-mobile-label="Desc">Sets the background-color property on <code class="code">:checked</code> state.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$thumb-box-shadow</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">0 0 0 2px core.$gray-400</code></td>
+        <td data-mobile-label="Desc">Sets the box-shadow property for the <code class="code">switch__thumb</code> element.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$thumb-box-shadow-hover</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">0 0 0 2px $color</code></td>
+        <td data-mobile-label="Desc">Sets the box-shadow property on <code class="code">:hover</code> state.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$thumb-box-shadow-focus</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">0 0 0 2px $color</code></td>
+        <td data-mobile-label="Desc">Sets the box-shadow property on <code class="code">:focus</code> state.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$thumb-box-shadow-active</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">0 0 0 2px $color</code></td>
+        <td data-mobile-label="Desc">Sets the box-shadow property on <code class="code">:active</code> state.</td>
+      </tr>
+      <tr>
+        <td data-mobile-label="Var"><code class="code text-nowrap">$thumb-box-shadow-checked</code></td>
+        <td data-mobile-label="Default"><code class="code color-secondary text-nowrap">0 0 0 2px $color</code></td>
+        <td data-mobile-label="Desc">Sets the box-shadow property on <code class="code">:checked</code> state.</td>
+      </tr>
     </tbody>
   </table>
 </div>

--- a/packages/switch/README.md
+++ b/packages/switch/README.md
@@ -48,49 +48,43 @@ For switch with labels, just wrap the switch component along with label text usi
 
 ### Sass Variables
 
-| Variable                 | Default | Description                            |
-| ------------------------ | ------- | -------------------------------------- |
-| `$prefix-block`          | `null`  | String to prefix blocks with.          |
-| `$prefix-element`        | `"__"`  | String to prefix element with.         |
-| `$prefix-modifier`       | `"_"`   | String to prefix modifier with.        |
-| `$prefix-modifier-value` | `"_"`   | String to prefix modifier values with. |
-
-<!--
-$color: core.$primary !default;
-$size: 2.5em !default;
-$transition-duration: core.$transition-duration !default;
-$transition-timing-function: core.$transition-timing-function !default;
-
-$background: transparent !default;
-$background-hover: rgba(core.$black, 0.03) !default;
-$background-focus: rgba(core.$black, 0.03) !default;
-$background-active: rgba(core.$black, 0.06) !default;
-$background-checked: null !default;
-$background-border-radius: core.$border-radius-circle !default;
-
-$track-size: 20px !default;
-$track-background: core.$gray-200 !default;
-$track-background-hover: null !default;
-$track-background-focus: null !default;
-$track-background-active: null !default;
-$track-background-checked: core.$primary-lighter !default;
-$track-border-color: core.$gray-400 !default;
-$track-border-color-hover: null !default;
-$track-border-color-focus: null !default;
-$track-border-color-active: null !default;
-$track-border-color-checked: $color !default;
-$track-border-width: 2px !default;
-$track-border-radius: core.$border-radius-circle !default;
-
-$thumb-size: 16px !default;
-$thumb-background: core.$white !default;
-$thumb-background-hover: null !default;
-$thumb-background-focus: null !default;
-$thumb-background-active: null !default;
-$thumb-background-checked: null !default;
-$thumb-box-shadow: 0 0 0 2px core.$gray-400 !default;
-$thumb-box-shadow-hover: 0 0 0 2px $color !default;
-$thumb-box-shadow-focus: 0 0 0 2px $color !default;
-$thumb-box-shadow-active: 0 0 0 2px $color !default;
-$thumb-box-shadow-checked: 0 0 0 2px $color !default;
--->
+| Variable                      | Default                            | Description                                                                   |
+| ----------------------------- | ---------------------------------- | ----------------------------------------------------------------------------- |
+| `$prefix-block`               | `null`                             | String to prefix blocks with.                                                 |
+| `$prefix-element`             | `"__"`                             | String to prefix element with.                                                |
+| `$prefix-modifier`            | `"_"`                              | String to prefix modifier with.                                               |
+| `$prefix-modifier-value`      | `"_"`                              | String to prefix modifier values with.                                        |
+| `$color`                      | `core.$primary`                    | Sets the base color theme for the switch component.                           |
+| `$size`                       | `2.5em`                            | Sets the width and height of the `switch__background` element.                |
+| `$transition-duration`        | `core.$transition-duration`        | Sets the transition-duration property for the `switch__thumb` element.        |
+| `$transition-timing-function` | `core.$transition-timing-function` | Sets the transition-timing-function property for the `switch__thumb` element. |
+| `$background`                 | `transparent`                      | Sets the background-color property for the `switch__background` element.      |
+| `$background-hover`           | `rgba(core.$black, 0.03)`          | Sets the background-color property on `:hover` state.                         |
+| `$background-focus`           | `rgba(core.$black, 0.03)`          | Sets the background-color property on `:focus` state.                         |
+| `$background-active`          | `rgba(core.$black, 0.06)`          | Sets the background-color property on `:active` state.                        |
+| `$background-checked`         | `null`                             | Sets the background-color property on `:checked` state.                       |
+| `$background-border-radius`   | `core.$border-radius-circle`       | Sets the border-radius property for the `switch__background` element.         |
+| `$track-size`                 | `20px`                             | Sets the width and height of the `switch__track` element.                     |
+| `$track-background`           | `core.$gray-200`                   | Sets the background-color property for the `switch__track` element.           |
+| `$track-background-hover`     | `null`                             | Sets the background-color property on `:hover` state.                         |
+| `$track-background-focus`     | `null`                             | Sets the background-color property on `:focus` state.                         |
+| `$track-background-active`    | `null`                             | Sets the background-color property on `:active` state.                        |
+| `$track-background-checked`   | `core.$primary-lighter`            | Sets the background-color property on `:checked` state.                       |
+| `$track-border-color`         | `core.$gray-400`                   | Sets the border-color property for the `switch__track` element.               |
+| `$track-border-color-hover`   | `null`                             | Sets the border-color property on `:hover` state.                             |
+| `$track-border-color-focus`   | `null`                             | Sets the border-color property on `:focus` state.                             |
+| `$track-border-color-active`  | `null`                             | Sets the border-color property on `:active` state.                            |
+| `$track-border-color-checked` | `$color`                           | Sets the border-color property on `:checked` state.                           |
+| `$track-border-width`         | `2px`                              | Sets the border-width property for the `switch__track` element.               |
+| `$track-border-radius`        | `core.$border-radius-circle`       | Sets the border-radius property for the `switch__track` element.              |
+| `$thumb-size`                 | `16px`                             | Sets the width and height of the `switch__thumb` element.                     |
+| `$thumb-background`           | `core.$white`                      | Sets the background-color property for the `switch__thumb` element.           |
+| `$thumb-background-hover`     | `null`                             | Sets the background-color property on `:hover` state.                         |
+| `$thumb-background-focus`     | `null`                             | Sets the background-color property on `:focus` state.                         |
+| `$thumb-background-active`    | `null`                             | Sets the background-color property on `:active` state.                        |
+| `$thumb-background-checked`   | `null`                             | Sets the background-color property on `:checked` state.                       |
+| `$thumb-box-shadow`           | `0 0 0 2px core.$gray-400`         | Sets the box-shadow property for the `switch__thumb` element.                 |
+| `$thumb-box-shadow-hover`     | `0 0 0 2px $color`                 | Sets the box-shadow property on `:hover` state.                               |
+| `$thumb-box-shadow-focus`     | `0 0 0 2px $color`                 | Sets the box-shadow property on `:focus` state.                               |
+| `$thumb-box-shadow-active`    | `0 0 0 2px $color`                 | Sets the box-shadow property on `:active` state.                              |
+| `$thumb-box-shadow-checked`   | `0 0 0 2px $color`                 | Sets the box-shadow property on `:checked` state.                             |

--- a/packages/switch/README.md
+++ b/packages/switch/README.md
@@ -5,3 +5,92 @@ Switches are a binary form element used to toggle between two options.
 [![npm version](https://img.shields.io/npm/v/%40vrembem%2Fswitch.svg)](https://www.npmjs.com/package/%40vrembem%2Fswitch)
 
 [Documentation](https://vrembem.com/packages/switch)
+
+## Installation
+
+```sh
+npm install @vrembem/switch
+```
+
+### Styles
+
+```scss
+@use "@vrembem/switch";
+```
+
+### Markup
+
+Switch form controls are composed using a set of `<span>` elements alongside the native `<input type="checkbox">` element which should be given the `switch__native` class and come before the remaining presentational `<span>` elements.
+
+```html
+<span class="switch">
+  <input type="checkbox" class="switch__native">
+  <span class="switch__background">
+    <span class="switch__track">
+      <span class="switch__thumb"></span>
+    </span>
+  </span>
+</span>
+```
+
+For switch with labels, just wrap the switch component along with label text using the `<label>` element.
+
+```html
+<label>
+  <span class="switch">
+    ...
+  </span>
+  Switch with a label
+</label>
+```
+
+## Customization
+
+### Sass Variables
+
+| Variable                 | Default | Description                            |
+| ------------------------ | ------- | -------------------------------------- |
+| `$prefix-block`          | `null`  | String to prefix blocks with.          |
+| `$prefix-element`        | `"__"`  | String to prefix element with.         |
+| `$prefix-modifier`       | `"_"`   | String to prefix modifier with.        |
+| `$prefix-modifier-value` | `"_"`   | String to prefix modifier values with. |
+
+<!--
+$color: core.$primary !default;
+$size: 2.5em !default;
+$transition-duration: core.$transition-duration !default;
+$transition-timing-function: core.$transition-timing-function !default;
+
+$background: transparent !default;
+$background-hover: rgba(core.$black, 0.03) !default;
+$background-focus: rgba(core.$black, 0.03) !default;
+$background-active: rgba(core.$black, 0.06) !default;
+$background-checked: null !default;
+$background-border-radius: core.$border-radius-circle !default;
+
+$track-size: 20px !default;
+$track-background: core.$gray-200 !default;
+$track-background-hover: null !default;
+$track-background-focus: null !default;
+$track-background-active: null !default;
+$track-background-checked: core.$primary-lighter !default;
+$track-border-color: core.$gray-400 !default;
+$track-border-color-hover: null !default;
+$track-border-color-focus: null !default;
+$track-border-color-active: null !default;
+$track-border-color-checked: $color !default;
+$track-border-width: 2px !default;
+$track-border-radius: core.$border-radius-circle !default;
+
+$thumb-size: 16px !default;
+$thumb-background: core.$white !default;
+$thumb-background-hover: null !default;
+$thumb-background-focus: null !default;
+$thumb-background-active: null !default;
+$thumb-background-checked: null !default;
+$thumb-box-shadow: 0 0 0 2px core.$gray-400 !default;
+$thumb-box-shadow-hover: 0 0 0 2px $color !default;
+$thumb-box-shadow-focus: 0 0 0 2px $color !default;
+$thumb-box-shadow-active: 0 0 0 2px $color !default;
+$thumb-box-shadow-checked: 0 0 0 2px $color !default;
+-->


### PR DESCRIPTION
## Problem

The switch component is missing README documentation.

## Solution

This PR adds the missing switch component README documentation and updates it's docs page to match.