### PR TITLE
Refactor layout state to use props instead of global state module

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,6 @@
     "@types/node": "^20.5.9",
     "astro": "^2.10.14",
     "feather-icons": "^4.29.1",
-    "nanostores": "^0.9.3",
     "vrembem": "^4.0.0-next.3",
     "vue": "^3.3.4"
   }

--- a/docs/src/components/OnThisPage.astro
+++ b/docs/src/components/OnThisPage.astro
@@ -1,13 +1,13 @@
 ---
 import OnThisPageList from "./OnThisPageList.astro";
-import { $layout } from "../modules/useLayoutStore";
+import { layout } from "../modules/useLayoutStore";
 
 const { headings, menuClass } = Astro.props;
 
 // Filter the headings to only display the ones we want.
 const otp = build(headings.filter((item) => item.depth === 2));
 
-$layout.setKey('hasAside', !!otp.length);
+layout.hasAside = !!otp.length;
 
 function build(headings) {
   const otp = [];
@@ -29,7 +29,7 @@ function build(headings) {
 
 <nav>
   { 
-    $layout.get().hasAside && (
+    layout.hasAside && (
       <h2 class="padding padding-y-sm">On this page</h2>
       <ul class={`menu menu_otp${menuClass ? " " + menuClass : ""}`}>
         {otp.map((item) => <OnThisPageList {item} />)}

--- a/docs/src/components/OnThisPage.astro
+++ b/docs/src/components/OnThisPage.astro
@@ -1,13 +1,10 @@
 ---
 import OnThisPageList from "./OnThisPageList.astro";
-import { layout } from "../modules/useLayoutStore";
 
 const { headings, menuClass } = Astro.props;
 
 // Filter the headings to only display the ones we want.
-const otp = build(headings.filter((item) => item.depth === 2));
-
-layout.hasAside = !!otp.length;
+const filteredHeadings = build(headings.filter((item) => item.depth === 2));
 
 function build(headings) {
   const otp = [];
@@ -28,29 +25,25 @@ function build(headings) {
 ---
 
 <nav>
-  { 
-    layout.hasAside && (
-      <h2 class="padding padding-y-sm">On this page</h2>
-      <ul class={`menu menu_otp${menuClass ? " " + menuClass : ""}`}>
-        {otp.map((item) => <OnThisPageList {item} />)}
-        <li class="menu__sep slide-up scroll-spy"></li>
-        <li class="menu__item slide-up scroll-spy">
-          <a href="#main" class="menu__action">Back to top</a>
-        </li>
-      </ul>
-    )
-  }
+  <h2 class="padding padding-y-sm">On this page</h2>
+  <ul class={`menu menu_otp${menuClass ? " " + menuClass : ""}`}>
+    {filteredHeadings.map((item) => <OnThisPageList {item} />)}
+    <li class="menu__sep slide-up scroll-spy"></li>
+    <li class="menu__item slide-up scroll-spy">
+      <a href="#main" class="menu__action">Back to top</a>
+    </li>
+  </ul>
 </nav>
 
 <script>
-import { scrollSpy } from '../modules/scrollSpy';
-import { onThisPage } from '../modules/onThisPage';
+  import { scrollSpy } from "../modules/scrollSpy";
+  import { onThisPage } from "../modules/onThisPage";
 
-scrollSpy({
-  value: 200
-}).mount();
+  scrollSpy({
+    value: 200,
+  }).mount();
 
-onThisPage({
-  selectorAnchors: '.menu_otp a'
-}).mount();
+  onThisPage({
+    selectorAnchors: ".menu_otp a",
+  }).mount();
 </script>

--- a/docs/src/components/Toolbar.astro
+++ b/docs/src/components/Toolbar.astro
@@ -1,15 +1,13 @@
 ---
 import Icon from "../components/Icon.vue";
-import { $layout } from "../modules/useLayoutStore";
-
-const hasAsideOrDrawer = $layout.get().hasDrawer || $layout.get().hasAside;
+import { layout } from "../modules/useLayoutStore";
 ---
 
 {
-  hasAsideOrDrawer && (
+  layout.hasAsideOrDrawer && (
     <div class="toolbar">
       <div class="clearfix">
-        {$layout.get().hasDrawer && (
+        {layout.hasDrawer && (
           <button
             data-drawer-open="layout-drawer"
             class="button padding-left-sm float-left"
@@ -18,7 +16,7 @@ const hasAsideOrDrawer = $layout.get().hasDrawer || $layout.get().hasAside;
             <span>Packages</span>
           </button>
         )}
-        {$layout.get().hasAside && (
+        {layout.hasAside && (
           <button
             data-drawer-open="layout-aside"
             class="button padding-right-sm float-right"

--- a/docs/src/components/Toolbar.astro
+++ b/docs/src/components/Toolbar.astro
@@ -1,10 +1,20 @@
 ---
 import Icon from "../components/Icon.vue";
-import { layout } from "../modules/useLayoutStore";
+
+interface Props {
+  layout?: {
+    hasAside?: boolean;
+    hasDrawer?: boolean;
+  };
+}
+
+const { layout } = Astro.props;
+
+const hasAsideOrDrawer = layout.hasAside || layout.hasDrawer;
 ---
 
 {
-  layout.hasAsideOrDrawer && (
+  hasAsideOrDrawer && (
     <div class="toolbar">
       <div class="clearfix">
         {layout.hasDrawer && (

--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -6,18 +6,21 @@ import Footer from "../components/Footer.astro";
 import LayoutDrawer from "../components/LayoutDrawer.vue";
 import LayoutAside from "../components/LayoutAside.vue";
 import Icon from "../components/Icon.vue";
-import { layout } from "../modules/useLayoutStore";
 
 interface Props {
   title?: string;
+  layout?: {
+    hasAside?: boolean;
+    hasDrawer?: boolean;
+  };
 }
 
-const { title } = Astro.props;
+const { title, layout = {} } = Astro.props;
 ---
 
-<Root {title}>
+<Root {title} {layout}>
   <Navibar />
-  <Toolbar />
+  <Toolbar {layout} />
   <div class="layout">
     {
       layout.hasDrawer && (

--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -6,7 +6,7 @@ import Footer from "../components/Footer.astro";
 import LayoutDrawer from "../components/LayoutDrawer.vue";
 import LayoutAside from "../components/LayoutAside.vue";
 import Icon from "../components/Icon.vue";
-import { $layout } from "../modules/useLayoutStore";
+import { layout } from "../modules/useLayoutStore";
 
 interface Props {
   title?: string;
@@ -20,7 +20,7 @@ const { title } = Astro.props;
   <Toolbar />
   <div class="layout">
     {
-      $layout.get().hasDrawer && (
+      layout.hasDrawer && (
         <div class="layout__drawer">
           <LayoutDrawer client:load>
             <slot name="drawer" />
@@ -31,7 +31,7 @@ const { title } = Astro.props;
     <div class="layout__main">
       <div class="layout__grid">
         {
-          $layout.get().hasAside && (
+          layout.hasAside && (
             <div class="layout__aside">
               <LayoutAside client:load>
                 <slot name="aside" />
@@ -41,7 +41,7 @@ const { title } = Astro.props;
         }
         <div class="layout__content">
           {
-            $layout.get().hasAside && (
+            layout.hasAside && (
               <div class="toolbar-mini">
                 <button
                   data-drawer-open="layout-aside"

--- a/docs/src/layouts/Page.astro
+++ b/docs/src/layouts/Page.astro
@@ -2,25 +2,29 @@
 import Base from "./Base.astro";
 import Menu from "../components/CollectionMenu.astro";
 import OnThisPage from "../components/OnThisPage.astro";
-import { $collection } from "../modules/useLayoutStore";
+import { layout } from "../modules/useLayoutStore";
 
 const { headings } = Astro.props;
 const { title, collection } = Astro.props.frontmatter || Astro.props;
 
-$collection.set(collection);
+layout.hasDrawer = !!collection;
 ---
 
 <Base {title}>
   {
-    $collection.get() && (
+    layout.hasDrawer && (
       <div slot="drawer">
-        <Menu collection={$collection.get()} menuClass="layout__menu" />
+        <Menu collection={collection} menuClass="layout__menu" />
       </div>
     )
   }
-  <div slot="aside">
-    <OnThisPage {headings} menuClass="layout__menu" />
-  </div>
+  {
+    layout.hasAside && (
+      <div slot="aside">
+        <OnThisPage {headings} menuClass="layout__menu" />
+      </div>
+    )
+  }
   <slot />
 </Base>
 

--- a/docs/src/layouts/Page.astro
+++ b/docs/src/layouts/Page.astro
@@ -2,15 +2,17 @@
 import Base from "./Base.astro";
 import Menu from "../components/CollectionMenu.astro";
 import OnThisPage from "../components/OnThisPage.astro";
-import { layout } from "../modules/useLayoutStore";
 
 const { headings } = Astro.props;
 const { title, collection } = Astro.props.frontmatter || Astro.props;
 
-layout.hasDrawer = !!collection;
+const layout = {
+  hasDrawer: !!collection,
+  hasAside: !!headings.filter((item) => item.depth === 2).length,
+};
 ---
 
-<Base {title}>
+<Base {title} {layout}>
   {
     layout.hasDrawer && (
       <div slot="drawer">

--- a/docs/src/layouts/Root.astro
+++ b/docs/src/layouts/Root.astro
@@ -1,13 +1,16 @@
 ---
 import "../styles/global.scss";
-import { layout } from "../modules/useLayoutStore";
 
 interface Props {
   title?: string;
   bodyClass?: string;
+  layout?: {
+    hasAside?: boolean;
+    hasDrawer?: boolean;
+  };
 }
 
-const { title, bodyClass } = Astro.props;
+const { title, bodyClass, layout = {} } = Astro.props;
 
 let mainClasses = "main";
 mainClasses += layout.hasDrawer ? " has-drawer" : "";

--- a/docs/src/layouts/Root.astro
+++ b/docs/src/layouts/Root.astro
@@ -1,6 +1,6 @@
 ---
 import "../styles/global.scss";
-import { $layout } from "../modules/useLayoutStore";
+import { layout } from "../modules/useLayoutStore";
 
 interface Props {
   title?: string;
@@ -10,8 +10,8 @@ interface Props {
 const { title, bodyClass } = Astro.props;
 
 let mainClasses = "main";
-mainClasses += $layout.get().hasDrawer ? " has-drawer" : "";
-mainClasses += $layout.get().hasAside ? " has-aside" : "";
+mainClasses += layout.hasDrawer ? " has-drawer" : "";
+mainClasses += layout.hasAside ? " has-aside" : "";
 ---
 
 <!DOCTYPE html>

--- a/docs/src/modules/useLayoutStore.js
+++ b/docs/src/modules/useLayoutStore.js
@@ -1,9 +1,0 @@
-const layout = {
-  hasDrawer: false,
-  hasAside: false,
-  get hasAsideOrDrawer() {
-    return this.hasDrawer || this.hasAside;
-  }
-};
-
-export { layout };

--- a/docs/src/modules/useLayoutStore.js
+++ b/docs/src/modules/useLayoutStore.js
@@ -1,18 +1,9 @@
-import { atom, map } from 'nanostores';
-
-const $collection = atom(null);
-
-const $layout = map({
-  hasAside: false,
+const layout = {
   hasDrawer: false,
-});
-
-$collection.listen((value) => {
-  if (value) {
-    $layout.setKey('hasDrawer', true);
-  } else {
-    $layout.setKey('hasDrawer', false);
+  hasAside: false,
+  get hasAsideOrDrawer() {
+    return this.hasDrawer || this.hasAside;
   }
-});
+};
 
-export { $layout, $collection };
+export { layout };

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -5,9 +5,6 @@ import Footer from "../components/Footer.astro";
 import Navibar from "../components/Navibar.astro";
 import CodeBlock from "../components/CodeBlock.vue";
 import Icon from "../components/Icon.vue";
-import { $collection } from "../modules/useLayoutStore";
-
-$collection.set(null);
 ---
 
 <Root bodyClass="background-darker">

--- a/docs/src/pages/packages/[slug].astro
+++ b/docs/src/pages/packages/[slug].astro
@@ -5,7 +5,7 @@ import Menu from "../../components/CollectionMenu.astro";
 import OnThisPage from "../../components/OnThisPage.astro";
 import Pre from "../../components/Pre.astro";
 import Table from "../../components/Table.astro";
-import { $collection } from "../../modules/useLayoutStore";
+import { layout } from "../../modules/useLayoutStore";
 
 export async function getStaticPaths() {
   const packages = await getCollection("packages");
@@ -22,12 +22,12 @@ interface Props {
 const { entry } = Astro.props;
 const { Content, headings } = await entry.render();
 
-$collection.set("packages");
+layout.hasDrawer = true;
 ---
 
 <Base title={entry.data.title}>
   <div slot="drawer">
-    <Menu collection={$collection.get()} menuClass="layout__menu" />
+    <Menu collection="packages" menuClass="layout__menu" />
   </div>
   <div slot="aside">
     <OnThisPage {headings} />

--- a/docs/src/pages/packages/[slug].astro
+++ b/docs/src/pages/packages/[slug].astro
@@ -5,7 +5,6 @@ import Menu from "../../components/CollectionMenu.astro";
 import OnThisPage from "../../components/OnThisPage.astro";
 import Pre from "../../components/Pre.astro";
 import Table from "../../components/Table.astro";
-import { layout } from "../../modules/useLayoutStore";
 
 export async function getStaticPaths() {
   const packages = await getCollection("packages");
@@ -22,10 +21,13 @@ interface Props {
 const { entry } = Astro.props;
 const { Content, headings } = await entry.render();
 
-layout.hasDrawer = true;
+const layout = {
+  hasDrawer: true,
+  hasAside: true,
+};
 ---
 
-<Base title={entry.data.title}>
+<Base title={entry.data.title} {layout}>
   <div slot="drawer">
     <Menu collection="packages" menuClass="layout__menu" />
   </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "@types/node": "^20.5.9",
         "astro": "^2.10.14",
         "feather-icons": "^4.29.1",
-        "nanostores": "^0.9.3",
         "vrembem": "^4.0.0-next.3",
         "vue": "^3.3.4"
       }
@@ -15160,21 +15159,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/nanostores": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-0.9.3.tgz",
-      "integrity": "sha512-KobZjcVyNndNrb5DAjfs0WG0lRcZu5Q1BOrfTOxokFLi25zFrWPjg+joXC6kuDqNfSt9fQwppyjUBkRPtsL+8w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "engines": {
-        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/natural-compare": {


### PR DESCRIPTION
## What changed?

This PR refactors how we handle layout state by using props instead of trying to use a global state module which was not working and caused some weird issues.
