### PR TITLE
Bump node js to the most current version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 17.4.0
+          node-version: 17.5.0
       - run: npm ci
       - run: npx lerna bootstrap
       - run: npm run build

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 17.4.0
+nodejs 17.5.0


### PR DESCRIPTION
This PR bumps the version of node js to the most current version.

Fixes #823