### PR TITLE
Accessible popover tooltip support using aria-describedby

### DIFF
--- a/docs/_includes/menu.html
+++ b/docs/_includes/menu.html
@@ -18,7 +18,7 @@
   <li class="menu__item" data-category="{{ item.category }}">
     <a class="menu__action{{ class }}" href="{{ item.url }}">
       <span class="menu__text name">{{ item.title }}</span>
-      <span class="menu__icon category" data-category="{{ item.category }}" aria-controls="popover-category-{{ forloop.index }}">
+      <span class="menu__icon category" data-category="{{ item.category }}" aria-describedby="popover-category-{{ forloop.index }}">
         {%- if item.category == 'layout' -%}
         {%- include icon.html icon="layout" -%}
         {%- elsif item.category == 'compound' -%}
@@ -29,7 +29,7 @@
         {%- include icon.html icon="settings" -%}
         {%- endif -%}
       </span>
-      <div id="popover-category-{{ forloop.index }}" class="popover popover_tooltip" style="--popover-placement: left;">
+      <div id="popover-category-{{ forloop.index }}" class="popover popover_tooltip" role="tooltip" style="--popover-placement: left;">
         {{ item.category }}
         <span class="popover__arrow"></span>
       </div>

--- a/docs/_packages/popover.md
+++ b/docs/_packages/popover.md
@@ -272,22 +272,28 @@ Adjusts the size of the popover. There are two options relative to the default s
 
 ## popover_tooltip
 
-Applies styles to a popover to better fit a "tooltip" application. The default placement will be set to `top` and are triggered by the `hover` event.
+Applies styles to create a popover tooltip. The default placement of a tooltip is `top` and are triggered by the `hover` and `focus` events. Tooltips also require a different set of attributes for accessibility:
+
+- The popover element should have the `role="tooltip"` set.
+- The popover trigger should have `aria-describedby` (instead of `aria-controls`) set to the ID of the popover element.
 
 {% include demo_open.html %}
-<button class="button" aria-controls="popover-11">Tooltip Trigger</button>
-<div class="popover popover_tooltip" id="popover-11">
-  This is a tooltip...
+<span class="border-bottom" aria-describedby="popover-11">HTML</span>
+<div id="popover-11" class="popover popover_tooltip" role="tooltip">
+  Hypertext Markup Language
   <span class="popover__arrow"></span>
 </div>
 {% include demo_switch.html %}
 ```html
-<div id="unique-id" class="popover popover_tooltip">
-  ...
+<span aria-describedby="unique-id">HTML</span>
+<div id="unique-id" class="popover popover_tooltip" role="tooltip">
+  Hypertext Markup Language
   <span class="popover__arrow"></span>
 </div>
 ```
 {% include demo_close.html %}
+
+> For more information regarding tooltip accessibility and best practices: [ARIA: tooltip role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role)
 
 ## Sass variables
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,11 +19,11 @@ title: "Home"
           </a>
         </div>
         <div class="grid__item">
-          <a href="http://github.com/{{ site.repository }}/releases" class="cover__version" aria-controls="popover-release">
+          <a href="http://github.com/{{ site.repository }}/releases" class="cover__version" aria-describedby="popover-release">
             <span>Version</span>
             <span class="version loading" data-role="version"></span>
           </a>
-          <div id="popover-release" class="popover popover_tooltip" style="--popover-placement: bottom-start;">
+          <div id="popover-release" class="popover popover_tooltip" role="tooltip" style="--popover-placement: bottom-start;">
             View releases on Github
             <span class="popover__arrow"></span>
           </div>

--- a/packages/popover/README.md
+++ b/packages/popover/README.md
@@ -160,14 +160,20 @@ Adjusts the size of the popover. There are two options relative to the default s
 
 ### `popover_tooltip`
 
-Applies styles to a popover to better fit a "tooltip" application. The default placement will be set to `top` and are triggered by the `hover` event.
+Applies styles to create a popover tooltip. The default placement of a tooltip is `top` and are triggered by the `hover` and `focus` events. Tooltips also require a different set of attributes for accessibility:
+
+- The popover element should have the `role="tooltip"` set.
+- The popover trigger should have `aria-describedby` (instead of `aria-controls`) set to the ID of the popover element.
 
 ```html
-<div id="unique-id" class="popover popover_tooltip">
-  ...
+<span aria-describedby="unique-id">HTML</span>
+<div id="unique-id" class="popover popover_tooltip" role="tooltip">
+  Hypertext Markup Language
   <span class="popover__arrow"></span>
 </div>
 ```
+
+> For more information regarding tooltip accessibility and best practices: [ARIA: tooltip role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role)
 
 ## Customization
 

--- a/packages/popover/example.html
+++ b/packages/popover/example.html
@@ -80,8 +80,8 @@
             </div>
           </div>
           <div>
-            <button class="button" aria-controls="popover-tooltip">Tooltip Trigger</button>
-            <div id="popover-tooltip" class="popover popover_tooltip">
+            <button class="button" aria-describedby="popover-tooltip">Tooltip Trigger</button>
+            <div id="popover-tooltip" class="popover popover_tooltip" role="tooltip">
               This is a tooltip...
               <span class="popover__arrow"></span>
             </div>

--- a/packages/popover/src/js/close.js
+++ b/packages/popover/src/js/close.js
@@ -3,7 +3,9 @@ export function close(popover) {
   popover.target.classList.remove(this.settings.stateActive);
 
   // Update a11y attributes
-  popover.trigger.setAttribute('aria-expanded', 'false');
+  if (popover.trigger.hasAttribute('aria-controls')) {
+    popover.trigger.setAttribute('aria-expanded', 'false');
+  }
 
   // Disable popper event listeners
   popover.popper.setOptions({

--- a/packages/popover/src/js/helpers.js
+++ b/packages/popover/src/js/helpers.js
@@ -115,6 +115,11 @@ export function getPopoverID(obj) {
       return obj.getAttribute('aria-controls');
     }
 
+    // If it's a popover tooltip trigger
+    else if (obj.hasAttribute('aria-describedby')) {
+      return obj.getAttribute('aria-describedby');
+    }
+
     // If it's a popover target
     else if (obj.closest(this.settings.selectorPopover)) {
       return obj.id;
@@ -136,7 +141,9 @@ export function getPopoverID(obj) {
 export function getPopoverElements(query) {
   const id = getPopoverID.call(this, query);
   if (id) {
-    const trigger = document.querySelector(`[aria-controls="${id}"]`);
+    const trigger =
+      document.querySelector(`[aria-controls="${id}"]`) ||
+      document.querySelector(`[aria-describedby="${id}"]`);
     const target = document.querySelector(`#${id}`);
 
     if (!trigger && !target) {

--- a/packages/popover/src/js/open.js
+++ b/packages/popover/src/js/open.js
@@ -5,7 +5,9 @@ export function open(popover) {
   popover.target.classList.add(this.settings.stateActive);
 
   // Update a11y attribute
-  popover.trigger.setAttribute('aria-expanded', 'true');
+  if (popover.trigger.hasAttribute('aria-controls')) {
+    popover.trigger.setAttribute('aria-expanded', 'true');
+  }
 
   // Update popover config
   popover.config = getConfig(popover.target, this.settings);

--- a/packages/popover/tests/close.test.js
+++ b/packages/popover/tests/close.test.js
@@ -11,6 +11,8 @@ const markup = `
   <div id="asdf" class="popover is-active" tabindex="0">...</div>
   <button aria-controls="fdsa">...</button>
   <div id="fdsa" class="popover is-active">...</div>
+  <span aria-describedby="afsd">...</span>
+  <div id="afsd" class="popover popover_tooltip is-active" role="tooltip">...</div>
 `;
 
 afterEach(() => {
@@ -23,11 +25,27 @@ describe('close()', () => {
   test('should close the provided popover', () => {
     document.body.innerHTML = markup;
     popover = new Popover({ autoInit: true });
-    expect(popover.collection[0].state).toBe('opened');
-    expect(popover.collection[0].target).toHaveClass('is-active');
-    popover.close(popover.collection[0].id);
-    expect(popover.collection[0].state).toBe('closed');
-    expect(popover.collection[0].target).not.toHaveClass('is-active');
+    const el = popover.get('asdf');
+    expect(el.state).toBe('opened');
+    expect(el.target).toHaveClass('is-active');
+    expect(el.trigger.getAttribute('aria-expanded')).toBe('true');
+    el.close();
+    expect(el.state).toBe('closed');
+    expect(el.target).not.toHaveClass('is-active');
+    expect(el.trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  test('should close the provided popover tooltip', () => {
+    document.body.innerHTML = markup;
+    popover = new Popover({ autoInit: true });
+    const el = popover.get('afsd');
+    expect(el.state).toBe('opened');
+    expect(el.target).toHaveClass('is-active');
+    expect(el.trigger.hasAttribute('aria-expanded')).toBe(false);
+    el.close();
+    expect(el.state).toBe('closed');
+    expect(el.target).not.toHaveClass('is-active');
+    expect(el.trigger.hasAttribute('aria-expanded')).toBe(false);
   });
 });
 
@@ -35,7 +53,7 @@ describe('closeAll()', () => {
   test('should close all popovers', () => {
     document.body.innerHTML = markup;
     popover = new Popover({ autoInit: true });
-    expect(popover.collection.length).toBe(2);
+    expect(popover.collection.length).toBe(3);
     expect(popover.collection[0].target).toHaveClass('is-active');
     expect(popover.collection[1].target).toHaveClass('is-active');
     closeAll.call(popover);
@@ -48,7 +66,7 @@ describe('closeCheck()', () => {
   test('should close popover if closeCheck does not detect a hover or focus on trigger or target elements', () => {
     document.body.innerHTML = markup;
     popover = new Popover({ autoInit: true });
-    expect(popover.collection.length).toBe(2);
+    expect(popover.collection.length).toBe(3);
     closeCheck.call(popover, popover.collection[0]);
     jest.advanceTimersByTime(100);
     expect(popover.collection[0].target).not.toHaveClass('is-active');

--- a/packages/popover/tests/helpers.test.js
+++ b/packages/popover/tests/helpers.test.js
@@ -17,8 +17,8 @@ const markup = `
   <button aria-controls="pop-2">...</button>
   <div id="pop-2" class="popover">...</div>
 
-  <button aria-controls="pop-3">...</button>
-  <div id="pop-3" class="popover">...</div>
+  <span aria-describedby="pop-3">...</span>
+  <div id="pop-3" class="popover popover_tooltip" role="tooltip">...</div>
 
   <button aria-controls="asdf">...</button>
   <div id="fdsa" class="popover">...</div>
@@ -144,6 +144,30 @@ describe('getConfig() & getModifiers()', () => {
 });
 
 describe('getPopoverID()', () => {
+  test('should return the popover id using a popover', () => {
+    document.body.innerHTML = markup;
+    popover = new Popover();
+    const el = document.querySelector('.popover');
+    const result = getPopoverID.call(popover, el);
+    expect(result).toBe('pop-1');
+  });
+
+  test('should return the popover id using a popover trigger', () => {
+    document.body.innerHTML = markup;
+    popover = new Popover();
+    const el = document.querySelector('[aria-controls="pop-2"]');
+    const result = getPopoverID.call(popover, el);
+    expect(result).toBe('pop-2');
+  });
+
+  test('should return the popover id using a popover tooltip trigger', () => {
+    document.body.innerHTML = markup;
+    popover = new Popover();
+    const el = document.querySelector('[aria-describedby="pop-3"]');
+    const result = getPopoverID.call(popover, el);
+    expect(result).toBe('pop-3');
+  });
+
   test('should return false if html element does not have the correct attributes', () => {
     document.body.innerHTML = markup;
     popover = new Popover();
@@ -190,16 +214,6 @@ describe('getPopoverElements()', () => {
     expect(console.error).toHaveBeenCalledWith('No popover trigger associated with the provided popover:', target);
   });
 
-  test('should return popover target and trigger elements when found using ID', () => {
-    document.body.innerHTML = markup;
-    const trigger = document.querySelector('[aria-controls="pop-1"]');
-    const target = document.querySelector('#pop-1');
-    popover = new Popover();
-    const result = getPopoverElements.call(popover, 'pop-1');
-    expect(result.target).toBe(target);
-    expect(result.trigger).toBe(trigger);
-  });
-
   test('should throw error if unable to resolve a popover ID with provided query', () => {
     document.body.innerHTML = markup;
     console.error = jest.fn();
@@ -208,5 +222,15 @@ describe('getPopoverElements()', () => {
     const result = getPopoverElements.call(popover, trigger);
     expect(result).toBe(false);
     expect(console.error).toHaveBeenCalledWith('Could not resolve the popover ID:', trigger);
+  });
+
+  test('should return popover target and trigger elements when found using ID', () => {
+    document.body.innerHTML = markup;
+    const trigger = document.querySelector('[aria-controls="pop-1"]');
+    const target = document.querySelector('#pop-1');
+    popover = new Popover();
+    const result = getPopoverElements.call(popover, 'pop-1');
+    expect(result.target).toBe(target);
+    expect(result.trigger).toBe(trigger);
   });
 });

--- a/packages/popover/tests/open.test.js
+++ b/packages/popover/tests/open.test.js
@@ -8,6 +8,8 @@ jest.useFakeTimers();
 const markup = `
   <button aria-controls="asdf">...</button>
   <div id="asdf" class="popover">...</div>
+  <span aria-describedby="fdsa">...</span>
+  <div id="fdsa" class="popover popover_tooltip" role="tooltip">...</div>
 `;
 
 afterEach(() => {
@@ -20,10 +22,26 @@ describe('open()', () => {
   test('should open the provided popover', () => {
     document.body.innerHTML = markup;
     popover = new Popover({ autoInit: true });
-    expect(popover.collection[0].state).toBe('closed');
-    expect(popover.collection[0].target).not.toHaveClass('is-active');
-    popover.open(popover.collection[0].id);
-    expect(popover.collection[0].state).toBe('opened');
-    expect(popover.collection[0].target).toHaveClass('is-active');
+    const el = popover.get('asdf');
+    expect(el.state).toBe('closed');
+    expect(el.target).not.toHaveClass('is-active');
+    expect(el.trigger.getAttribute('aria-expanded')).toBe('false');
+    el.open();
+    expect(el.state).toBe('opened');
+    expect(el.target).toHaveClass('is-active');
+    expect(el.trigger.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  test('should open the provided popover tooltip', () => {
+    document.body.innerHTML = markup;
+    popover = new Popover({ autoInit: true });
+    const el = popover.get('fdsa');
+    expect(el.state).toBe('closed');
+    expect(el.target).not.toHaveClass('is-active');
+    expect(el.trigger.hasAttribute('aria-expanded')).toBe(false);
+    el.open();
+    expect(el.state).toBe('opened');
+    expect(el.target).toHaveClass('is-active');
+    expect(el.trigger.hasAttribute('aria-expanded')).toBe(false);
   });
 });


### PR DESCRIPTION
## What changed?

This PR introduces accessibility improvements to the tooltip variation of popover. Now able to use `aria-describedby` instead of `aria-controls` for tooltip triggers and updates documentation to reflect required attributes for accessible tooltip usage.