### PR TITLE
Add background and foreground theme to popover and dialog components

### DIFF
--- a/packages/dialog/src/_variables.scss
+++ b/packages/dialog/src/_variables.scss
@@ -1,3 +1,4 @@
+@use "@vrembem/core/theme";
 @use "@vrembem/core";
 
 $prefix-block: core.$prefix-block !default;
@@ -8,8 +9,8 @@ $prefix-modifier-value: core.$prefix-modifier-value !default;
 $z-index: 500 !default;
 $padding: 1em !default;
 $spacing: 0.5em !default;
-$background: white !default;
-$foreground: null !default;
+$foreground: theme.get("foreground") !default;
+$background: theme.get("background") !default;
 $border: null !default;
 $sep-border: core.$border !default;
 $border-radius: core.$border-radius !default;

--- a/packages/popover/src/scss/_popover.scss
+++ b/packages/popover/src/scss/_popover.scss
@@ -20,6 +20,7 @@ $_offset: calc(calc(var(--#{$_v}popover-offset) + 1) * 1px);
   background: var.$background;
   background-clip: var.$background-clip;
   box-shadow: var.$shadow;
+  color: var.$foreground;
   font-size: var.$font-size;
   line-height: var.$line-height;
 

--- a/packages/popover/src/scss/_variables.scss
+++ b/packages/popover/src/scss/_variables.scss
@@ -1,3 +1,4 @@
+@use "@vrembem/core/theme";
 @use "@vrembem/core";
 
 $prefix-variable: core.$prefix-variable !default;
@@ -18,7 +19,8 @@ $max-width: calc(100vw - 20px) !default;
 $padding: 0.5em !default;
 $border: null !default;
 $border-radius: core.$border-radius !default;
-$background: white !default;
+$foreground: theme.get("foreground") !default;
+$background: theme.get("background") !default;
 $background-clip: padding-box !default;
 $shadow: core.$shadow-2 !default;
 $font-size: core.$font-size-sm !default;


### PR DESCRIPTION
## What changed?

Popovers and dialogs did not look very well on dark mode and that's because their foreground and backgrounds were not setup to use the new theme module system. This PR applies the background and foreground theme so that the content of popovers and modals are still readable in dark mode.