### PR TITLE
Remove the use of proxies in favor of modules

### DIFF
--- a/packages/core/src/js/localStore.js
+++ b/packages/core/src/js/localStore.js
@@ -9,15 +9,23 @@ export function localStore(key, enable = true) {
     localStorage.setItem(key, JSON.stringify(obj));
   }
 
-  return new Proxy(getStore(), {
-    set: (target, property, value) => {
-      if (value === undefined) {
-        delete target[property];
-      } else {
-        target[property] = value;
-      }
-      if (enable) setStore(target);
-      return true;
+  return {
+    proxy: getStore(),
+
+    get value() {
+      return this.proxy;
+    },
+
+    add(prop, value) {
+      this.proxy[prop] = value;
+      if (enable) setStore(this.value);
+      return this.value;
+    },
+
+    remove(prop) {
+      delete this.proxy[prop];
+      if (enable) setStore(this.value);
+      return this.value;
     }
-  });
+  };
 }

--- a/packages/core/src/js/localStore.js
+++ b/packages/core/src/js/localStore.js
@@ -1,31 +1,20 @@
 export function localStore(key, enable = true) {
-
-  function getStore() {
-    const value = localStorage.getItem(key);
-    return (value) ? JSON.parse(value) : {};
-  }
-
-  function setStore(obj) {
-    localStorage.setItem(key, JSON.stringify(obj));
-  }
+  const local = localStorage.getItem(key);
+  const store = (local) ? JSON.parse(local) : {};
 
   return {
-    proxy: getStore(),
-
-    get value() {
-      return this.proxy;
+    get(prop) {
+      return (prop) ? store[prop] : store;
     },
 
-    add(prop, value) {
-      this.proxy[prop] = value;
-      if (enable) setStore(this.value);
-      return this.value;
-    },
-
-    remove(prop) {
-      delete this.proxy[prop];
-      if (enable) setStore(this.value);
-      return this.value;
+    set(prop, value) {
+      if (value) {
+        store[prop] = value;
+      } else {
+        delete store[prop];
+      }
+      if (enable) localStorage.setItem(key, JSON.stringify(store));
+      return store;
     }
   };
 }

--- a/packages/core/tests/localStore.test.js
+++ b/packages/core/tests/localStore.test.js
@@ -8,7 +8,7 @@ test('should setup a poxy that updates local storage on set', () => {
   result = localStorage.getItem('asdf');
   expect(result).toBe(null);
 
-  store.add('asdf', 'fdsa');
+  store.set('asdf', 'fdsa');
 
   result = localStorage.getItem('asdf');
   expect(JSON.parse(result)['asdf']).toBe('fdsa');
@@ -16,7 +16,12 @@ test('should setup a poxy that updates local storage on set', () => {
 
 test('should restore the state of an existing local storage object', () => {
   const store = localStore('asdf');
-  expect(store.value['asdf']).toBe('fdsa');
+  expect(store.get('asdf')).toBe('fdsa');
+});
+
+test('should return the store object when get is not provided a param', () => {
+  const store = localStore('asdf');
+  expect(store.get()).toEqual({ 'asdf': 'fdsa' });
 });
 
 test('should disable saving local storage if enable param is set to false', () => {
@@ -25,12 +30,12 @@ test('should disable saving local storage if enable param is set to false', () =
   result = localStorage.getItem('asdf');
   expect(JSON.parse(result)['asdf']).toEqual('fdsa');
 
-  store.add('fdsa', 'asdf');
+  store.set('fdsa', 'asdf');
 
   result = localStorage.getItem('asdf');
   expect(JSON.parse(result)['fdsa']).toBe(undefined);
 
-  store.remove('asdf');
+  store.set('asdf');
 
   result = localStorage.getItem('asdf');
   expect(JSON.parse(result)['asdf']).toEqual('fdsa');
@@ -38,7 +43,7 @@ test('should disable saving local storage if enable param is set to false', () =
 
 test('should remove property from local storage when value is set to undefined', () => {
   const store = localStore('asdf');
-  store.remove('asdf');
+  store.set('asdf');
 
   result = localStorage.getItem('asdf');
   expect(JSON.parse(result)['asdf']).toBe(undefined);

--- a/packages/core/tests/localStore.test.js
+++ b/packages/core/tests/localStore.test.js
@@ -8,7 +8,7 @@ test('should setup a poxy that updates local storage on set', () => {
   result = localStorage.getItem('asdf');
   expect(result).toBe(null);
 
-  store['asdf'] = 'fdsa';
+  store.add('asdf', 'fdsa');
 
   result = localStorage.getItem('asdf');
   expect(JSON.parse(result)['asdf']).toBe('fdsa');
@@ -16,7 +16,7 @@ test('should setup a poxy that updates local storage on set', () => {
 
 test('should restore the state of an existing local storage object', () => {
   const store = localStore('asdf');
-  expect(store['asdf']).toBe('fdsa');
+  expect(store.value['asdf']).toBe('fdsa');
 });
 
 test('should disable saving local storage if enable param is set to false', () => {
@@ -25,12 +25,12 @@ test('should disable saving local storage if enable param is set to false', () =
   result = localStorage.getItem('asdf');
   expect(JSON.parse(result)['asdf']).toEqual('fdsa');
 
-  store['fdsa'] = 'asdf';
+  store.add('fdsa', 'asdf');
 
   result = localStorage.getItem('asdf');
   expect(JSON.parse(result)['fdsa']).toBe(undefined);
 
-  store['asdf'] = undefined;
+  store.remove('asdf');
 
   result = localStorage.getItem('asdf');
   expect(JSON.parse(result)['asdf']).toEqual('fdsa');
@@ -38,7 +38,7 @@ test('should disable saving local storage if enable param is set to false', () =
 
 test('should remove property from local storage when value is set to undefined', () => {
   const store = localStore('asdf');
-  store['asdf'] = undefined;
+  store.remove('asdf');
 
   result = localStorage.getItem('asdf');
   expect(JSON.parse(result)['asdf']).toBe(undefined);

--- a/packages/drawer/src/js/deregister.js
+++ b/packages/drawer/src/js/deregister.js
@@ -18,7 +18,7 @@ export async function deregister(obj, close = true) {
     }
 
     // Remove entry from local store.
-    this.store[entry.id] = undefined;
+    this.store.set(entry.id);
 
     // Unmount the MatchMedia functionality.
     entry.unmountBreakpoint();

--- a/packages/drawer/src/js/helpers/initialState.js
+++ b/packages/drawer/src/js/helpers/initialState.js
@@ -3,9 +3,9 @@ export async function initialState(entry) {
   //  1. If a store state is available, restore from local store.
   //  2. If opened state class is set, set state to opened.
   //  3. Else, initialize default state.
-  if (this.store[entry.id]) {
+  if (this.store.get(entry.id)) {
     // Restore drawers to saved inline state.
-    if (this.store[entry.id] === 'opened') {
+    if (this.store.get(entry.id) === 'opened') {
       await entry.open(false, false);
     } else {
       await entry.close(false, false);

--- a/packages/drawer/src/js/register.js
+++ b/packages/drawer/src/js/register.js
@@ -68,7 +68,7 @@ export async function register(el, dialog) {
       __state = value;
       // Save 'opened' and 'closed' states to store if mode is inline.
       if (value === 'opened' || value === 'closed') {
-        if (this.mode === 'inline') root.store[this.id] = this.state;
+        if (this.mode === 'inline') root.store.set(this.id, this.state);
       }
     },
     get mode() {

--- a/packages/drawer/src/js/switchMode.js
+++ b/packages/drawer/src/js/switchMode.js
@@ -49,9 +49,9 @@ async function toModal(entry) {
   entry.dialog.setAttribute('aria-modal', 'true');
 
   // If there isn't a stored state but also has the opened state class...
-  if (!this.store[entry.id] && entry.el.classList.contains(entry.getSetting('stateOpened'))) {
+  if (!this.store.get(entry.id) && entry.el.classList.contains(entry.getSetting('stateOpened'))) {
     // Save the opened state in local store.
-    this.store[entry.id] = 'opened';
+    this.store.set(entry.id, 'opened');
   }
 
   // Modal drawer defaults to closed state.

--- a/packages/drawer/tests/api.test.js
+++ b/packages/drawer/tests/api.test.js
@@ -198,7 +198,7 @@ describe('register() & deregister()', () => {
   });
 
   it('should return drawer to state saved in local store', async () => {
-    drawer.store['drawer-4'] = 'opened';
+    drawer.store.set('drawer-4', 'opened');
     const entry = await drawer.register('drawer-4');
     expect(entry.mode).toBe('inline');
     expect(entry.state).toBe('opened');
@@ -219,7 +219,7 @@ describe('register() & deregister()', () => {
     const el = document.querySelector('#drawer-4');
     el.classList.add(drawer.settings.stateOpened);
 
-    drawer.store['drawer-4'] = 'closed';
+    drawer.store.set('drawer-4', 'closed');
     const entry = await drawer.register('drawer-4');
 
     expect(entry.mode).toBe('inline');

--- a/packages/drawer/tests/switchMode.test.js
+++ b/packages/drawer/tests/switchMode.test.js
@@ -47,33 +47,33 @@ test('should return local store state when switching modes', async () => {
   const entry = await drawer.register('drawer-1');
   await entry.open();
 
-  expect(drawer.store['drawer-1']).toBe('opened');
+  expect(drawer.store.get('drawer-1')).toBe('opened');
   expect(entry.mode).toBe('inline');
   expect(entry.state).toBe('opened');
 
   entry.mode = 'modal';
   await transition(entry.el);
 
-  expect(drawer.store['drawer-1']).toBe('opened');
+  expect(drawer.store.get('drawer-1')).toBe('opened');
   expect(entry.mode).toBe('modal');
   expect(entry.state).toBe('closed');
 
   await entry.open();
 
-  expect(drawer.store['drawer-1']).toBe('opened');
+  expect(drawer.store.get('drawer-1')).toBe('opened');
   expect(entry.mode).toBe('modal');
   expect(entry.state).toBe('opened');
 
   entry.mode = 'inline';
   await transition(entry.el);
 
-  expect(drawer.store['drawer-1']).toBe('opened');
+  expect(drawer.store.get('drawer-1')).toBe('opened');
   expect(entry.mode).toBe('inline');
   expect(entry.state).toBe('opened');
 
   await entry.close();
 
-  expect(drawer.store['drawer-1']).toBe('closed');
+  expect(drawer.store.get('drawer-1')).toBe('closed');
   expect(entry.mode).toBe('inline');
   expect(entry.state).toBe('closed');
 });
@@ -82,7 +82,7 @@ test('should store initial state when switching to modal', async () => {
   const entry = await drawer.register('drawer-3');
   expect(entry.mode).toBe('modal');
   expect(entry.state).toBe('closed');
-  expect(drawer.store[entry.id]).toBe('opened');
+  expect(drawer.store.get(entry.id)).toBe('opened');
 });
 
 test('should throw an error when setting mode to an invalid value', async () => {

--- a/packages/modal/src/js/close.js
+++ b/packages/modal/src/js/close.js
@@ -22,16 +22,8 @@ export async function close(query, transition, focus = true) {
     // Run the close transition.
     await closeTransition(modal.el, config);
 
-    // Remove z-index styles.
-    modal.el.style.zIndex = null;
-
-    // Get index of modal in stack array.
-    const index = this.stack.findIndex((entry) => {
-      return (entry.id === modal.id);
-    });
-
-    // Remove modal from stack array.
-    this.stack.splice(index, 1);
+    // Remove modal from stack.
+    this.stack.remove(modal);
 
     // Update focus if the focus param is true.
     if (focus) {

--- a/packages/modal/src/js/closeAll.js
+++ b/packages/modal/src/js/closeAll.js
@@ -2,7 +2,7 @@ import { close } from './close';
 
 export async function closeAll(exclude, transition) {
   const result = [];
-  await Promise.all(this.stack.map(async (modal) => {
+  await Promise.all(this.stack.value.map(async (modal) => {
     if (exclude && exclude === modal.id) {
       Promise.resolve();
     } else {

--- a/packages/modal/src/js/deregister.js
+++ b/packages/modal/src/js/deregister.js
@@ -15,15 +15,8 @@ export async function deregister(obj, close = true) {
     if (close && entry.state === 'opened') {
       await entry.close(false);
     } else {
-      // Get index of modal in stack array.
-      const stackIndex = this.stack.findIndex((item) => {
-        return (item.id === entry.id);
-      });
-
-      // Remove modal from stack array.
-      if (stackIndex >= 0) {
-        this.stack.splice(stackIndex, 1);
-      }
+      // Remove modal from stack.
+      this.stack.remove(entry);
     }
 
     // Return teleported modal if a reference has been set.

--- a/packages/modal/src/js/helpers/index.js
+++ b/packages/modal/src/js/helpers/index.js
@@ -2,4 +2,3 @@ export * from './getModal';
 export * from './getModalElements';
 export * from './getModalID';
 export * from './updateFocusState';
-export * from './updateStackIndex';

--- a/packages/modal/src/js/helpers/updateStackIndex.js
+++ b/packages/modal/src/js/helpers/updateStackIndex.js
@@ -1,7 +1,0 @@
-export function updateStackIndex(stack) {
-  stack.forEach((entry, index) => {
-    entry.el.style.zIndex = null;
-    const value = getComputedStyle(entry.el)['z-index'];
-    entry.el.style.zIndex = parseInt(value) + index + 1;
-  });
-}

--- a/packages/modal/src/js/index.js
+++ b/packages/modal/src/js/index.js
@@ -31,7 +31,7 @@ export default class Modal extends Collection {
   }
 
   get active() {
-    return this.stack.last;
+    return this.stack.top;
   }
 
   async init(options) {

--- a/packages/modal/src/js/index.js
+++ b/packages/modal/src/js/index.js
@@ -1,4 +1,4 @@
-import { Collection, FocusTrap, updateGlobalState } from '@vrembem/core/index';
+import { Collection, FocusTrap } from '@vrembem/core/index';
 
 import defaults from './defaults';
 import { handleClick, handleKeydown } from './handlers';
@@ -8,7 +8,8 @@ import { open } from './open';
 import { close } from './close';
 import { closeAll } from './closeAll';
 import { replace } from './replace';
-import { updateFocusState, updateStackIndex, getModalElements, getModalID } from './helpers';
+import { stack } from './stack';
+import { updateFocusState, getModalElements, getModalID } from './helpers';
 
 export default class Modal extends Collection {
   #handleClick;
@@ -21,18 +22,8 @@ export default class Modal extends Collection {
     this.trigger = null;
     this.focusTrap = new FocusTrap();
 
-    // Setup a proxy for stack array.
-    this.stack = new Proxy([], {
-      set: (target, property, value) => {
-        target[property] = value;
-        // Update global state if stack length changed.
-        if (property === 'length') {
-          updateGlobalState(this.active, this.settings);
-          updateStackIndex(this.stack);
-        }
-        return true;
-      }
-    });
+    // Setup stack module.
+    this.stack = stack(this.settings);
 
     this.#handleClick = handleClick.bind(this);
     this.#handleKeydown = handleKeydown.bind(this);
@@ -40,7 +31,7 @@ export default class Modal extends Collection {
   }
 
   get active() {
-    return this.stack[this.stack.length - 1];
+    return this.stack.last;
   }
 
   async init(options) {

--- a/packages/modal/src/js/open.js
+++ b/packages/modal/src/js/open.js
@@ -11,32 +11,16 @@ export async function open(query, transition, focus = true) {
   // Add transition parameter to configuration.
   if (transition !== undefined) config.transition = transition;
 
-  // Check if modal is already in the stack.
-  const index = this.stack.findIndex((entry) => {
-    return (entry.id === modal.id);
-  });
-
-  // If modal is already open.
-  if (index >= 0) {
-    // Remove modal from stack array.
-    this.stack.splice(index, 1);
-
-    // Move back to end of stack.
-    this.stack.push(modal);
-  }
+  // Maybe add modal to top of stack.
+  this.stack.maybeAdd(modal);
 
   // If modal is closed.
   if (modal.state === 'closed') {
     // Update modal state.
     modal.state = 'opening';
 
-    // Apply z-index styles based on stack length.
-    modal.el.style.zIndex = null;
-    const value = getComputedStyle(modal.el)['z-index'];
-    modal.el.style.zIndex = parseInt(value) + this.stack.length + 1;
-
-    // Store modal in stack array.
-    this.stack.push(modal);
+    // Add modal to stack.
+    this.stack.add(modal);
 
     // Run the open transition.
     await openTransition(modal.el, config);

--- a/packages/modal/src/js/open.js
+++ b/packages/modal/src/js/open.js
@@ -12,7 +12,7 @@ export async function open(query, transition, focus = true) {
   if (transition !== undefined) config.transition = transition;
 
   // Maybe add modal to top of stack.
-  this.stack.maybeAdd(modal);
+  this.stack.moveToTop(modal);
 
   // If modal is closed.
   if (modal.state === 'closed') {

--- a/packages/modal/src/js/stack.js
+++ b/packages/modal/src/js/stack.js
@@ -6,7 +6,7 @@ export function stack(settings) {
 
   return {
     get value() {
-      return stackArray;
+      return [...stackArray];
     },
 
     get last() {
@@ -21,7 +21,7 @@ export function stack(settings) {
       });
     },
 
-    update() {
+    updateGlobalState() {
       updateGlobalState(this.last, settings);
       this.updateIndex();
     },
@@ -36,11 +36,11 @@ export function stack(settings) {
       stackArray.push(entry);
 
       // Update the global state.
-      this.update();
+      this.updateGlobalState();
     },
 
     remove(entry) {
-      // Get index of modal in stack array.
+      // Get the index of the entry.
       const index = stackArray.findIndex((item) => {
         return (item.id === entry.id);
       });
@@ -54,12 +54,12 @@ export function stack(settings) {
         stackArray.splice(index, 1);
 
         // Update the global state.
-        this.update();
+        this.updateGlobalState();
       }
     },
 
     maybeAdd(entry) {
-      // Check if modal is already in the stack.
+      // Get the index of the entry.
       const index = stackArray.findIndex((item) => {
         return (item.id === entry.id);
       });

--- a/packages/modal/src/js/stack.js
+++ b/packages/modal/src/js/stack.js
@@ -1,5 +1,4 @@
 import { updateGlobalState } from '@vrembem/core/index';
-import { updateStackIndex } from './helpers';
 
 export function stack(settings) {
 
@@ -12,14 +11,27 @@ export function stack(settings) {
 
     get last() {
       return stackArray[stackArray.length - 1];
-    }
+    },
+
+    updateIndex() {
+      stackArray.forEach((entry, index) => {
+        entry.el.style.zIndex = null;
+        const value = getComputedStyle(entry.el)['z-index'];
+        entry.el.style.zIndex = parseInt(value) + index + 1;
+      });
+    },
 
     update() {
       updateGlobalState(this.last, settings);
-      updateStackIndex(stackArray);
+      this.updateIndex();
     },
 
     add(entry) {
+      // Apply z-index styles based on stack length.
+      entry.el.style.zIndex = null;
+      const value = getComputedStyle(entry.el)['z-index'];
+      entry.el.style.zIndex = parseInt(value) + stackArray.length + 1;
+
       // Move back to end of stack.
       stackArray.push(entry);
 
@@ -35,6 +47,9 @@ export function stack(settings) {
 
       // If entry is in stack...
       if (index >= 0) {
+        // Remove z-index styles.
+        entry.el.style.zIndex = null;
+
         // Remove entry from stack array.
         stackArray.splice(index, 1);
 
@@ -58,5 +73,5 @@ export function stack(settings) {
         this.add(entry);
       }
     }
-  }
+  };
 }

--- a/packages/modal/src/js/stack.js
+++ b/packages/modal/src/js/stack.js
@@ -9,7 +9,7 @@ export function stack(settings) {
       return [...stackArray];
     },
 
-    get last() {
+    get top() {
       return stackArray[stackArray.length - 1];
     },
 
@@ -22,7 +22,7 @@ export function stack(settings) {
     },
 
     updateGlobalState() {
-      updateGlobalState(this.last, settings);
+      updateGlobalState(this.top, settings);
       this.updateIndex();
     },
 
@@ -58,7 +58,7 @@ export function stack(settings) {
       }
     },
 
-    maybeAdd(entry) {
+    moveToTop(entry) {
       // Get the index of the entry.
       const index = stackArray.findIndex((item) => {
         return (item.id === entry.id);

--- a/packages/modal/src/js/stack.js
+++ b/packages/modal/src/js/stack.js
@@ -1,0 +1,62 @@
+import { updateGlobalState } from '@vrembem/core/index';
+import { updateStackIndex } from './helpers';
+
+export function stack(settings) {
+
+  const stackArray = [];
+
+  return {
+    get value() {
+      return stackArray;
+    },
+
+    get last() {
+      return stackArray[stackArray.length - 1];
+    }
+
+    update() {
+      updateGlobalState(this.last, settings);
+      updateStackIndex(stackArray);
+    },
+
+    add(entry) {
+      // Move back to end of stack.
+      stackArray.push(entry);
+
+      // Update the global state.
+      this.update();
+    },
+
+    remove(entry) {
+      // Get index of modal in stack array.
+      const index = stackArray.findIndex((item) => {
+        return (item.id === entry.id);
+      });
+
+      // If entry is in stack...
+      if (index >= 0) {
+        // Remove entry from stack array.
+        stackArray.splice(index, 1);
+
+        // Update the global state.
+        this.update();
+      }
+    },
+
+    maybeAdd(entry) {
+      // Check if modal is already in the stack.
+      const index = stackArray.findIndex((item) => {
+        return (item.id === entry.id);
+      });
+
+      // If entry is in stack...
+      if (index >= 0) {
+        // Remove entry from stack array.
+        stackArray.splice(index, 1);
+
+        // Add entry back to top of stack.
+        this.add(entry);
+      }
+    }
+  }
+}

--- a/packages/modal/tests/api.test.js
+++ b/packages/modal/tests/api.test.js
@@ -333,7 +333,7 @@ describe('replace()', () => {
       await transition(entry.el);
     }));
 
-    expect(modal.stack.length).toBe(3);
+    expect(modal.stack.value.length).toBe(3);
     expect(modal.get('modal-1').state).toBe('opened');
     expect(modal.get('modal-2').state).toBe('opened');
     expect(modal.get('modal-3').state).toBe('opened');
@@ -344,7 +344,7 @@ describe('replace()', () => {
       await transition(entry.el);
     }));
 
-    expect(modal.stack.length).toBe(1);
+    expect(modal.stack.value.length).toBe(1);
     expect(modal.get('modal-1').state).toBe('closed');
     expect(modal.get('modal-2').state).toBe('opened');
     expect(modal.get('modal-3').state).toBe('closed');

--- a/packages/modal/tests/helpers.test.js
+++ b/packages/modal/tests/helpers.test.js
@@ -1,5 +1,5 @@
 import './mocks/getComputedStyle.mock';
-import { updateStackIndex, getModalID, getModalElements } from '../src/js/helpers';
+import { getModalID, getModalElements } from '../src/js/helpers';
 
 document.body.innerHTML = `
   <button data-modal-open="modal-1">...</button>
@@ -32,22 +32,6 @@ const mockObj = {
     selectorDialog: '.modal__dialog'
   }
 };
-
-describe('updateStackIndex()', () => {
-  it('should update the z-index of a modal array', () => {
-    const array = document.querySelectorAll('.modal');
-    const collectionMock = [];
-    for (let i = 0; i < array.length; i++) {
-      collectionMock.push({ el: array[i] });
-    }
-
-    updateStackIndex(collectionMock);
-
-    expect(collectionMock[0].el.style.zIndex).toBe('1001');
-    expect(collectionMock[1].el.style.zIndex).toBe('1002');
-    expect(collectionMock[2].el.style.zIndex).toBe('1003');
-  });
-});
 
 describe('getModalID()', () => {
   it('should return the string if a string is passed', () => {

--- a/packages/modal/tests/stack.test.js
+++ b/packages/modal/tests/stack.test.js
@@ -42,7 +42,7 @@ beforeAll(async () => {
 
 test('should allow opening multiple modals at once', async () => {
   expect(modal.collection.length).toBe(3);
-  expect(modal.stack.length).toBe(0);
+  expect(modal.stack.value.length).toBe(0);
 
   btn1.click();
   await delay();
@@ -51,7 +51,7 @@ test('should allow opening multiple modals at once', async () => {
   btn3.click();
   await delay();
 
-  expect(modal.stack.length).toBe(3);
+  expect(modal.stack.value.length).toBe(3);
   expect(modal1.state).toBe('opened');
   expect(modal2.state).toBe('opened');
   expect(modal3.state).toBe('opened');
@@ -91,9 +91,9 @@ test('should close the currently opened modal at the top of the stack', async ()
 });
 
 test('should update the stack array and z-index of remaining active modals', () => {
-  expect(modal.stack.length).toBe(2);
-  expect(modal.stack[0]).toBe(modal1);
-  expect(modal.stack[1]).toBe(modal3);
+  expect(modal.stack.value.length).toBe(2);
+  expect(modal.stack.value[0]).toBe(modal1);
+  expect(modal.stack.value[1]).toBe(modal3);
 
   expect(modal1.el.style.zIndex).toBe('1001');
   expect(modal2.el.style.zIndex).toBe('');
@@ -109,8 +109,8 @@ test('should close the currently opened modal and update stack array and z-index
   expect(modal3.state).toBe('closed');
   expect(document.activeElement).toBe(modal1.dialog);
 
-  expect(modal.stack.length).toBe(1);
-  expect(modal.stack[0]).toBe(modal1);
+  expect(modal.stack.value.length).toBe(1);
+  expect(modal.stack.value[0]).toBe(modal1);
 
   expect(modal1.el.style.zIndex).toBe('1001');
   expect(modal2.el.style.zIndex).toBe('');
@@ -126,7 +126,7 @@ test('should focus root trigger when the last modal in stack is closed', async (
   expect(modal1.state).toBe('closed');
   expect(document.activeElement).toBe(btn1);
 
-  expect(modal.stack.length).toBe(0);
+  expect(modal.stack.value.length).toBe(0);
 });
 
 test('should close all open modals when close button with value of * is set', async () => {
@@ -137,7 +137,7 @@ test('should close all open modals when close button with value of * is set', as
   btn3.click();
   await delay();
 
-  expect(modal.stack.length).toBe(3);
+  expect(modal.stack.value.length).toBe(3);
   expect(modal1.state).toBe('opened');
   expect(modal2.state).toBe('opened');
   expect(modal3.state).toBe('opened');
@@ -145,7 +145,7 @@ test('should close all open modals when close button with value of * is set', as
   btnCloseAll.click();
   await delay();
 
-  expect(modal.stack.length).toBe(0);
+  expect(modal.stack.value.length).toBe(0);
   expect(modal1.state).toBe('closed');
   expect(modal2.state).toBe('closed');
   expect(modal3.state).toBe('closed');
@@ -157,14 +157,14 @@ test('should properly replace all modal modals with the trigger modal', async ()
   btn2.click();
   await delay();
 
-  expect(modal.stack.length).toBe(2);
+  expect(modal.stack.value.length).toBe(2);
   expect(modal1.state).toBe('opened');
   expect(modal2.state).toBe('opened');
   expect(modal3.state).toBe('closed');
 
   await modal.replace('modal-3');
 
-  expect(modal.stack.length).toBe(1);
+  expect(modal.stack.value.length).toBe(1);
   expect(modal1.state).toBe('closed');
   expect(modal2.state).toBe('closed');
   expect(modal3.state).toBe('opened');


### PR DESCRIPTION
## What changed?

Modal stacking and local store features are written to take advantage of the Proxy object API. This became an issue since Proxy is not supported in IE11 and the [polyfill has some major limitations](https://github.com/GoogleChrome/proxy-polyfill). This PR refactors stack and local store features into modules with their own APIs for handling a private array and object internally. 

### `localStore`

Used to maintain a JSON object in local storage. This is a `@vrembem/core` module used by the drawer component to maintain persistent drawer states via local storage. `localStore` takes a string key name parameter used to save the object in local storage. Once instantiated, the following API is returned:

- `set(prop, value)` - Sets a prop/value pair to the stored object. Omitting a `value` parameter will delete the property. This method triggers the local storage update.
- `get(key)` - Returns the value of a property on the stored object. Omitting `key` will return the entire stored object.

**Usage**

```js
import { localStore } from '@vrembem/core';

const store = localStore('key');

store.set('foo', 'bar');

console.log(store.get('foo'));
// => String 'bar'

console.log(store.get());
// => Object { 'foo': 'bar' }
```

### `stack`

The stack module is stored as a property of the instantiated modal object. This can be accessed under the `.stack` property and makes available the following API:

- `value` - Returns the current stack array. This is a returned copy and not a reference to prevent the array from being modified directly.
- `top` - Returns the entry at top of stack (the currently active modal). This is also aliased to `modal.active`.
- `updateIndex()` - Updated the z-index styles for all entries in the array based on their current sort.
- `updateGlobalState()` - Updates the global state based on whether or not there is an active modal. Will also update the z-index of entries.
- `add(entry)` - Adds an entry to the top of the stack array.
- `remove(entry)` - Removes an entry from the stack array.
- `moveToTop(entry)` - Will move an entry to the top of the stack if it's already in the stack array.

The stack module is used internally whenever a modal is opened, closed or deregistered but the API is also available under the `stack ` property of the instantiated modal object.

**Usage**

```js
import Modal from '@vrembem/modal';

modal = new Modal();

console.log(modal.stack);
// => Object {add: ƒ, remove: ƒ, maybeAdd: ƒ, …}
```
