### PR TITLE
Add export maps for SCSS files

### DIFF
--- a/.changeset/pretty-spiders-remember.md
+++ b/.changeset/pretty-spiders-remember.md
@@ -1,0 +1,27 @@
+---
+"@vrembem/icon-action": patch
+"@vrembem/checkbox": patch
+"@vrembem/popover": patch
+"@vrembem/section": patch
+"@vrembem/utility": patch
+"vrembem": patch
+"@vrembem/button": patch
+"@vrembem/dialog": patch
+"@vrembem/drawer": patch
+"@vrembem/notice": patch
+"@vrembem/switch": patch
+"@vrembem/input": patch
+"@vrembem/level": patch
+"@vrembem/media": patch
+"@vrembem/modal": patch
+"@vrembem/radio": patch
+"@vrembem/table": patch
+"@vrembem/base": patch
+"@vrembem/card": patch
+"@vrembem/core": patch
+"@vrembem/grid": patch
+"@vrembem/icon": patch
+"@vrembem/menu": patch
+---
+
+Added exports map for SCSS files. These are used when importing SCSS files within the context of JavaScript.

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -9,6 +9,14 @@
     "component",
     "base"
   ],
+  "exports": {
+    ".": "./index.scss",
+    "./css": "./dist/index.css",
+    "./scss": "./index.scss",
+    "./dev": "./dev/index.css",
+    "./dist": "./dist/index.css",
+    "./*": "./src/*"
+  },
   "sass": "index.scss",
   "style": "dist/index.css",
   "scripts": {

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -9,6 +9,14 @@
     "component",
     "button"
   ],
+  "exports": {
+    ".": "./index.scss",
+    "./css": "./dist/index.css",
+    "./scss": "./index.scss",
+    "./dev": "./dev/index.css",
+    "./dist": "./dist/index.css",
+    "./*": "./src/*"
+  },
   "sass": "index.scss",
   "style": "dist/index.css",
   "scripts": {

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -9,6 +9,14 @@
     "component",
     "card"
   ],
+  "exports": {
+    ".": "./index.scss",
+    "./css": "./dist/index.css",
+    "./scss": "./index.scss",
+    "./dev": "./dev/index.css",
+    "./dist": "./dist/index.css",
+    "./*": "./src/*"
+  },
   "sass": "index.scss",
   "style": "dist/index.css",
   "scripts": {

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -15,7 +15,12 @@
     ".": {
       "import": "./dist/index.js",
       "require": "./dist/index.umd.cjs"
-    }
+    },
+    "./css": "./dist/index.css",
+    "./scss": "./index.scss",
+    "./dev": "./dev/index.css",
+    "./dist": "./dist/index.css",
+    "./*": "./src/scss/*"
   },
   "unpkg": "dist/index.umd.cjs",
   "sass": "index.scss",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,17 @@
     ".": {
       "import": "./dist/index.js",
       "require": "./dist/index.umd.cjs"
-    }
+    },
+    "./css": "./dist/index.css",
+    "./scss": "./index.scss",
+    "./dev": "./dev/index.css",
+    "./dist": "./dist/index.css",
+    "./*": "./src/scss/*",
+    "./root": "./root.scss",
+    "./palette": "./palette.scss",
+    "./theme": "./theme.scss",
+    "./root/*": "./src/scss/root/*",
+    "./src/scss/root/*": "./src/scss/root/*"
   },
   "unpkg": "dist/index.umd.cjs",
   "sass": "index.scss",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -9,6 +9,14 @@
     "component",
     "dialog"
   ],
+  "exports": {
+    ".": "./index.scss",
+    "./css": "./dist/index.css",
+    "./scss": "./index.scss",
+    "./dev": "./dev/index.css",
+    "./dist": "./dist/index.css",
+    "./*": "./src/*"
+  },
   "sass": "index.scss",
   "style": "dist/index.css",
   "scripts": {

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -15,7 +15,12 @@
     ".": {
       "import": "./dist/index.js",
       "require": "./dist/index.umd.cjs"
-    }
+    },
+    "./css": "./dist/index.css",
+    "./scss": "./index.scss",
+    "./dev": "./dev/index.css",
+    "./dist": "./dist/index.css",
+    "./*": "./src/scss/*"
   },
   "unpkg": "dist/index.umd.cjs",
   "sass": "index.scss",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -9,6 +9,14 @@
     "component",
     "grid"
   ],
+  "exports": {
+    ".": "./index.scss",
+    "./css": "./dist/index.css",
+    "./scss": "./index.scss",
+    "./dev": "./dev/index.css",
+    "./dist": "./dist/index.css",
+    "./*": "./src/*"
+  },
   "sass": "index.scss",
   "style": "dist/index.css",
   "scripts": {

--- a/packages/icon-action/package.json
+++ b/packages/icon-action/package.json
@@ -9,6 +9,14 @@
     "component",
     "icon-action"
   ],
+  "exports": {
+    ".": "./index.scss",
+    "./css": "./dist/index.css",
+    "./scss": "./index.scss",
+    "./dev": "./dev/index.css",
+    "./dist": "./dist/index.css",
+    "./*": "./src/*"
+  },
   "sass": "index.scss",
   "style": "dist/index.css",
   "scripts": {

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -9,6 +9,14 @@
     "component",
     "icon"
   ],
+  "exports": {
+    ".": "./index.scss",
+    "./css": "./dist/index.css",
+    "./scss": "./index.scss",
+    "./dev": "./dev/index.css",
+    "./dist": "./dist/index.css",
+    "./*": "./src/*"
+  },
   "sass": "index.scss",
   "style": "dist/index.css",
   "scripts": {

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -9,6 +9,14 @@
     "component",
     "input"
   ],
+  "exports": {
+    ".": "./index.scss",
+    "./css": "./dist/index.css",
+    "./scss": "./index.scss",
+    "./dev": "./dev/index.css",
+    "./dist": "./dist/index.css",
+    "./*": "./src/*"
+  },
   "sass": "index.scss",
   "style": "dist/index.css",
   "scripts": {

--- a/packages/level/package.json
+++ b/packages/level/package.json
@@ -9,6 +9,14 @@
     "component",
     "level"
   ],
+  "exports": {
+    ".": "./index.scss",
+    "./css": "./dist/index.css",
+    "./scss": "./index.scss",
+    "./dev": "./dev/index.css",
+    "./dist": "./dist/index.css",
+    "./*": "./src/*"
+  },
   "sass": "index.scss",
   "style": "dist/index.css",
   "scripts": {

--- a/packages/media/package.json
+++ b/packages/media/package.json
@@ -9,6 +9,14 @@
     "component",
     "media"
   ],
+  "exports": {
+    ".": "./index.scss",
+    "./css": "./dist/index.css",
+    "./scss": "./index.scss",
+    "./dev": "./dev/index.css",
+    "./dist": "./dist/index.css",
+    "./*": "./src/*"
+  },
   "sass": "index.scss",
   "style": "dist/index.css",
   "scripts": {

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -9,6 +9,14 @@
     "component",
     "menu"
   ],
+  "exports": {
+    ".": "./index.scss",
+    "./css": "./dist/index.css",
+    "./scss": "./index.scss",
+    "./dev": "./dev/index.css",
+    "./dist": "./dist/index.css",
+    "./*": "./src/*"
+  },
   "sass": "index.scss",
   "style": "dist/index.css",
   "scripts": {

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -15,7 +15,12 @@
     ".": {
       "import": "./dist/index.js",
       "require": "./dist/index.umd.cjs"
-    }
+    },
+    "./css": "./dist/index.css",
+    "./scss": "./index.scss",
+    "./dev": "./dev/index.css",
+    "./dist": "./dist/index.css",
+    "./*": "./src/scss/*"
   },
   "unpkg": "dist/index.umd.cjs",
   "sass": "index.scss",

--- a/packages/notice/package.json
+++ b/packages/notice/package.json
@@ -9,6 +9,14 @@
     "component",
     "notice"
   ],
+  "exports": {
+    ".": "./index.scss",
+    "./css": "./dist/index.css",
+    "./scss": "./index.scss",
+    "./dev": "./dev/index.css",
+    "./dist": "./dist/index.css",
+    "./*": "./src/*"
+  },
   "sass": "index.scss",
   "style": "dist/index.css",
   "scripts": {

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -15,7 +15,12 @@
     ".": {
       "import": "./dist/index.js",
       "require": "./dist/index.umd.cjs"
-    }
+    },
+    "./css": "./dist/index.css",
+    "./scss": "./index.scss",
+    "./dev": "./dev/index.css",
+    "./dist": "./dist/index.css",
+    "./*": "./src/scss/*"
   },
   "unpkg": "dist/index.umd.cjs",
   "sass": "index.scss",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -9,6 +9,14 @@
     "component",
     "radio"
   ],
+  "exports": {
+    ".": "./index.scss",
+    "./css": "./dist/index.css",
+    "./scss": "./index.scss",
+    "./dev": "./dev/index.css",
+    "./dist": "./dist/index.css",
+    "./*": "./src/*"
+  },
   "sass": "index.scss",
   "style": "dist/index.css",
   "scripts": {

--- a/packages/section/package.json
+++ b/packages/section/package.json
@@ -9,6 +9,14 @@
     "component",
     "section"
   ],
+  "exports": {
+    ".": "./index.scss",
+    "./css": "./dist/index.css",
+    "./scss": "./index.scss",
+    "./dev": "./dev/index.css",
+    "./dist": "./dist/index.css",
+    "./*": "./src/*"
+  },
   "sass": "index.scss",
   "style": "dist/index.css",
   "scripts": {

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -9,6 +9,14 @@
     "component",
     "switch"
   ],
+  "exports": {
+    ".": "./index.scss",
+    "./css": "./dist/index.css",
+    "./scss": "./index.scss",
+    "./dev": "./dev/index.css",
+    "./dist": "./dist/index.css",
+    "./*": "./src/*"
+  },
   "sass": "index.scss",
   "style": "dist/index.css",
   "scripts": {

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -9,6 +9,14 @@
     "component",
     "table"
   ],
+  "exports": {
+    ".": "./index.scss",
+    "./css": "./dist/index.css",
+    "./scss": "./index.scss",
+    "./dev": "./dev/index.css",
+    "./dist": "./dist/index.css",
+    "./*": "./src/*"
+  },
   "sass": "index.scss",
   "style": "dist/index.css",
   "scripts": {

--- a/packages/utility/package.json
+++ b/packages/utility/package.json
@@ -9,6 +9,14 @@
     "component",
     "utility"
   ],
+  "exports": {
+    ".": "./index.scss",
+    "./css": "./dist/index.css",
+    "./scss": "./index.scss",
+    "./dev": "./dev/index.css",
+    "./dist": "./dist/index.css",
+    "./*": "./src/*"
+  },
   "sass": "index.scss",
   "style": "dist/index.css",
   "scripts": {

--- a/packages/vrembem/package.json
+++ b/packages/vrembem/package.json
@@ -15,7 +15,11 @@
     ".": {
       "import": "./dist/index.js",
       "require": "./dist/index.umd.cjs"
-    }
+    },
+    "./css": "./dist/index.css",
+    "./scss": "./index.scss",
+    "./dev": "./dev/index.css",
+    "./dist": "./dist/index.css"
   },
   "unpkg": "dist/index.umd.cjs",
   "sass": "index.scss",


### PR DESCRIPTION
## What changed?

Added exports map for SCSS files. These are used when importing SCSS files within the context of JavaScript.
