### PR TITLE
Add shared state using layout store

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -11,9 +11,11 @@
   "devDependencies": {
     "@astrojs/mdx": "^0.19.7",
     "@astrojs/vue": "^2.2.1",
+    "@nanostores/vue": "^0.10.0",
     "@types/node": "^20.5.7",
     "astro": "^2.10.14",
     "feather-icons": "^4.29.1",
+    "nanostores": "^0.9.3",
     "vrembem": "^4.0.0-next.3",
     "vue": "^3.3.4"
   }

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,6 @@
   "devDependencies": {
     "@astrojs/mdx": "^0.19.7",
     "@astrojs/vue": "^2.2.1",
-    "@nanostores/vue": "^0.10.0",
     "@types/node": "^20.5.7",
     "astro": "^2.10.14",
     "feather-icons": "^4.29.1",

--- a/docs/src/components/CodeBlock.vue
+++ b/docs/src/components/CodeBlock.vue
@@ -61,5 +61,4 @@ function copyCode(event) {
       console.error('Error:', error);
     });
 }
-
 </script>

--- a/docs/src/components/Icon.vue
+++ b/docs/src/components/Icon.vue
@@ -1,28 +1,21 @@
 <template>
-  <span :class="rootClass" v-html="svg"></span>
+  <span :class="rootClass || 'display-flex'" v-html="svg"></span>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import feather from 'feather-icons';
 
-const props = defineProps({
-  name: {
-    type: String,
-    default: 'feather',
-  },
-  rootClass: {
-    type: String,
-    default: 'display-flex'
-  },
-  iconClass: {
-    type: String,
-    default: ''
-  }
+const props = withDefaults(defineProps<{
+  name: string
+  rootClass?: string
+  iconClass?: string
+}>(), {
+  iconClass: ''
 });
 
 const svg = ref(null);
-const iconClass = `icon${(props.iconClass) ? ' ' + props.iconClass : ''}`;
+const iconClass = `icon ${props.iconClass}`.trim();
 
 svg.value = feather.icons[props.name].toSvg({
   class: iconClass

--- a/docs/src/components/Icon.vue
+++ b/docs/src/components/Icon.vue
@@ -9,7 +9,7 @@ import feather from 'feather-icons';
 const props = defineProps({
   name: {
     type: String,
-    default: 'feather'
+    default: 'feather',
   },
   rootClass: {
     type: String,

--- a/docs/src/components/OnThisPage.astro
+++ b/docs/src/components/OnThisPage.astro
@@ -1,13 +1,13 @@
 ---
 import OnThisPageList from "./OnThisPageList.astro";
-import { layout } from "../modules/useLayoutStore";
+import { $layout } from "../modules/useLayoutStore";
 
 const { headings, menuClass } = Astro.props;
 
 // Filter the headings to only display the ones we want.
 const otp = build(headings.filter((item) => item.depth === 2));
 
-layout.hasAside = !!otp.length;
+$layout.setKey('hasAside', !!otp.length);
 
 function build(headings) {
   const otp = [];
@@ -29,7 +29,7 @@ function build(headings) {
 
 <nav>
   { 
-    layout.hasAside && (
+    $layout.get().hasAside && (
       <h2 class="padding padding-y-sm">On this page</h2>
       <ul class={`menu menu_otp${menuClass ? " " + menuClass : ""}`}>
         {otp.map((item) => <OnThisPageList {item} />)}

--- a/docs/src/components/OnThisPage.astro
+++ b/docs/src/components/OnThisPage.astro
@@ -1,10 +1,13 @@
 ---
 import OnThisPageList from "./OnThisPageList.astro";
+import { layout } from "../modules/useLayoutStore";
 
 const { headings, menuClass } = Astro.props;
 
 // Filter the headings to only display the ones we want.
 const otp = build(headings.filter((item) => item.depth === 2));
+
+layout.hasAside = !!otp.length;
 
 function build(headings) {
   const otp = [];
@@ -26,7 +29,7 @@ function build(headings) {
 
 <nav>
   { 
-    !!otp.length && (
+    layout.hasAside && (
       <h2 class="padding padding-y-sm">On this page</h2>
       <ul class={`menu menu_otp${menuClass ? " " + menuClass : ""}`}>
         {otp.map((item) => <OnThisPageList {item} />)}

--- a/docs/src/components/Toolbar.astro
+++ b/docs/src/components/Toolbar.astro
@@ -1,19 +1,13 @@
 ---
 import Icon from "../components/Icon.vue";
-
-interface Props {
-  drawer?: boolean;
-  aside?: boolean;
-}
-
-const { drawer = false, aside = false } = Astro.props;
+import { layout } from "../modules/useLayoutStore";
 ---
 
 {
-  (drawer || aside) && (
+  layout.hasAsideOrDrawer && (
     <div class="toolbar">
       <div class="clearfix">
-        {drawer && (
+        {layout.hasDrawer && (
           <button
             data-drawer-open="layout-drawer"
             class="button padding-left-sm float-left"
@@ -22,7 +16,7 @@ const { drawer = false, aside = false } = Astro.props;
             <span>Packages</span>
           </button>
         )}
-        {aside && (
+        {layout.hasAside && (
           <button
             data-drawer-open="layout-aside"
             class="button padding-right-sm float-right"

--- a/docs/src/components/Toolbar.astro
+++ b/docs/src/components/Toolbar.astro
@@ -1,13 +1,15 @@
 ---
 import Icon from "../components/Icon.vue";
-import { layout } from "../modules/useLayoutStore";
+import { $layout } from "../modules/useLayoutStore";
+
+const hasAsideOrDrawer = $layout.get().hasDrawer || $layout.get().hasAside;
 ---
 
 {
-  layout.hasAsideOrDrawer && (
+  hasAsideOrDrawer && (
     <div class="toolbar">
       <div class="clearfix">
-        {layout.hasDrawer && (
+        {$layout.get().hasDrawer && (
           <button
             data-drawer-open="layout-drawer"
             class="button padding-left-sm float-left"
@@ -16,7 +18,7 @@ import { layout } from "../modules/useLayoutStore";
             <span>Packages</span>
           </button>
         )}
-        {layout.hasAside && (
+        {$layout.get().hasAside && (
           <button
             data-drawer-open="layout-aside"
             class="button padding-right-sm float-right"

--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -6,7 +6,7 @@ import Footer from "../components/Footer.astro";
 import LayoutDrawer from "../components/LayoutDrawer.vue";
 import LayoutAside from "../components/LayoutAside.vue";
 import Icon from "../components/Icon.vue";
-import { layout } from "../modules/useLayoutStore";
+import { $layout } from "../modules/useLayoutStore";
 
 interface Props {
   title?: string;
@@ -20,7 +20,7 @@ const { title } = Astro.props;
   <Toolbar />
   <div class="layout">
     {
-      layout.hasDrawer && (
+      $layout.get().hasDrawer && (
         <div class="layout__drawer">
           <LayoutDrawer client:load>
             <slot name="drawer" />
@@ -31,7 +31,7 @@ const { title } = Astro.props;
     <div class="layout__main">
       <div class="layout__grid">
         {
-          layout.hasAside && (
+          $layout.get().hasAside && (
             <div class="layout__aside">
               <LayoutAside client:load>
                 <slot name="aside" />
@@ -41,7 +41,7 @@ const { title } = Astro.props;
         }
         <div class="layout__content">
           {
-            layout.hasAside && (
+            $layout.get().hasAside && (
               <div class="toolbar-mini">
                 <button
                   data-drawer-open="layout-aside"

--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -6,22 +6,21 @@ import Footer from "../components/Footer.astro";
 import LayoutDrawer from "../components/LayoutDrawer.vue";
 import LayoutAside from "../components/LayoutAside.vue";
 import Icon from "../components/Icon.vue";
+import { layout } from "../modules/useLayoutStore";
 
 interface Props {
   title?: string;
-  drawer?: boolean;
-  aside?: boolean;
 }
 
-const { title, drawer = false, aside = false } = Astro.props;
+const { title } = Astro.props;
 ---
 
-<Root {title} {drawer} {aside}>
+<Root {title}>
   <Navibar />
-  <Toolbar {drawer} {aside} />
+  <Toolbar />
   <div class="layout">
     {
-      drawer && (
+      layout.hasDrawer && (
         <div class="layout__drawer">
           <LayoutDrawer client:load>
             <slot name="drawer" />
@@ -32,7 +31,7 @@ const { title, drawer = false, aside = false } = Astro.props;
     <div class="layout__main">
       <div class="layout__grid">
         {
-          aside && (
+          layout.hasAside && (
             <div class="layout__aside">
               <LayoutAside client:load>
                 <slot name="aside" />
@@ -42,7 +41,7 @@ const { title, drawer = false, aside = false } = Astro.props;
         }
         <div class="layout__content">
           {
-            aside && (
+            layout.hasAside && (
               <div class="toolbar-mini">
                 <button
                   data-drawer-open="layout-aside"

--- a/docs/src/layouts/Page.astro
+++ b/docs/src/layouts/Page.astro
@@ -2,25 +2,24 @@
 import Base from "./Base.astro";
 import Menu from "../components/CollectionMenu.astro";
 import OnThisPage from "../components/OnThisPage.astro";
+import { layout } from "../modules/useLayoutStore";
 
 const { headings } = Astro.props;
-const {
-  title,
-  drawer = false,
-  aside = true,
-} = Astro.props.frontmatter || Astro.props;
+const { title, collection } = Astro.props.frontmatter || Astro.props;
+
+layout.collection = collection;
 ---
 
-<Base {title} {drawer} {aside}>
+<Base {title}>
   {
-    drawer && (
+    layout.hasDrawer && (
       <div slot="drawer">
-        <Menu collection={drawer} menuClass="layout__menu" />
+        <Menu collection={layout.collection} menuClass="layout__menu" />
       </div>
     )
   }
   {
-    aside && (
+    layout.hasAside && (
       <div slot="aside">
         <OnThisPage {headings} menuClass="layout__menu" />
       </div>

--- a/docs/src/layouts/Page.astro
+++ b/docs/src/layouts/Page.astro
@@ -2,29 +2,25 @@
 import Base from "./Base.astro";
 import Menu from "../components/CollectionMenu.astro";
 import OnThisPage from "../components/OnThisPage.astro";
-import { layout } from "../modules/useLayoutStore";
+import { $collection } from "../modules/useLayoutStore";
 
 const { headings } = Astro.props;
 const { title, collection } = Astro.props.frontmatter || Astro.props;
 
-layout.collection = collection;
+$collection.set(collection);
 ---
 
 <Base {title}>
   {
-    layout.hasDrawer && (
+    $collection.get() && (
       <div slot="drawer">
-        <Menu collection={layout.collection} menuClass="layout__menu" />
+        <Menu collection={$collection.get()} menuClass="layout__menu" />
       </div>
     )
   }
-  {
-    layout.hasAside && (
-      <div slot="aside">
-        <OnThisPage {headings} menuClass="layout__menu" />
-      </div>
-    )
-  }
+  <div slot="aside">
+    <OnThisPage {headings} menuClass="layout__menu" />
+  </div>
   <slot />
 </Base>
 

--- a/docs/src/layouts/Root.astro
+++ b/docs/src/layouts/Root.astro
@@ -1,6 +1,6 @@
 ---
 import "../styles/global.scss";
-import { layout } from "../modules/useLayoutStore";
+import { $layout } from "../modules/useLayoutStore";
 
 interface Props {
   title?: string;
@@ -10,8 +10,8 @@ interface Props {
 const { title, bodyClass } = Astro.props;
 
 let mainClasses = "main";
-mainClasses += layout.hasDrawer ? " has-drawer" : "";
-mainClasses += layout.hasAside ? " has-aside" : "";
+mainClasses += $layout.get().hasDrawer ? " has-drawer" : "";
+mainClasses += $layout.get().hasAside ? " has-aside" : "";
 ---
 
 <!DOCTYPE html>

--- a/docs/src/layouts/Root.astro
+++ b/docs/src/layouts/Root.astro
@@ -1,18 +1,17 @@
 ---
 import "../styles/global.scss";
+import { layout } from "../modules/useLayoutStore";
 
 interface Props {
   title?: string;
-  drawer?: boolean;
-  aside?: boolean;
   bodyClass?: string;
 }
 
-const { title, drawer, aside, bodyClass } = Astro.props;
+const { title, bodyClass } = Astro.props;
 
 let mainClasses = "main";
-mainClasses += drawer ? " has-drawer" : "";
-mainClasses += aside ? " has-aside" : "";
+mainClasses += layout.hasDrawer ? " has-drawer" : "";
+mainClasses += layout.hasAside ? " has-aside" : "";
 ---
 
 <!DOCTYPE html>

--- a/docs/src/modules/useLayoutStore.js
+++ b/docs/src/modules/useLayoutStore.js
@@ -1,0 +1,22 @@
+let _collection = null;
+
+const layout = {
+  get collection() {
+    return _collection;
+  },
+  set collection(value) {
+    if (value) {
+      _collection = value;
+      this.hasDrawer = true;
+    } else {
+      this.hasDrawer = false;
+    }
+  },
+  hasAside: false,
+  hasDrawer: false,
+  get hasAsideOrDrawer() {
+    return this.hasAside || this.hasDrawer;
+  }
+};
+
+export { layout };

--- a/docs/src/modules/useLayoutStore.js
+++ b/docs/src/modules/useLayoutStore.js
@@ -1,22 +1,18 @@
-let _collection = null;
+import { atom, map } from 'nanostores'
 
-const layout = {
-  get collection() {
-    return _collection;
-  },
-  set collection(value) {
-    if (value) {
-      _collection = value;
-      this.hasDrawer = true;
-    } else {
-      this.hasDrawer = false;
-    }
-  },
+const $collection = atom(null);
+
+const $layout = map({
   hasAside: false,
   hasDrawer: false,
-  get hasAsideOrDrawer() {
-    return this.hasAside || this.hasDrawer;
-  }
-};
+});
 
-export { layout };
+$collection.listen((value) => {
+  if (value) {
+    $layout.setKey('hasDrawer', true);
+  } else {
+    $layout.setKey('hasDrawer', false);
+  }
+});
+
+export { $layout, $collection };

--- a/docs/src/pages/404.mdx
+++ b/docs/src/pages/404.mdx
@@ -1,7 +1,6 @@
 ---
 layout: ../layouts/Page.astro
 title: Page Not Found
-aside: false
 ---
 
 # 404

--- a/docs/src/pages/packages/[slug].astro
+++ b/docs/src/pages/packages/[slug].astro
@@ -5,6 +5,7 @@ import Menu from "../../components/CollectionMenu.astro";
 import OnThisPage from "../../components/OnThisPage.astro";
 import Pre from "../../components/Pre.astro";
 import Table from "../../components/Table.astro";
+import { $collection } from "../../modules/useLayoutStore";
 
 export async function getStaticPaths() {
   const packages = await getCollection("packages");
@@ -20,11 +21,13 @@ interface Props {
 
 const { entry } = Astro.props;
 const { Content, headings } = await entry.render();
+
+$collection.set("packages");
 ---
 
 <Base title={entry.data.title}>
   <div slot="drawer">
-    <Menu collection="packages" menuClass="layout__menu" />
+    <Menu collection={$collection.get()} menuClass="layout__menu" />
   </div>
   <div slot="aside">
     <OnThisPage {headings} />

--- a/docs/src/pages/packages/[slug].astro
+++ b/docs/src/pages/packages/[slug].astro
@@ -22,7 +22,7 @@ const { entry } = Astro.props;
 const { Content, headings } = await entry.render();
 ---
 
-<Base title={entry.data.title} drawer={true} aside={true}>
+<Base title={entry.data.title}>
   <div slot="drawer">
     <Menu collection="packages" menuClass="layout__menu" />
   </div>

--- a/docs/src/pages/packages/index.mdx
+++ b/docs/src/pages/packages/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../layouts/Page.astro
 title: Packages
-drawer: packages
+collection: packages
 ---
 
 # Packages

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
       "devDependencies": {
         "@astrojs/mdx": "^0.19.7",
         "@astrojs/vue": "^2.2.1",
-        "@nanostores/vue": "^0.10.0",
         "@types/node": "^20.5.7",
         "astro": "^2.10.14",
         "feather-icons": "^4.29.1",
@@ -3011,29 +3010,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/@nanostores/vue": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@nanostores/vue/-/vue-0.10.0.tgz",
-      "integrity": "sha512-832RAUbzRfHPs1CdqVEwfvgB2+RD/INji4Zo8bUSEfRO2pQRMMeq479gydnohGpRaa0oNwlfKo7TGFXCghq/1g==",
-      "dev": true,
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "peerDependencies": {
-        "@nanostores/logger": ">=0.2.3",
-        "@vue/devtools-api": ">=6.5.0",
-        "nanostores": ">=0.9.2",
-        "vue": ">=3.3.1"
-      },
-      "peerDependenciesMeta": {
-        "@nanostores/logger": {
-          "optional": true
-        },
-        "@vue/devtools-api": {
-          "optional": true
-        }
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,9 +32,11 @@
       "devDependencies": {
         "@astrojs/mdx": "^0.19.7",
         "@astrojs/vue": "^2.2.1",
+        "@nanostores/vue": "^0.10.0",
         "@types/node": "^20.5.7",
         "astro": "^2.10.14",
         "feather-icons": "^4.29.1",
+        "nanostores": "^0.9.3",
         "vrembem": "^4.0.0-next.3",
         "vue": "^3.3.4"
       }
@@ -3009,6 +3011,29 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@nanostores/vue": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@nanostores/vue/-/vue-0.10.0.tgz",
+      "integrity": "sha512-832RAUbzRfHPs1CdqVEwfvgB2+RD/INji4Zo8bUSEfRO2pQRMMeq479gydnohGpRaa0oNwlfKo7TGFXCghq/1g==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@nanostores/logger": ">=0.2.3",
+        "@vue/devtools-api": ">=6.5.0",
+        "nanostores": ">=0.9.2",
+        "vue": ">=3.3.1"
+      },
+      "peerDependenciesMeta": {
+        "@nanostores/logger": {
+          "optional": true
+        },
+        "@vue/devtools-api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -15820,6 +15845,21 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nanostores": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-0.9.3.tgz",
+      "integrity": "sha512-KobZjcVyNndNrb5DAjfs0WG0lRcZu5Q1BOrfTOxokFLi25zFrWPjg+joXC6kuDqNfSt9fQwppyjUBkRPtsL+8w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "engines": {
+        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/natural-compare": {


### PR DESCRIPTION
## What changed?

This PR adds nanostores for sharing global state of the layout. This includes things like if the layout has a drawer or aside and automatically toggles the drawer states if a collection has been defined. This PR also fixes a type error in the Icon component.