### PR TITLE
Trim custom property values and create getPrefix module

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -3,6 +3,7 @@ export * from './src/js/Collection';
 export * from './src/js/FocusTrap';
 
 export * from './src/js/getConfig';
+export * from './src/js/getPrefix';
 export * from './src/js/localStore';
 export * from './src/js/teleport';
 export * from './src/js/transition';

--- a/packages/core/src/js/getPrefix.js
+++ b/packages/core/src/js/getPrefix.js
@@ -1,0 +1,3 @@
+export function getPrefix() {
+  return getComputedStyle(document.body).getPropertyValue('--vrembem-variable-prefix').trim();
+}

--- a/packages/core/tests/getPrefix.test.js
+++ b/packages/core/tests/getPrefix.test.js
@@ -1,0 +1,12 @@
+import { getPrefix } from '../index';
+
+test('should return the vrembem prefix value', () => {
+  const data = getPrefix();
+  expect(data).toBe('');
+});
+
+test('should return the vrembem prefix value', () => {
+  document.body.style.setProperty('--vrembem-variable-prefix', 'vb-');
+  const data = getPrefix();
+  expect(data).toBe('vb-');
+});

--- a/packages/drawer/src/js/helpers/getBreakpoint.js
+++ b/packages/drawer/src/js/helpers/getBreakpoint.js
@@ -1,18 +1,13 @@
+import { getPrefix } from '@vrembem/core';
+
 export function getBreakpoint(drawer) {
-  const prefix = getVariablePrefix();
+  const prefix = getPrefix();
   const bp = drawer.getAttribute(`data-${this.settings.dataBreakpoint}`);
   if (this.settings.breakpoints && this.settings.breakpoints[bp]) {
     return this.settings.breakpoints[bp];
-  } else if (getComputedStyle(document.body).getPropertyValue(prefix + bp)) {
-    return getComputedStyle(document.body).getPropertyValue(prefix + bp);
+  } else if (getComputedStyle(document.body).getPropertyValue(`--${prefix}breakpoint-${bp}`).trim()) {
+    return getComputedStyle(document.body).getPropertyValue(`--${prefix}breakpoint-${bp}`).trim();
   } else {
     return bp;
   }
-}
-
-function getVariablePrefix() {
-  let prefix = '--';
-  prefix += getComputedStyle(document.body).getPropertyValue('--vrembem-variable-prefix');
-  prefix += 'breakpoint-';
-  return prefix;
 }

--- a/packages/popover/src/js/helpers/getConfig.js
+++ b/packages/popover/src/js/helpers/getConfig.js
@@ -1,3 +1,5 @@
+import { getPrefix } from '@vrembem/core';
+
 export function getConfig(el, settings) {
   // Get the computed styles of the element.
   const styles = getComputedStyle(el);
@@ -16,7 +18,7 @@ export function getConfig(el, settings) {
   // Loop through config obj.
   for (const prop in config) {
     // Get the CSS variable property values.
-    const prefix = getComputedStyle(document.body).getPropertyValue('--vrembem-variable-prefix');
+    const prefix = getPrefix();
     const value = styles.getPropertyValue(`--${prefix}popover-${prop}`).trim();
 
     // If a value was found, replace the default in config obj.


### PR DESCRIPTION
## Problem

In some browsers, getting the value of a custom property in JavaScript returns extra spacing. This caused some flows to break unexpectedly in browsers that included extra spacing on returned values.

## Solution

This PR adds the `trim()` method to the returned custom property value and creates the `getPrefix()` module for shared functionality. 