### PR TITLE
Update modal and drawer docs to include missing JS API parameter docs

### DIFF
--- a/docs/_packages/drawer.md
+++ b/docs/_packages/drawer.md
@@ -574,7 +574,7 @@ Drawers can slide in from the left or right using the position modifiers:
 
 ## API
 
-### `drawer.init()`
+### `drawer.init(options)`
 
 Initializes the drawer instance. During initialization, the following processes are run:
 
@@ -583,6 +583,10 @@ Initializes the drawer instance. During initialization, the following processes 
 - Runs `breakpoint.init()` to initialize all breakpoints for drawers.
 - Adds the `click` event listener to the document.
 - Adds the `keydown` event listener for closing modal drawers with the `esc` key.
+
+**Parameters**
+
+- `options [Object] (optional) (default null)` An options object for passing your custom settings.
 
 ```js
 const drawer = new Drawer();
@@ -730,7 +734,7 @@ const el = drawer.getDrawer('drawer-key');
 console.log(el);
 ```
 
-### `drawer.setTabindex`
+### `drawer.setTabindex()`
 
 Sets the `tabindex="-1"` attribute on all drawer dialogs. This makes it possible to set focus on the dialog when opened but won't allow users to focus it using the keyboard. This is ran automatically on `drawer.init()` if the `setTabindex` option is set to `true`.
 

--- a/docs/_packages/modal.md
+++ b/docs/_packages/modal.md
@@ -609,7 +609,7 @@ Adjusts the size of modals. This modifier provides two options, `modal_size_sm` 
 
 ## API
 
-### `modal.init()`
+### `modal.init(options)`
 
 Initializes the modal instance. During initialization, the following processes are run:
 
@@ -618,6 +618,10 @@ Initializes the modal instance. During initialization, the following processes a
 - Moves all modals in the DOM to a location specified in the `moveModals` option.
 - Adds the `click` event listener to the document.
 - Adds the `keydown` event listener for closing modals with the `esc` key.
+
+**Parameters**
+
+- `options [Object] (optional) (default null)` An options object for passing your custom settings.
 
 ```js
 const modal = new Modal();

--- a/packages/drawer/README.md
+++ b/packages/drawer/README.md
@@ -268,7 +268,7 @@ Drawers can slide in from the left or right using the position modifiers:
 
 ## API
 
-### `drawer.init()`
+### `drawer.init(options)`
 
 Initializes the drawer instance. During initialization, the following processes are run:
 
@@ -277,6 +277,10 @@ Initializes the drawer instance. During initialization, the following processes 
 - Runs `breakpoint.init()` to initialize all breakpoints for drawers.
 - Adds the `click` event listener to the document.
 - Adds the `keydown` event listener for closing modal drawers with the `esc` key.
+
+**Parameters**
+
+- `options [Object] (optional) (default null)` An options object for passing your custom settings.
 
 ```js
 const drawer = new Drawer();
@@ -424,7 +428,7 @@ const el = drawer.getDrawer('drawer-key');
 console.log(el);
 ```
 
-### `drawer.setTabindex`
+### `drawer.setTabindex()`
 
 Sets the `tabindex="-1"` attribute on all drawer dialogs. This makes it possible to set focus on the dialog when opened but won't allow users to focus it using the keyboard. This is ran automatically on `drawer.init()` if the `setTabindex` option is set to `true`.
 

--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -220,7 +220,7 @@ Adjusts the size of modals. This modifier provides two options, `modal_size_sm` 
 
 ## API
 
-### `modal.init()`
+### `modal.init(options)`
 
 Initializes the modal instance. During initialization, the following processes are run:
 
@@ -229,6 +229,10 @@ Initializes the modal instance. During initialization, the following processes a
 - Moves all modals in the DOM to a location specified in the `moveModals` option.
 - Adds the `click` event listener to the document.
 - Adds the `keydown` event listener for closing modals with the `esc` key.
+
+**Parameters**
+
+- `options [Object] (optional) (default null)` An options object for passing your custom settings.
 
 ```js
 const modal = new Modal();


### PR DESCRIPTION
## What changed?

This PR adds the parameter documentation to the `init()` methods of drawer and modal components.

Fixes #634
