### PR TITLE
Add ability to sync component state with existing collection entries

### DIFF
--- a/packages/drawer/src/js/index.js
+++ b/packages/drawer/src/js/index.js
@@ -76,6 +76,7 @@ export default class Drawer extends Collection {
   }
 
   register(query) {
+    // TODO: Pass "force" param to `deregister()` first before fresh `register()`.
     const els = getDrawerElements.call(this, query);
     if (els.error) return Promise.reject(els.error);
     return register.call(this, els.drawer, els.dialog);

--- a/packages/drawer/src/js/register.js
+++ b/packages/drawer/src/js/register.js
@@ -9,6 +9,18 @@ import { initialState } from './helpers/initialState';
 import { getBreakpoint } from './helpers';
 
 export async function register(el, dialog) {
+  // Check if entry is already registered.
+  const asdf = this.get(el.id);
+
+  // Run sync() if entry has already been registered.
+  if (asdf) {
+    console.log('Already registered, run sync()...');
+    return asdf;
+  }
+
+  console.log('Not registered, run register()...');
+
+  // TODO: Only run deregister() if "force" param is passed.
   // Deregister entry incase it has already been registered.
   await deregister.call(this, el, false);
 
@@ -29,7 +41,7 @@ export async function register(el, dialog) {
     toggle(transition, focus) {
       return toggle.call(root, this, transition, focus);
     },
-    refresh() {
+    sync() {
       if (this.mode === 'modal') {
         this.el.classList.add(root.settings.classModal);
       } else {

--- a/packages/drawer/src/js/register.js
+++ b/packages/drawer/src/js/register.js
@@ -29,6 +29,23 @@ export async function register(el, dialog) {
     toggle(transition, focus) {
       return toggle.call(root, this, transition, focus);
     },
+    refresh() {
+      if (this.mode === 'modal') {
+        this.el.classList.add(root.settings.classModal);
+      } else {
+        this.el.classList.remove(root.settings.classModal);
+      }
+
+      if (this.state === 'opened') {
+        this.el.classList.remove(root.settings.stateClosed);
+        this.el.classList.add(root.settings.stateOpened);
+      } else if (this.state === 'closed') {
+        this.el.classList.add(root.settings.stateClosed);
+        this.el.classList.remove(root.settings.stateOpened);
+      }
+
+      return this;
+    },
     deregister() {
       return deregister.call(root, this);
     },

--- a/packages/drawer/src/js/register.js
+++ b/packages/drawer/src/js/register.js
@@ -4,6 +4,7 @@ import { deregister } from './deregister';
 import { open } from './open';
 import { close } from './close';
 import { toggle } from './toggle';
+import { sync } from './sync';
 import { switchMode } from './switchMode';
 import { initialState } from './helpers/initialState';
 import { getBreakpoint } from './helpers';
@@ -14,8 +15,8 @@ export async function register(el, dialog) {
 
   // Run sync() if entry has already been registered.
   if (asdf) {
-    console.log('Already registered, run sync()...');
-    return asdf;
+    // TODO: should sync el => obj
+    return sync.call(this, asdf);
   }
 
   console.log('Not registered, run register()...');
@@ -42,21 +43,8 @@ export async function register(el, dialog) {
       return toggle.call(root, this, transition, focus);
     },
     sync() {
-      if (this.mode === 'modal') {
-        this.el.classList.add(root.settings.classModal);
-      } else {
-        this.el.classList.remove(root.settings.classModal);
-      }
-
-      if (this.state === 'opened') {
-        this.el.classList.remove(root.settings.stateClosed);
-        this.el.classList.add(root.settings.stateOpened);
-      } else if (this.state === 'closed') {
-        this.el.classList.add(root.settings.stateClosed);
-        this.el.classList.remove(root.settings.stateOpened);
-      }
-
-      return this;
+      // TODO: should sync obj => el
+      return sync.call(root, this);
     },
     deregister() {
       return deregister.call(root, this);

--- a/packages/drawer/src/js/sync.js
+++ b/packages/drawer/src/js/sync.js
@@ -1,0 +1,19 @@
+export async function sync(entry) {
+  console.log('sync()...', entry.id, this);
+
+  if (entry.mode === 'modal') {
+    entry.el.classList.add(this.settings.classModal);
+  } else {
+    entry.el.classList.remove(this.settings.classModal);
+  }
+
+  if (entry.state === 'opened') {
+    entry.el.classList.remove(this.settings.stateClosed);
+    entry.el.classList.add(this.settings.stateOpened);
+  } else if (entry.state === 'closed') {
+    entry.el.classList.add(this.settings.stateClosed);
+    entry.el.classList.remove(this.settings.stateOpened);
+  }
+
+  return entry;
+}

--- a/packages/modal/src/js/register.js
+++ b/packages/modal/src/js/register.js
@@ -23,6 +23,17 @@ export async function register(el, dialog) {
     replace(transition, focus) {
       return replace.call(root, this, transition, focus);
     },
+    refresh() {
+      if (this.state === 'opened') {
+        this.el.classList.remove(root.settings.stateClosed);
+        this.el.classList.add(root.settings.stateOpened);
+      } else if (this.state === 'closed') {
+        this.el.classList.add(root.settings.stateClosed);
+        this.el.classList.remove(root.settings.stateOpened);
+      }
+
+      return this;
+    },
     deregister() {
       return deregister.call(root, this);
     },

--- a/packages/modal/src/js/register.js
+++ b/packages/modal/src/js/register.js
@@ -23,7 +23,7 @@ export async function register(el, dialog) {
     replace(transition, focus) {
       return replace.call(root, this, transition, focus);
     },
-    refresh() {
+    sync() {
       if (this.state === 'opened') {
         this.el.classList.remove(root.settings.stateClosed);
         this.el.classList.add(root.settings.stateOpened);

--- a/packages/popover/src/js/register.js
+++ b/packages/popover/src/js/register.js
@@ -21,7 +21,7 @@ export async function register(el, trigger) {
     close() {
       return close.call(root, this);
     },
-    refresh() {
+    sync() {
       if (this.state === 'opened') {
         this.el.classList.add(root.settings.stateActive);
       } else if (this.state === 'closed') {

--- a/packages/popover/src/js/register.js
+++ b/packages/popover/src/js/register.js
@@ -21,6 +21,15 @@ export async function register(el, trigger) {
     close() {
       return close.call(root, this);
     },
+    refresh() {
+      if (this.state === 'opened') {
+        this.el.classList.add(root.settings.stateActive);
+      } else if (this.state === 'closed') {
+        this.el.classList.remove(root.settings.stateActive);
+      }
+
+      return this;
+    },
     deregister() {
       return deregister.call(root, this);
     }


### PR DESCRIPTION
## Problem

There are cases where a components state may become desynced from the state stored in a collection entry. This is typically caused by front-end frameworks updating the DOM or not catching an update made by the component.

## Solution

This PR introduces the ability to sync a component in two ways:

- From collection entry to DOM.
- From DOM to collection entry.
