### PR TITLE
Fix missing aria-describedby check in close and handler functions

### DIFF
--- a/packages/popover/src/js/close.js
+++ b/packages/popover/src/js/close.js
@@ -55,7 +55,9 @@ export function closeCheck(popover) {
       popover.trigger.closest(':hover') === popover.trigger;
 
     // Check if trigger or element are being focused.
-    const isFocused = document.activeElement.closest(`#${popover.id}, [aria-controls="${popover.id}"]`);
+    const isFocused = document.activeElement.closest(
+      `#${popover.id}, [aria-controls="${popover.id}"], [aria-describedby="${popover.id}"]`
+    );
 
     // Close if the trigger and element are not currently hovered or focused.
     if (!isHovered && !isFocused) {

--- a/packages/popover/src/js/handlers.js
+++ b/packages/popover/src/js/handlers.js
@@ -33,19 +33,24 @@ export function handleKeydown(event) {
 export function handleDocumentClick(popover) {
   const root = this;
   document.addEventListener('click', function _f(event) {
-    // Check if a popover was clicked.
-    const result = event.target.closest(`#${popover.id}, [aria-controls="${popover.id}"]`);
-    if (!result) {
-      // If it doesn't match and popover is open, close it and remove event listener.
+    // Check if a popover or its trigger was clicked.
+    const wasClicked = event.target.closest(
+      `#${popover.id}, [aria-controls="${popover.id}"], [aria-describedby="${popover.id}"]`
+    );
+
+    // If popover or popover trigger was clicked...
+    if (wasClicked) {
+      // If popover element exists and is not active...
+      if (popover.el && !popover.el.classList.contains(root.settings.stateActive)) {
+        this.removeEventListener('click', _f);
+      }
+
+    } else {
+      // If popover element exists and is active...
       if (popover.el && popover.el.classList.contains(root.settings.stateActive)) {
         popover.close();
       }
       this.removeEventListener('click', _f);
-    } else {
-      // If it does match and popover isn't currently active, remove event listener.
-      if (popover.el && !popover.el.classList.contains(root.settings.stateActive)) {
-        this.removeEventListener('click', _f);
-      }
     }
   });
 }


### PR DESCRIPTION
## Problem

The `close()` and `handleDocumentClick()` functions are not correctly catching cases where the popover trigger is a `aria-describedby` element typically used in tooltip popovers.

## Solution

This PR adds the missing `aria-describedby` check in `close()` and `handleDocumentClick()` functions.