### PR TITLE
Fix support for proxy polyfill and available traps

### DIFF
--- a/packages/core/src/js/localStore.js
+++ b/packages/core/src/js/localStore.js
@@ -11,13 +11,12 @@ export function localStore(key, enable = true) {
 
   return new Proxy(getStore(), {
     set: (target, property, value) => {
-      target[property] = value;
-      if (enable) setStore(target);
-      return true;
-    },
-
-    deleteProperty: (target, property) => {
-      delete target[property];
+      console.log('localStore() => set');
+      if (value === undefined) {
+        delete target[property];
+      } else {
+        target[property] = value;
+      }
       if (enable) setStore(target);
       return true;
     }

--- a/packages/core/tests/localStore.test.js
+++ b/packages/core/tests/localStore.test.js
@@ -30,15 +30,15 @@ test('should disable saving local storage if enable param is set to false', () =
   result = localStorage.getItem('asdf');
   expect(JSON.parse(result)['fdsa']).toBe(undefined);
 
-  delete store['asdf'];
+  store['asdf'] = undefined;
 
   result = localStorage.getItem('asdf');
   expect(JSON.parse(result)['asdf']).toEqual('fdsa');
 });
 
-test('should update local storage on delete', () => {
+test('should remove property from local storage when value is set to undefined', () => {
   const store = localStore('asdf');
-  delete store['asdf'];
+  store['asdf'] = undefined;
 
   result = localStorage.getItem('asdf');
   expect(JSON.parse(result)['asdf']).toBe(undefined);

--- a/packages/drawer/src/js/deregister.js
+++ b/packages/drawer/src/js/deregister.js
@@ -18,7 +18,7 @@ export async function deregister(obj, close = true) {
     }
 
     // Remove entry from local store.
-    delete this.store[entry.id];
+    this.store[entry.id] = undefined;
 
     // Unmount the MatchMedia functionality.
     entry.unmountBreakpoint();


### PR DESCRIPTION
## What changed?

Proxy is supported by [all major browsers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#browser_compatibility), but in cases where a [proxy polyfill](https://github.com/GoogleChrome/proxy-polyfill) is needed we should only use supported traps. This PR removes the use of `deleteProperty` and instead uses `set` to determine if a property should be deleted based on if it is being set to `undefined`.