### PR TITLE
Add the ability to set a custom screen for modals and modal drawers

### DIFF
--- a/docs/src/components/LayoutDrawer.vue
+++ b/docs/src/components/LayoutDrawer.vue
@@ -8,7 +8,7 @@
     <div class="layout-drawer__mask"></div>
     <slot />
   </aside>
-  <div @click="closeDrawer" class="layout-drawer__screen"></div>
+  <div class="layout-drawer__screen" :data-drawer-close="uid"></div>
 </template>
 
 <script lang="ts">
@@ -21,10 +21,6 @@ export default {
     const uid = ref('layout-drawer');
     const elDrawer = ref(null);
 
-    function closeDrawer() {
-      drawer.close(uid.value);
-    }
-
     onMounted(() => {
       drawer.register(elDrawer.value);
     });
@@ -35,8 +31,7 @@ export default {
 
     return {
       uid,
-      elDrawer,
-      closeDrawer
+      elDrawer
     };
   },
 };

--- a/packages/drawer/src/js/defaults.js
+++ b/packages/drawer/src/js/defaults.js
@@ -11,6 +11,7 @@ export default {
   // Selectors
   selectorDrawer: '.drawer',
   selectorDialog: '.drawer__dialog',
+  selectorScreen: '.drawer',
   selectorFocus: '[data-focus]',
   selectorInert: null,
   selectorOverflow: 'body',

--- a/packages/drawer/src/js/handlers.js
+++ b/packages/drawer/src/js/handlers.js
@@ -59,10 +59,10 @@ export async function handleClick(event) {
     return;
   }
 
-  // If the modal drawer screen was clicked...
-  if (event.target.matches(this.settings.selectorDrawer)) {
+  // If there is an active modal drawer and the screen was clicked...
+  if (this.activeModal && event.target.matches(this.settings.selectorScreen)) {
     // Close the modal drawer.
-    return this.close(event.target.id);
+    return this.close(this.activeModal.id);
   }
 }
 

--- a/packages/modal/src/js/defaults.js
+++ b/packages/modal/src/js/defaults.js
@@ -10,6 +10,7 @@ export default {
   // Selectors
   selectorModal: '.modal',
   selectorDialog: '.modal__dialog',
+  selectorScreen: '.modal',
   selectorRequired: '[role="alertdialog"]',
   selectorFocus: '[data-focus]',
   selectorInert: null,

--- a/packages/modal/src/js/handlers.js
+++ b/packages/modal/src/js/handlers.js
@@ -40,12 +40,14 @@ export async function handleClick(event) {
     }
   }
 
-  // If the modal screen was clicked, close the modal.
+  // If there is an active modal and the screen was clicked...
   if (
-    event.target.matches(this.settings.selectorModal) &&
-    !event.target.querySelector(this.settings.selectorRequired)
+    this.active &&
+    event.target.matches(this.settings.selectorScreen) &&
+    !this.active.el.querySelector(this.settings.selectorRequired)
   ) {
-    return this.close(event.target.id);
+    // Close the modal.
+    return this.close(this.active.id);
   }
 }
 

--- a/packages/modal/src/js/handlers.js
+++ b/packages/modal/src/js/handlers.js
@@ -44,7 +44,7 @@ export async function handleClick(event) {
   if (
     this.active &&
     event.target.matches(this.settings.selectorScreen) &&
-    !this.active.el.querySelector(this.settings.selectorRequired)
+    !this.active.required
   ) {
     // Close the modal.
     return this.close(this.active.id);

--- a/packages/modal/src/js/register.js
+++ b/packages/modal/src/js/register.js
@@ -18,6 +18,10 @@ export async function register(el) {
     state: 'closed',
     el: el,
     dialog: null,
+    get required() {
+      return (this.dialog) ?
+        this.dialog.matches(this.getSetting('selectorRequired')) : false;
+    },
     returnRef: null,
     settings: getConfig(el, this.settings.dataConfig),
     open(transition, focus) {


### PR DESCRIPTION
## What changed?

This PR adds the ability to set a custom screen element for closing modals. This by default is the root modal and modal drawer elements. It also updates the handlers appropriately and also adds a `required` property on the modal collection entries so it's easier to access that data point using `entry.required`.