### PR TITLE
Add new overflow utility

### DIFF
--- a/packages/utility/index.scss
+++ b/packages/utility/index.scss
@@ -11,6 +11,7 @@
 @forward "./src/gap";
 @forward "./src/margin";
 @forward "./src/max-width";
+@forward "./src/overflow";
 @forward "./src/padding";
 @forward "./src/position";
 @forward "./src/text";

--- a/packages/utility/src/_overflow.scss
+++ b/packages/utility/src/_overflow.scss
@@ -8,15 +8,11 @@ $_c: var.$class-overflow;
     .#{$_u}#{$_c}-#{$property} {
       overflow: $property !important;
     }
-  }
 
-  @each $property in var.$overflow-properties {
     .#{$_u}#{$_c}-x-#{$property} {
       overflow-x: $property !important;
     }
-  }
 
-  @each $property in var.$overflow-properties {
     .#{$_u}#{$_c}-y-#{$property} {
       overflow-y: $property !important;
     }

--- a/packages/utility/src/_overflow.scss
+++ b/packages/utility/src/_overflow.scss
@@ -1,0 +1,24 @@
+@use "./variables" as var;
+
+$_u: var.$prefix-utility;
+$_c: var.$class-overflow;
+
+@if (var.$output-overflow) {
+  @each $property in var.$overflow-properties {
+    .#{$_u}#{$_c}-#{$property} {
+      overflow: $property !important;
+    }
+  }
+
+  @each $property in var.$overflow-properties {
+    .#{$_u}#{$_c}-x-#{$property} {
+      overflow-x: $property !important;
+    }
+  }
+
+  @each $property in var.$overflow-properties {
+    .#{$_u}#{$_c}-y-#{$property} {
+      overflow-y: $property !important;
+    }
+  }
+}

--- a/packages/utility/src/_variables.scss
+++ b/packages/utility/src/_variables.scss
@@ -19,6 +19,7 @@ $output-gap-x: $output !default;
 $output-gap-y: $output !default;
 $output-margin: $output !default;
 $output-max-width: $output !default;
+$output-overflow: $output !default;
 $output-padding: $output !default;
 $output-position: $output !default;
 $output-text: $output !default;
@@ -38,6 +39,7 @@ $class-gap-x: "gap-x" !default;
 $class-gap-y: "gap-y" !default;
 $class-margin: "margin" !default;
 $class-max-width: "max-width" !default;
+$class-overflow: "overflow" !default;
 $class-padding: "padding" !default;
 $class-position: "position" !default;
 $class-text: "text" !default;
@@ -76,4 +78,12 @@ $max-width-scale: (
   "lg": 80rem,
   "xl": 90rem,
   "full": 100%
+) !default;
+
+$overflow-properties: (
+  visible,
+  hidden,
+  clip,
+  scroll,
+  auto
 ) !default;


### PR DESCRIPTION
## What changed?

This PR adds the new overflow utility to allow setting the `x`, `y` or both shorthand of the overflow property. It includes the `$overflow-properties` map allowing users to specify which values to output for the property.