### PR TITLE
Remove touch events from modal and drawer click handling

### DIFF
--- a/packages/drawer/src/js/index.js
+++ b/packages/drawer/src/js/index.js
@@ -65,13 +65,11 @@ export default class Drawer extends Collection {
 
   initEventListeners() {
     document.addEventListener('click', this.#handleClick, false);
-    document.addEventListener('touchend', this.#handleClick, false);
     document.addEventListener('keydown', this.#handleKeydown, false);
   }
 
   destroyEventListeners() {
     document.removeEventListener('click', this.#handleClick, false);
-    document.removeEventListener('touchend', this.#handleClick, false);
     document.removeEventListener('keydown', this.#handleKeydown, false);
   }
 

--- a/packages/modal/src/js/index.js
+++ b/packages/modal/src/js/index.js
@@ -69,13 +69,11 @@ export default class Modal extends Collection {
 
   initEventListeners() {
     document.addEventListener('click', this.#handleClick, false);
-    document.addEventListener('touchend', this.#handleClick, false);
     document.addEventListener('keydown', this.#handleKeydown, false);
   }
 
   destroyEventListeners() {
     document.removeEventListener('click', this.#handleClick, false);
-    document.removeEventListener('touchend', this.#handleClick, false);
     document.removeEventListener('keydown', this.#handleKeydown, false);
   }
 


### PR DESCRIPTION
## Problem

The `touchend` events were triggering some undesired behavior when scrolling a page on mobile.

## Solution

This PR removes the `touchend` events from triggering the click handlers.