### PR TITLE
Refactor modal screen styles and how they are applied

### DIFF
--- a/packages/card/src/_variables.scss
+++ b/packages/card/src/_variables.scss
@@ -21,8 +21,8 @@ $title-font-size: core.$font-size-lg !default;
 $title-line-height: core.$line-height-lg !default;
 $title-font-weight: core.$font-weight-semi-bold !default;
 
-$screen-opacity: 0.7 !default;
 $screen-background: palette.get("neutral", 10) !default;
+$screen-opacity: 0.7 !default;
 
 $link-shadow: core.$shadow-2 !default;
 $link-shadow-hover: core.$shadow-3 !default;

--- a/packages/modal/src/scss/_modal.scss
+++ b/packages/modal/src/scss/_modal.scss
@@ -72,26 +72,26 @@ $_e: var.$prefix-element;
 
 .#{$_b}modal.is-opening,
 .#{$_b}modal.is-closing {
+  &::before {
+    transition: opacity var.$transition-duration var.$transition-timing-function;
+  }
+
   .#{$_b}modal#{$_e}dialog {
     transition-property: opacity, transform;
     transition-duration: var.$transition-duration;
     transition-timing-function: var.$transition-timing-function;
   }
-
-  &::before {
-    transition: opacity var.$transition-duration var.$transition-timing-function;
-  }
 }
 
 .#{$_b}modal.is-opening,
 .#{$_b}modal.is-opened {
+  &::before {
+    opacity: var.$screen-opacity;
+  }
+
   .#{$_b}modal#{$_e}dialog {
     transform: translateY(0);
     opacity: 1;
-  }
-
-  &::before {
-    opacity: var.$screen-opacity;
   }
 }
 

--- a/packages/modal/src/scss/_modal.scss
+++ b/packages/modal/src/scss/_modal.scss
@@ -17,7 +17,19 @@ $_e: var.$prefix-element;
   width: 0;
   height: 0;
   overflow: hidden;
-  background-color: hsl(#{var.$background}, 0);
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: var.$screen-background;
+    opacity: 0;
+  }
 }
 
 .#{$_b}modal#{$_e}dialog {
@@ -60,22 +72,26 @@ $_e: var.$prefix-element;
 
 .#{$_b}modal.is-opening,
 .#{$_b}modal.is-closing {
-  transition: background-color var.$transition-duration var.$transition-timing-function;
-
   .#{$_b}modal#{$_e}dialog {
     transition-property: opacity, transform;
     transition-duration: var.$transition-duration;
     transition-timing-function: var.$transition-timing-function;
   }
+
+  &::before {
+    transition: opacity var.$transition-duration var.$transition-timing-function;
+  }
 }
 
 .#{$_b}modal.is-opening,
 .#{$_b}modal.is-opened {
-  background-color: hsl(#{var.$background}, #{var.$background-alpha});
-
   .#{$_b}modal#{$_e}dialog {
     transform: translateY(0);
     opacity: 1;
+  }
+
+  &::before {
+    opacity: var.$screen-opacity;
   }
 }
 

--- a/packages/modal/src/scss/_modal.scss
+++ b/packages/modal/src/scss/_modal.scss
@@ -17,7 +17,7 @@ $_e: var.$prefix-element;
   width: 0;
   height: 0;
   overflow: hidden;
-  background-color: var.$background;
+  background-color: hsl(#{var.$background}, 0);
 }
 
 .#{$_b}modal#{$_e}dialog {
@@ -71,7 +71,7 @@ $_e: var.$prefix-element;
 
 .#{$_b}modal.is-opening,
 .#{$_b}modal.is-opened {
-  background-color: var.$background;
+  background-color: hsl(#{var.$background}, #{var.$background-alpha});
 
   .#{$_b}modal#{$_e}dialog {
     transform: translateY(0);

--- a/packages/modal/src/scss/_modal.scss
+++ b/packages/modal/src/scss/_modal.scss
@@ -17,7 +17,7 @@ $_e: var.$prefix-element;
   width: 0;
   height: 0;
   overflow: hidden;
-  background-color: rgba(var.$background, 0);
+  background-color: var.$background;
 }
 
 .#{$_b}modal#{$_e}dialog {
@@ -71,7 +71,7 @@ $_e: var.$prefix-element;
 
 .#{$_b}modal.is-opening,
 .#{$_b}modal.is-opened {
-  background-color: rgba(var.$background, var.$background-alpha);
+  background-color: var.$background;
 
   .#{$_b}modal#{$_e}dialog {
     transform: translateY(0);

--- a/packages/modal/src/scss/_variables.scss
+++ b/packages/modal/src/scss/_variables.scss
@@ -11,9 +11,10 @@ $width: 36em !default;
 $travel: 5em !default;
 $transition-duration: core.$transition-duration !default;
 $transition-timing-function: core.$transition-timing-function !default;
-$background: palette.get("neutral", "var"), 10% !default;
-$background-alpha: 0.8 !default;
 $shadow: core.$shadow-5 !default;
+
+$screen-background: palette.get("neutral", 10) !default;
+$screen-opacity: 0.8 !default;
 
 $outline: 0 solid transparent !default;
 $outline-focus: 4px solid palette.get("primary") !default;

--- a/packages/modal/src/scss/_variables.scss
+++ b/packages/modal/src/scss/_variables.scss
@@ -11,7 +11,7 @@ $width: 36em !default;
 $travel: 5em !default;
 $transition-duration: core.$transition-duration !default;
 $transition-timing-function: core.$transition-timing-function !default;
-$background: palette.get("neutral", 10) !default;
+$background: palette.get("neutral", "var"), 10% !default;
 $background-alpha: 0.8 !default;
 $shadow: core.$shadow-5 !default;
 

--- a/packages/section/src/_variables.scss
+++ b/packages/section/src/_variables.scss
@@ -7,8 +7,8 @@ $prefix-modifier: core.$prefix-modifier !default;
 $prefix-modifier-value: core.$prefix-modifier-value !default;
 
 $max-width: 70rem !default;
-$screen-opacity: 0.7 !default;
 $screen-background: palette.get("neutral", 10) !default;
+$screen-opacity: 0.7 !default;
 
 $padding: (
   "base": 1.5em,


### PR DESCRIPTION
## Problem

The current implementation of modal screens requires an RGB color along with a separate alpha variable that sets the appropriate styles on the root modal element. This breaks once we switched to the new palette system that uses CSS variables and HSL color values.

## Solution

This PR refactors the modal screen styles to instead be applied to a pseudo element allowing us to set any color property for the background and controlling the transparency of the background using the separate `opacity` property. This PR also renames the related variables to prefix `screen-` for clarity and consistency.