### PR TITLE
Refactor custom properties output in popover component

### DIFF
--- a/packages/popover/index.scss
+++ b/packages/popover/index.scss
@@ -1,4 +1,7 @@
+@use "@vrembem/core/src/scss/root/prefix";
+
 @forward "./src/scss/variables";
+@forward "./src/scss/root";
 @forward "./src/scss/popover";
 @forward "./src/scss/popover__arrow";
 @forward "./src/scss/popover_size";

--- a/packages/popover/src/scss/_popover.scss
+++ b/packages/popover/src/scss/_popover.scss
@@ -5,20 +5,6 @@ $_v: var.$prefix-variable;
 $_b: var.$prefix-block;
 $_offset: calc(calc(var(--#{$_v}popover-offset) + 1) * 1px);
 
-:root {
-  @if (var.$event) {
-    --#{$_v}popover-event: #{var.$event};
-  }
-
-  @if (var.$placement) {
-    --#{$_v}popover-placement: #{var.$placement};
-  }
-
-  --#{$_v}popover-offset: #{core.strip-unit(var.$offset)};
-  --#{$_v}popover-overflow-padding: #{core.strip-unit(var.$overflow-padding)};
-  --#{$_v}popover-flip-padding: #{core.strip-unit(var.$flip-padding)};
-}
-
 .#{$_b}popover {
   position: absolute;
   z-index: var.$z-index;

--- a/packages/popover/src/scss/_popover__arrow.scss
+++ b/packages/popover/src/scss/_popover__arrow.scss
@@ -5,10 +5,6 @@ $_v: var.$prefix-variable;
 $_b: var.$prefix-block;
 $_e: var.$prefix-element;
 
-:root {
-  --#{$_v}popover-arrow-padding: #{var.$arrow-padding};
-}
-
 .#{$_b}popover#{$_e}arrow,
 .#{$_b}popover#{$_e}arrow::after {
   @include core.size(var(--#{$_v}popover-arrow-size, var.$arrow-size));

--- a/packages/popover/src/scss/_popover__arrow.scss
+++ b/packages/popover/src/scss/_popover__arrow.scss
@@ -6,14 +6,12 @@ $_b: var.$prefix-block;
 $_e: var.$prefix-element;
 
 :root {
-  --#{$_v}popover-arrow-size: #{var.$arrow-size};
   --#{$_v}popover-arrow-padding: #{var.$arrow-padding};
-  --#{$_v}popover-arrow-border: #{var.$arrow-border};
 }
 
 .#{$_b}popover#{$_e}arrow,
 .#{$_b}popover#{$_e}arrow::after {
-  @include core.size(var(--#{$_v}popover-arrow-size));
+  @include core.size(var(--#{$_v}popover-arrow-size, var.$arrow-size));
   position: absolute;
   z-index: -1;
   visibility: hidden;
@@ -24,14 +22,14 @@ $_e: var.$prefix-element;
   content: "";
   visibility: visible;
   transform: rotate(45deg);
-  border: var(--#{$_v}popover-arrow-border);
+  border: var(--#{$_v}popover-arrow-border, var.$arrow-border);
   border-right-color: transparent;
   border-bottom-color: transparent;
   background-clip: padding-box;
 }
 
 [data-popper-placement^="top"] > .#{$_b}popover#{$_e}arrow {
-  bottom: calc(var(--#{$_v}popover-arrow-size) * -0.5);
+  bottom: calc(var(--#{$_v}popover-arrow-size, var.$arrow-size) * -0.5);
 
   &::after {
     transform: rotate(-135deg);
@@ -39,7 +37,7 @@ $_e: var.$prefix-element;
 }
 
 [data-popper-placement^="bottom"] > .#{$_b}popover#{$_e}arrow {
-  top: calc(var(--#{$_v}popover-arrow-size) * -0.5);
+  top: calc(var(--#{$_v}popover-arrow-size, var.$arrow-size) * -0.5);
 
   &::after {
     transform: rotate(45deg);
@@ -47,7 +45,7 @@ $_e: var.$prefix-element;
 }
 
 [data-popper-placement^="left"] > .#{$_b}popover#{$_e}arrow {
-  right: calc(var(--#{$_v}popover-arrow-size) * -0.5);
+  right: calc(var(--#{$_v}popover-arrow-size, var.$arrow-size) * -0.5);
 
   &::after {
     transform: rotate(135deg);
@@ -55,7 +53,7 @@ $_e: var.$prefix-element;
 }
 
 [data-popper-placement^="right"] > .#{$_b}popover#{$_e}arrow {
-  left: calc(var(--#{$_v}popover-arrow-size) * -0.5);
+  left: calc(var(--#{$_v}popover-arrow-size, var.$arrow-size) * -0.5);
 
   &::after {
     transform: rotate(-45deg);

--- a/packages/popover/src/scss/_root.scss
+++ b/packages/popover/src/scss/_root.scss
@@ -1,0 +1,17 @@
+@use "./variables" as var;
+
+$_v: var.$prefix-variable;
+
+:root {
+  @if (var.$event) {
+    --#{$_v}popover-event: #{var.$event};
+  }
+  @if (var.$placement) {
+    --#{$_v}popover-placement: #{var.$placement};
+  }
+
+  --#{$_v}popover-offset: #{var.$offset};
+  --#{$_v}popover-overflow-padding: #{var.$overflow-padding};
+  --#{$_v}popover-flip-padding: #{var.$flip-padding};
+  --#{$_v}popover-arrow-padding: #{var.$arrow-padding};
+}


### PR DESCRIPTION
## What changed?

This PR refactors the popover custom properties output by creating a `_root.scss` file that contains all global root level CSS variable declarations. This also removes global values that are not directly used in the JavaScript implementation.