### PR TITLE
Update github workflows build node versions to match tool-version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 17.4.0
       - run: npm ci
       - run: npx lerna bootstrap
       - run: npm run build


### PR DESCRIPTION
## What changed?

This PR changes the node-version set in github workflows build node version to match the version set in tool-version.