### PR TITLE
Add active states to navigation (navibar, drawer, aside) menus

### DIFF
--- a/docs/src/components/CollectionMenu.astro
+++ b/docs/src/components/CollectionMenu.astro
@@ -2,7 +2,7 @@
 import { getCollection } from "astro:content";
 import { currentPage } from "../modules/currentPage";
 
-const { collection } = Astro.props;
+const { collection, menuClass } = Astro.props;
 
 const packages = await getCollection(collection);
 const title = collection.charAt(0).toUpperCase() + collection.slice(1);
@@ -15,7 +15,7 @@ const cp = currentPage(new URL(Astro.request.url).pathname, {
 
 <nav>
   <h2 class="padding padding-y-sm">{title}</h2>
-  <ul class="menu">
+  <ul class={`menu${menuClass ? " " + menuClass : ""}`}>
     {
       packages.map((entry) => (
         <li class="menu__item">

--- a/docs/src/components/CollectionMenu.astro
+++ b/docs/src/components/CollectionMenu.astro
@@ -1,10 +1,16 @@
 ---
 import { getCollection } from "astro:content";
+import { currentPage } from "../modules/currentPage";
 
 const { collection } = Astro.props;
 
 const packages = await getCollection(collection);
 const title = collection.charAt(0).toUpperCase() + collection.slice(1);
+
+const cp = currentPage(new URL(Astro.request.url).pathname, {
+  classBase: "menu__action",
+  classCurrent: "is-active",
+});
 ---
 
 <nav>
@@ -13,7 +19,10 @@ const title = collection.charAt(0).toUpperCase() + collection.slice(1);
     {
       packages.map((entry) => (
         <li class="menu__item">
-          <a class="menu__action" href={`/${collection}/${entry.slug}`}>
+          <a
+            class={cp.classes(`/${collection}/${entry.slug}`)}
+            href={`/${collection}/${entry.slug}`}
+          >
             {entry.data.title}
           </a>
         </li>

--- a/docs/src/components/LayoutAside.vue
+++ b/docs/src/components/LayoutAside.vue
@@ -9,7 +9,7 @@
       <slot />
     </div>
   </aside>
-  <div class="layout-aside__screen" :data-drawer-close="uid"></div>
+  <div class="layout__screen" :data-drawer-close="uid"></div>
 </template>
 
 <script lang="ts">

--- a/docs/src/components/LayoutDrawer.vue
+++ b/docs/src/components/LayoutDrawer.vue
@@ -8,7 +8,7 @@
     <div class="layout-drawer__mask"></div>
     <slot />
   </aside>
-  <div class="layout-drawer__screen" :data-drawer-close="uid"></div>
+  <div class="layout__screen" :data-drawer-close="uid"></div>
 </template>
 
 <script lang="ts">

--- a/docs/src/components/Navi.astro
+++ b/docs/src/components/Navi.astro
@@ -1,18 +1,29 @@
 ---
 import Icon from "../components/Icon.vue";
+import { currentPage } from "../modules/currentPage";
 
 interface Props {
   classes?: string;
 }
 
 const { classes = "" } = Astro.props;
+
+const cp = currentPage(new URL(Astro.request.url).pathname, {
+  classBase: "menu__action",
+  classCurrent: "is-active",
+  classParent: "is-active",
+});
 ---
 
 <ul class={`menu${classes ? " " + classes : ""}`}>
   <li class="menu__item">
-    <a class="menu__action" href="/getting-started">Get Started</a>
+    <a class={cp.classes("/getting-started")} href="/getting-started"
+      >Get Started</a
+    >
   </li>
-  <li class="menu__item"><a class="menu__action" href="/packages">Docs</a></li>
+  <li class="menu__item">
+    <a class={cp.classes("/packages")} href="/packages">Docs</a>
+  </li>
   <li class="menu__item">
     <a
       class="menu__action"

--- a/docs/src/components/OnThisPage.astro
+++ b/docs/src/components/OnThisPage.astro
@@ -1,6 +1,7 @@
 ---
 import OnThisPageList from "./OnThisPageList.astro";
-const { headings } = Astro.props;
+
+const { headings, menuClass } = Astro.props;
 
 // Filter the headings to only display the ones we want.
 const otp = build(headings.filter((item) => item.depth === 2));
@@ -27,7 +28,7 @@ function build(headings) {
   { 
     !!otp.length && (
       <h2 class="padding padding-y-sm">On this page</h2>
-      <ul class="menu">
+      <ul class={`menu${menuClass ? " " + menuClass : ""}`}>
         {otp.map((item) => <OnThisPageList {item} />)}
       </ul>
     )

--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -19,9 +19,11 @@ const { title, drawer = false, aside = false } = Astro.props;
   <div class="layout">
     {
       drawer && (
-        <LayoutDrawer client:load>
-          <slot name="drawer" />
-        </LayoutDrawer>
+        <div class="layout__drawer">
+          <LayoutDrawer client:load>
+            <slot name="drawer" />
+          </LayoutDrawer>
+        </div>
       )
     }
     <div class="layout__main">

--- a/docs/src/layouts/Page.astro
+++ b/docs/src/layouts/Page.astro
@@ -15,14 +15,14 @@ const {
   {
     drawer && (
       <div slot="drawer">
-        <Menu collection={drawer} />
+        <Menu collection={drawer} menuClass="layout__menu" />
       </div>
     )
   }
   {
     aside && (
       <div slot="aside">
-        <OnThisPage {headings} />
+        <OnThisPage {headings} menuClass="layout__menu" />
       </div>
     )
   }

--- a/docs/src/modules/currentPage.js
+++ b/docs/src/modules/currentPage.js
@@ -1,0 +1,42 @@
+const currentPage = (pathname, options) => {
+  const settings = {
+    pathname: pathname,
+    classBase: '',
+    classCurrent: 'is-current',
+    classParent: 'is-parent',
+    ...options
+  };
+
+  function isCurrent(path) {
+    return (pathname === path);
+  }
+
+  function isParent(path) {
+    return (pathname.includes(path));
+  }
+
+  function classes(path, base = settings.classBase) {
+    const classes = [];
+
+    if (base) {
+      classes.push(base);
+    }
+
+    if (isCurrent(path)) {
+      classes.push(settings.classCurrent);
+    } else if (isParent(path)) {
+      classes.push(settings.classParent);
+    }
+
+    return classes.join(' ');
+  }
+
+  return {
+    settings,
+    isCurrent,
+    isParent,
+    classes
+  };
+};
+
+export { currentPage };

--- a/docs/src/pages/packages/[slug].astro
+++ b/docs/src/pages/packages/[slug].astro
@@ -24,7 +24,7 @@ const { Content, headings } = await entry.render();
 
 <Base title={entry.data.title} drawer={true} aside={true}>
   <div slot="drawer">
-    <Menu collection="packages" />
+    <Menu collection="packages" menuClass="layout__menu" />
   </div>
   <div slot="aside">
     <OnThisPage {headings} />

--- a/docs/src/styles/_layout-aside.scss
+++ b/docs/src/styles/_layout-aside.scss
@@ -2,7 +2,7 @@
 @use "./root";
 
 /**
- * Modal drawer
+ * Modal aside
  */
 
 .layout-aside {
@@ -32,28 +32,12 @@
     opacity: 1;
   }
 
+  &.is-closing {
+    visibility: visible;
+  }
+
   &.is-closed {
     visibility: hidden;
-  }
-}
-
-.layout-aside__screen {
-  position: fixed;
-  z-index: 99;
-  transition: opacity .25s;
-  background-color: var(--vb-neutral-10);
-  opacity: 0;
-  inset: auto;
-
-  .layout-aside.is-opened ~ &,
-  .layout-aside.is-opening ~ & {
-    opacity: 0.8;
-  }
-
-  .layout-aside.is-opened ~ &,
-  .layout-aside.is-opening ~ &,
-  .layout-aside.is-closing ~ & {
-    inset: 0;
   }
 }
 
@@ -85,10 +69,6 @@
     overflow-x: hidden;
     overflow-y: auto;
     scroll-behavior: smooth;
-  }
-
-  .layout-aside__screen {
-    display: none;
   }
 }
 

--- a/docs/src/styles/_layout-drawer.scss
+++ b/docs/src/styles/_layout-drawer.scss
@@ -25,30 +25,9 @@
 
   &.is-opened,
   &.is-opening {
-    visibility: visible;
     transform: translate(0);
     transition: opacity .25s, transform .5s cubic-bezier(0.19, 1, 0.22, 1);
     opacity: 1;
-  }
-}
-
-.layout-drawer__screen {
-  position: fixed;
-  z-index: 99;
-  transition: opacity .25s;
-  background-color: var(--vb-neutral-10);
-  opacity: 0;
-  inset: auto;
-
-  .layout-drawer.is-opened ~ &,
-  .layout-drawer.is-opening ~ & {
-    opacity: 0.8;
-  }
-
-  .layout-drawer.is-opened ~ &,
-  .layout-drawer.is-opening ~ &,
-  .layout-drawer.is-closing ~ & {
-    inset: 0;
   }
 }
 
@@ -100,10 +79,6 @@
       border-bottom: 1px solid var(--vb-border-color);
       inset: 100% 0 auto;
     }
-  }
-
-  .layout-drawer__screen {
-    display: none;
   }
 }
 

--- a/docs/src/styles/_layout.scss
+++ b/docs/src/styles/_layout.scss
@@ -75,3 +75,27 @@
   padding-top: 2em;
   border-top: 1px solid var(--vb-border-color);
 }
+
+/**
+ * Layout screen
+ */
+
+.layout__screen {
+  position: fixed;
+  z-index: 99;
+  transition: opacity .25s;
+  background-color: var(--vb-neutral-10);
+  opacity: 0;
+  inset: auto;
+
+  .is-opened ~ &,
+  .is-opening ~ & {
+    opacity: 0.8;
+  }
+
+  .is-opened ~ &,
+  .is-opening ~ &,
+  .is-closing ~ & {
+    inset: 0;
+  }
+}

--- a/docs/src/styles/_layout.scss
+++ b/docs/src/styles/_layout.scss
@@ -104,14 +104,14 @@
  * Layout menu
  */
 
-.layout .menu {
+.layout__menu {
   margin-top: 0.5rem;
-
-  .menu__item + .menu__item {
-    margin-top: 0;
-  }
 
   .is-active {
     background: var(--vb-background);
+  }
+
+  .menu__item + .menu__item {
+    margin-top: 0;
   }
 }

--- a/docs/src/styles/_layout.scss
+++ b/docs/src/styles/_layout.scss
@@ -99,3 +99,19 @@
     inset: 0;
   }
 }
+
+/**
+ * Layout menu
+ */
+
+.layout .menu {
+  margin-top: 0.5rem;
+
+  .menu__item + .menu__item {
+    margin-top: 0;
+  }
+
+  .is-active {
+    background: var(--vb-background);
+  }
+}

--- a/docs/src/styles/_navibar.scss
+++ b/docs/src/styles/_navibar.scss
@@ -40,6 +40,10 @@
     text-decoration: underline;
     text-underline-offset: 2px;
     text-decoration-thickness: 1px;
+
+    &.is-active {
+      text-decoration: none;
+    }
   }
 
   @media (min-width: root.$bp-drawer) {


### PR DESCRIPTION
## What changed?

This PR adds the current page module that allows setting the current and parent state classes on menus action elements. In addition, there is also some CSS consolidation of the layout screen element.