### PR TITLE
Allow configuring a modal on a per-modal basis

### DIFF
--- a/packages/modal/src/js/close.js
+++ b/packages/modal/src/js/close.js
@@ -1,6 +1,7 @@
 import { setInert, setOverflowHidden } from '@vrembem/core/index';
 import { focusTrigger } from '@vrembem/core/index';
 import { closeTransition } from '@vrembem/core/index';
+import { getModalConfig } from './helpers';
 
 export async function close(returnFocus = true) {
   const modal = document.querySelector(
@@ -8,12 +9,13 @@ export async function close(returnFocus = true) {
   );
   if (modal) {
     this.working = true;
-    setInert(false, this.settings.selectorInert);
-    setOverflowHidden(false, this.settings.selectorOverflow);
-    await closeTransition(modal, this.settings);
+    const config = getModalConfig.call(this, modal);
+    setInert(false, config.selectorInert);
+    setOverflowHidden(false, config.selectorOverflow);
+    await closeTransition(modal, config);
     if (returnFocus) focusTrigger(this);
     this.focusTrap.destroy();
-    modal.dispatchEvent(new CustomEvent(this.settings.customEventPrefix + 'closed', {
+    modal.dispatchEvent(new CustomEvent(config.customEventPrefix + 'closed', {
       detail: this,
       bubbles: true
     }));

--- a/packages/modal/src/js/defaults.js
+++ b/packages/modal/src/js/defaults.js
@@ -8,6 +8,7 @@ export default {
   dataClose: 'modal-close',
   dataFocus: 'modal-focus',
   dataRequired: 'modal-required',
+  dataConfig: 'modal-config',
 
   // State classes
   stateOpened: 'is-opened',

--- a/packages/modal/src/js/helpers.js
+++ b/packages/modal/src/js/helpers.js
@@ -1,7 +1,7 @@
 import { moveElement } from '@vrembem/core/index';
 
 export function getModalConfig(modal) {
-  const json = modal.getAttribute('data-modal-config');
+  const json = modal.getAttribute(`data-${this.settings.dataConfig}`);
   if (json) {
     const config = JSON.parse(json);
     return { ...this.settings, ...config };

--- a/packages/modal/src/js/helpers.js
+++ b/packages/modal/src/js/helpers.js
@@ -1,5 +1,15 @@
 import { moveElement } from '@vrembem/core/index';
 
+export function getModalConfig(modal) {
+  const json = modal.getAttribute('data-modal-config');
+  if (json) {
+    const config = JSON.parse(json);
+    return { ...this.settings, ...config };
+  } else {
+    return this.settings;
+  }
+}
+
 export function getModal(modalKey) {
   if (typeof modalKey !== 'string') return modalKey;
   return document.querySelector(

--- a/packages/modal/src/js/open.js
+++ b/packages/modal/src/js/open.js
@@ -3,19 +3,20 @@ import { setInert, setOverflowHidden } from '@vrembem/core/index';
 import { focusTarget } from '@vrembem/core/index';
 import { openTransition } from '@vrembem/core/index';
 
-import { getModal, modalNotFound } from './helpers';
+import { getModalConfig, getModal, modalNotFound } from './helpers';
 
 export async function open(modalKey) {
   const modal = getModal.call(this, modalKey);
   if (!modal) return modalNotFound(modalKey);
-  if (hasClass(modal, this.settings.stateClosed)) {
+  const config = getModalConfig.call(this, modal);
+  if (hasClass(modal, config.stateClosed)) {
     this.working = true;
-    setOverflowHidden(true, this.settings.selectorOverflow);
-    await openTransition(modal, this.settings);
+    setOverflowHidden(true, config.selectorOverflow);
+    await openTransition(modal, config);
     this.focusTrap.init(modal);
-    focusTarget(modal, this.settings);
-    setInert(true, this.settings.selectorInert);
-    modal.dispatchEvent(new CustomEvent(this.settings.customEventPrefix + 'opened', {
+    focusTarget(modal, config);
+    setInert(true, config.selectorInert);
+    modal.dispatchEvent(new CustomEvent(config.customEventPrefix + 'opened', {
       detail: this,
       bubbles: true
     }));

--- a/packages/modal/tests/api.test.js
+++ b/packages/modal/tests/api.test.js
@@ -26,6 +26,15 @@ const markupState = `
   </div>
 `;
 
+const markupConfig = `
+  <button data-modal-open="modal-default">Modal Default</button>
+  <div data-modal="modal-default" data-modal-config='{ "transition": false }' class="modal">
+    <div data-modal-dialog class="modal__dialog">
+      <button data-modal-close>Close</button>
+    </div>
+  </div>
+`;
+
 afterEach(() => {
   modal.destroy();
   modal = null;
@@ -137,7 +146,7 @@ test('should set tabindex attribute with api call', () => {
   expect(dialog).toHaveAttribute('tabindex');
 });
 
-test('should set initial state on api call', () => {
+test('should set initial() state on api call', () => {
   document.body.innerHTML = markupState;
   modal = new Modal();
   const modalOne = document.querySelector('[data-modal="modal-one"]');
@@ -180,4 +189,14 @@ test('should return null if getModal is not found', () => {
   modal = new Modal({ autoInit: true });
   const el = modal.getModal('asdf');
   expect(el).toBe(null);
+});
+
+test('should use a modal config to update the settings object', () => {
+  document.body.innerHTML = markupConfig;
+  modal = new Modal({ autoInit: true });
+
+  modal.open('modal-default');
+  const el = modal.getModal('modal-default');
+  expect(el).toHaveAttribute('data-modal-config');
+  expect(el).toHaveClass('is-opened');
 });


### PR DESCRIPTION
## What changed?

This PR introduces a new modal data attribute which allows passing a custom configuration object on a per modal basis.