### PR TITLE
Fix drawer transition styles

### DIFF
--- a/packages/drawer/index.scss
+++ b/packages/drawer/index.scss
@@ -1,4 +1,4 @@
 @forward "./src/scss/variables";
 @forward "./src/scss/drawer";
-@forward "./src/scss/drawer_modal";
 @forward "./src/scss/drawer_switch";
+@forward "./src/scss/drawer_modal";

--- a/packages/drawer/src/scss/_drawer.scss
+++ b/packages/drawer/src/scss/_drawer.scss
@@ -84,6 +84,10 @@ $_e: var.$prefix-element;
 
 .#{$_b}drawer.is-opening,
 .#{$_b}drawer.is-closing {
+  transition-property: background-color, opacity, transform;
+  transition-duration: var.$transition-duration;
+  transition-timing-function: var.$transition-timing-function;
+
   .#{$_b}drawer#{$_e}dialog {
     transition-property: opacity, transform;
     transition-duration: var.$transition-duration;

--- a/packages/drawer/src/scss/_drawer_modal.scss
+++ b/packages/drawer/src/scss/_drawer_modal.scss
@@ -4,20 +4,43 @@ $_b: var.$prefix-block;
 $_e: var.$prefix-element;
 $_m: var.$prefix-modifier;
 
+/**
+ * Drawer modal styles
+ */
+
 .#{$_b}drawer#{$_m}modal {
   z-index: var.$modal-z-index;
+  right: auto;
+  left: 0;
   width: 0;
   height: 0;
   overflow: hidden;
+  transform: translateX(0);
   background-color: rgba(var.$modal-background, 0);
 
   .#{$_b}drawer#{$_e}dialog {
     position: absolute;
     z-index: (var.$modal-z-index + 1);
+    left: 0;
     width: var.$modal-width;
     max-width: var.$modal-max-width;
+    transform: translateX(-100%);
+    border-right: var.$border;
     background-color: var.$modal-background;
     box-shadow: var.$modal-box-shadow;
+  }
+
+  &.#{$_b}drawer#{$_m}switch {
+    right: auto;
+    left: 0;
+    transform: translateX(0);
+
+    .#{$_b}drawer#{$_e}dialog {
+      right: 0;
+      left: auto;
+      transform: translateX(100%);
+      border-left: var.$border;
+    }
   }
 
   .#{$_b}dialog#{$_e}header,
@@ -31,6 +54,10 @@ $_m: var.$prefix-modifier;
   }
 }
 
+/**
+ * Drawer modal transition
+ */
+
 .#{$_b}drawer#{$_m}modal.is-opening,
 .#{$_b}drawer#{$_m}modal.is-opened,
 .#{$_b}drawer#{$_m}modal.is-closing {
@@ -40,15 +67,28 @@ $_m: var.$prefix-modifier;
 }
 
 .#{$_b}drawer#{$_m}modal.is-opening,
-.#{$_b}drawer#{$_m}modal.is-closing {
-  transition: background-color var.$transition-duration var.$transition-timing-function;
-}
-
-.#{$_b}drawer#{$_m}modal.is-opening,
 .#{$_b}drawer#{$_m}modal.is-opened {
+  transform: translateX(0);
   background-color: rgba(var.$modal-screen-background, var.$modal-screen-background-alpha);
+
+  .#{$_b}drawer#{$_e}dialog {
+    transform: translateX(0);
+  }
 }
 
 .#{$_b}drawer#{$_m}modal.is-closing {
+  transform: translateX(0);
   background-color: rgba(var.$modal-screen-background, 0);
+
+  .#{$_b}drawer#{$_e}dialog {
+    transform: translateX(-100%);
+  }
+}
+
+.#{$_b}drawer#{$_m}modal.#{$_b}drawer#{$_m}switch.is-closing {
+  transform: translateX(0);
+
+  .#{$_b}drawer#{$_e}dialog {
+    transform: translateX(100%);
+  }
 }

--- a/packages/drawer/src/scss/_drawer_switch.scss
+++ b/packages/drawer/src/scss/_drawer_switch.scss
@@ -5,55 +5,65 @@ $_e: var.$prefix-element;
 $_m: var.$prefix-modifier;
 $_v: var.$prefix-modifier-value;
 
-.#{$_b}drawer:not(.#{$_b}drawer#{$_m}switch) {
+/**
+ * Drawer slide transition
+ */
+
+.#{$_b}drawer {
   left: 0;
+  transform: translateX(-100%);
 
   .#{$_b}drawer#{$_e}dialog {
-    left: 0;
-    transform: translateX(-100%);
     border-right: var.$border;
-  }
-}
-
-.#{$_b}drawer#{$_m}switch {
-  right: 0;
-
-  .#{$_b}drawer#{$_e}dialog {
-    right: 0;
-    transform: translateX(100%);
-    border-left: var.$border;
-  }
-}
-
-.#{$_b}drawer:not(.#{$_b}drawer#{$_m}switch).is-opening,
-.#{$_b}drawer:not(.#{$_b}drawer#{$_m}switch).is-opened {
-  &:not(.#{$_b}drawer#{$_m}modal) ~ .#{var.$class-main} {
-    margin-left: var.$width;
-  }
-}
-
-.#{$_b}drawer#{$_m}switch.is-opening,
-.#{$_b}drawer#{$_m}switch.is-opened {
-  &:not(.#{$_b}drawer#{$_m}modal) ~ .#{var.$class-main} {
-    margin-right: var.$width;
   }
 }
 
 .#{$_b}drawer.is-opening,
 .#{$_b}drawer.is-opened {
-  .#{$_b}drawer#{$_e}dialog {
-    transform: translateX(0);
-  }
+  transform: translateX(0);
 }
 
-.#{$_b}drawer:not(.#{$_b}drawer#{$_m}switch).is-closing {
+.#{$_b}drawer.is-closing {
+  transform: translateX(-100%);
+}
+
+/**
+ * Drawer switched slide transition
+ */
+
+.#{$_b}drawer#{$_m}switch {
+  right: 0;
+  left: auto;
+  transform: translateX(100%);
+
   .#{$_b}drawer#{$_e}dialog {
-    transform: translateX(-100%);
+    @if (var.$border) {
+      border-right: none;
+    }
+    border-left: var.$border;
   }
 }
 
 .#{$_b}drawer#{$_m}switch.is-closing {
-  .#{$_b}drawer#{$_e}dialog {
-    transform: translateX(100%);
+  transform: translateX(100%);
+}
+
+/**
+ * Drawer main margins
+ */
+
+// IS .drawer NOT .drawer_modal .drawer_switch
+.#{$_b}drawer:not(.#{$_b}drawer#{$_m}modal, .#{$_b}drawer#{$_m}switch) {
+  &.is-opening ~ .#{var.$class-main},
+  &.is-opened ~ .#{var.$class-main} {
+    margin-left: var.$width;
+  }
+}
+
+// IS .drawer .drawer_switch NOT .drawer_modal
+.#{$_b}drawer.#{$_b}drawer#{$_m}switch:not(.#{$_b}drawer#{$_m}modal) {
+  &.is-opening ~ .#{var.$class-main},
+  &.is-opened ~ .#{var.$class-main} {
+    margin-right: var.$width;
   }
 }


### PR DESCRIPTION
## Problem

Because of a recent change with the transition module, drawers can no longer depend on the transition event to fire off the dialog element. This was relied on for the drawer component in its inline state to open and close.

## Solution

This PR fixes the transition bug by moving the inline transition styles to the base `.drawer` element instead of the `.drawer__dialog`. The drawer modal transition also needed to be updated since it relied on the previous styles. Lastly, the drawer manifest import order was updated to help reduce selector weight between interdependent modifiers (`.drawer_switch` and `.drawer_modal`).

Fixes #1351