### PR TITLE
Fix core Sass module order and move root manifest

### DIFF
--- a/packages/core/index.scss
+++ b/packages/core/index.scss
@@ -1,6 +1,6 @@
-@forward "./src/scss/functions";
 @forward "./src/scss/prefix";
 @forward "./src/scss/palette";
 @forward "./src/scss/theme";
 @forward "./src/scss/variables";
+@forward "./src/scss/functions";
 @forward "./src/scss/mixins";

--- a/packages/core/root.scss
+++ b/packages/core/root.scss
@@ -1,0 +1,2 @@
+@forward "./src/scss/root/prefix";
+@forward "./src/scss/root/breakpoints";

--- a/packages/core/src/scss/root/root.scss
+++ b/packages/core/src/scss/root/root.scss
@@ -1,2 +1,0 @@
-@use "./prefix";
-@use "./breakpoints";

--- a/packages/vrembem/index.scss
+++ b/packages/vrembem/index.scss
@@ -1,6 +1,3 @@
-@use "@vrembem/core/src/scss/root/prefix";
-@use "@vrembem/core/src/scss/root/breakpoints";
-
 @forward "@vrembem/core" as core-*;
 @forward "@vrembem/base" as base-*;
 @forward "@vrembem/breadcrumb" as breadcrumb-*;
@@ -25,3 +22,5 @@
 @forward "@vrembem/switch" as switch-*;
 @forward "@vrembem/table" as table-*;
 @forward "@vrembem/utility" as utility-*;
+
+@use "@vrembem/core/root";


### PR DESCRIPTION
## Problem

Because of `@vrembem/core` Sass module order, we get a Sass error when trying to set custom values using `with`.

## Solution

This PR fixes core Sass module `forward` order and moves the root manifest file to the root of core.