### PR TITLE
Fix transition bug when child elements transition event bubbles

### DIFF
--- a/.changeset/brown-foxes-drum.md
+++ b/.changeset/brown-foxes-drum.md
@@ -1,0 +1,5 @@
+---
+"@vrembem/core": patch
+---
+
+Fix transition bug when child elements transition event bubbles

--- a/packages/core/src/js/transition.js
+++ b/packages/core/src/js/transition.js
@@ -3,7 +3,9 @@ export const openTransition = (el, settings) => {
     if (settings.transition) {
       el.classList.remove(settings.stateClosed);
       el.classList.add(settings.stateOpening);
-      el.addEventListener('transitionend', function _f() {
+      el.addEventListener('transitionend', function _f(event) {
+        // Prevent child transition bubbling from firing this event
+        if (event.target != el) return;
         el.classList.add(settings.stateOpened);
         el.classList.remove(settings.stateOpening);
         resolve(el);
@@ -22,7 +24,10 @@ export const closeTransition = (el, settings) => {
     if (settings.transition) {
       el.classList.add(settings.stateClosing);
       el.classList.remove(settings.stateOpened);
-      el.addEventListener('transitionend', function _f() {
+      el.addEventListener('transitionend', function _f(event) {
+        // Prevent child transition bubbling from firing this event
+        if (event.target != el) return;
+        console.log('transitionend', event.target);
         el.classList.remove(settings.stateClosing);
         el.classList.add(settings.stateClosed);
         resolve(el);

--- a/packages/core/src/js/transition.js
+++ b/packages/core/src/js/transition.js
@@ -1,17 +1,26 @@
 export const openTransition = (el, settings) => {
   return new Promise((resolve) => {
+    // Check if transitions are enabled.
     if (settings.transition) {
+      // Toggle classes for opening transition.
       el.classList.remove(settings.stateClosed);
       el.classList.add(settings.stateOpening);
+
+      // Add event listener for when the transition is finished.
       el.addEventListener('transitionend', function _f(event) {
-        // Prevent child transition bubbling from firing this event
+        // Prevent child transition bubbling from firing this event.
         if (event.target != el) return;
+
+        // Toggle final opened state classes.
         el.classList.add(settings.stateOpened);
         el.classList.remove(settings.stateOpening);
+
+        // Resolve the promise and remove the event listener.
         resolve(el);
         this.removeEventListener('transitionend', _f);
       });
     } else {
+      // Toggle final opened state classes and resolve the promise.
       el.classList.add(settings.stateOpened);
       el.classList.remove(settings.stateClosed);
       resolve(el);
@@ -21,19 +30,27 @@ export const openTransition = (el, settings) => {
 
 export const closeTransition = (el, settings) => {
   return new Promise((resolve) => {
+    // Check if transitions are enabled.
     if (settings.transition) {
+      // Toggle classes for closing transition.
       el.classList.add(settings.stateClosing);
       el.classList.remove(settings.stateOpened);
+
+      // Add event listener for when the transition is finished.
       el.addEventListener('transitionend', function _f(event) {
-        // Prevent child transition bubbling from firing this event
+        // Prevent child transition bubbling from firing this event.
         if (event.target != el) return;
-        console.log('transitionend', event.target);
+        
+        // Toggle final closed state classes.
         el.classList.remove(settings.stateClosing);
         el.classList.add(settings.stateClosed);
+
+        // Resolve the promise and remove the event listener.
         resolve(el);
         this.removeEventListener('transitionend', _f);
       });
     } else {
+      // Toggle final closed state classes and resolve the promise.
       el.classList.add(settings.stateClosed);
       el.classList.remove(settings.stateOpened);
       resolve(el);

--- a/packages/core/tests/transition.test.js
+++ b/packages/core/tests/transition.test.js
@@ -2,10 +2,13 @@ import { openTransition, closeTransition } from '../index';
 import '@testing-library/jest-dom/extend-expect';
 
 document.body.innerHTML = `
-  <div class="el"></div>
+  <div class="el">
+    <button>...</button>
+  </div>
 `;
 
-const el = document.querySelector('.el');
+const el = document.querySelector('div');
+const btn = document.querySelector('button');
 const classes = {
   stateOpened: 'is-opened',
   stateOpening: 'is-opening',
@@ -66,4 +69,32 @@ test('should return a promise when closeTransition is called', () => {
     expect(el).toHaveClass('is-closed');
     expect(el.classList.length).toBe(2);
   });
+});
+
+test('should not run opening transition if the transitionend event fired from a child element', () => {
+  const item = openTransition(el, classes);
+  expect(el).toHaveClass('is-opening');
+  expect(el.classList.length).toBe(2);
+
+  btn.dispatchEvent(new Event('transitionend', { bubbles: true }));
+  expect(el).toHaveClass('is-opening');
+  expect(el.classList.length).toBe(2);
+
+  el.dispatchEvent(new Event('transitionend'));
+  expect(el).toHaveClass('is-opened');
+  expect(el.classList.length).toBe(2);
+});
+
+test('should not closing transition if the transitionend event fired from a child element', () => {
+  const item = closeTransition(el, classes);
+  expect(el).toHaveClass('is-closing');
+  expect(el.classList.length).toBe(2);
+
+  btn.dispatchEvent(new Event('transitionend', { bubbles: true }));
+  expect(el).toHaveClass('is-closing');
+  expect(el.classList.length).toBe(2);
+
+  el.dispatchEvent(new Event('transitionend'));
+  expect(el).toHaveClass('is-closed');
+  expect(el.classList.length).toBe(2);
 });


### PR DESCRIPTION
## What changed?

There is a bug with the transition module that caused it to fire too early if there was an element inside the modal that was transitioning and finished before the modal. This caused the event to bubble down to the parent modal and trigger the close transition event. This was typically caused by a button with a hover/focus transition.

This PR fixes this bug by adding a guard clause in the event listener that checks if the correct element triggered the `transitionend` event.