### PR TITLE
Add component theming support

### DIFF
--- a/docs/src/styles/_setup.scss
+++ b/docs/src/styles/_setup.scss
@@ -2,9 +2,11 @@
 @use "@vrembem/core/theme";
 
 @include theme.set(
+  "light",
   "background-glass",
   hsl(palette.get("neutral", "var"), 100%, 90%)
 );
+
 @include theme.set(
   "dark",
   "background-glass",

--- a/packages/core/src/scss/_functions.scss
+++ b/packages/core/src/scss/_functions.scss
@@ -65,11 +65,11 @@
 // TODO: documentation
 @function remove-nth($list, $n){
   $result: ();
-  $n: if($n < 0, length($list) + $n + 1, $n);
+  $n: if($n < 0, list.length($list) + $n + 1, $n);
   $bracketed: is-bracketed($list);
-  $separator: list-separator($list);
+  $separator: list.separator($list);
   @for $i from 1 through length($list){
-    @if $i != $n { $result: append($result, nth($list, $i)); }
+    @if $i != $n { $result: list.append($result, list.nth($list, $i)); }
   }
   @return join((), $result, $separator, $bracketed);
 }

--- a/packages/core/src/scss/_functions.scss
+++ b/packages/core/src/scss/_functions.scss
@@ -56,13 +56,16 @@
 
 /// Output the hue and saturation values of a provided color.
 /// @param {Color} $color - The color variable to pull hue and saturation values from.
-/// TODO: documentation
+/// @return {List} - The hue and saturation values of the provided color.
 @function get-hs($color) {
   @return math.round(color.hue($color)), math.round(color.saturation($color));
 }
 
-// Removed an item from a list based on it's index.
-// TODO: documentation
+/// Removes the item of $list at index $n. If $n is negative, it counts from the
+/// end of $list.
+/// @param {List} $list - The list to have an item removed from.
+/// @param {Number} $n - The position (index) in the list to have removed.
+/// @return {List} - A new list with the item removed.
 @function remove-nth($list, $n){
   $result: ();
   $n: if($n < 0, list.length($list) + $n + 1, $n);

--- a/packages/core/src/scss/_functions.scss
+++ b/packages/core/src/scss/_functions.scss
@@ -56,6 +56,20 @@
 
 /// Output the hue and saturation values of a provided color.
 /// @param {Color} $color - The color variable to pull hue and saturation values from.
+/// TODO: documentation
 @function get-hs($color) {
   @return math.round(color.hue($color)), math.round(color.saturation($color));
+}
+
+// Removed an item from a list based on it's index.
+// TODO: documentation
+@function remove-nth($list, $n){
+  $result: ();
+  $n: if($n < 0, length($list) + $n + 1, $n);
+  $bracketed: is-bracketed($list);
+  $separator: list-separator($list);
+  @for $i from 1 through length($list){
+    @if $i != $n { $result: append($result, nth($list, $i)); }
+  }
+  @return join((), $result, $separator, $bracketed);
 }

--- a/packages/core/src/scss/_functions.scss
+++ b/packages/core/src/scss/_functions.scss
@@ -69,7 +69,7 @@
 @function remove-nth($list, $n){
   $result: ();
   $n: if($n < 0, list.length($list) + $n + 1, $n);
-  $bracketed: is-bracketed($list);
+  $bracketed: list.is-bracketed($list);
   $separator: list.separator($list);
   @for $i from 1 through length($list){
     @if $i != $n { $result: list.append($result, list.nth($list, $i)); }

--- a/packages/core/src/scss/_theme.scss
+++ b/packages/core/src/scss/_theme.scss
@@ -75,130 +75,102 @@ $themes: (
 ) !default;
 
 /// Function to return the CSS variable with fallback of an entry within the
-/// $themes map. If a theme name is not provided, $theme-default will be used.
-/// @example - Return the background var() from the default theme.
-///   background: theme.get("background");
+/// $themes map.
 /// @example - Return the background var() from the dark theme.
 ///   background: theme.get("dark", "background");
-/// @param {String} $args... [$theme-default] - The theme name or property key to return.
+/// @example - Return the foreground var() from the card dark theme.
+///   background: theme.get("dark", "card", "background");
 /// @param {String} $args... - The property key to return.
 /// @require {Variable} $themes
 /// @return {CSS Var} - The var() CSS function with the value of the requested custom property.
 @function get($args...) {
-  @if length($args) == 1 {
-    $theme: $theme-default;
-    $key: list.nth($args, 1);
-    @return var(--#{$_v}#{$key}, map.get($themes, $theme, $key));
-  } @else if length($args) == 2 {
-    $theme: list.nth($args, 1);
-    $key: list.nth($args, 2);
-    @return var(--#{$_v}#{$key}, map.get($themes, $theme, $key));
+  @if map.has-key($themes, $theme-default, $args...) {
+    // Initial prop value and override if two arguments are passed.
+    $prop: #{list.nth($args, 1)};
+    @if length($args) == 2 {
+      $prop: #{list.nth($args, 1)}-#{list.nth($args, 2)};
+    }
+
+    // Return var() CSS function with the a fallback value.
+    @return var(--#{$_v}#{$prop}, map.get($themes, $theme-default, $args...));
+  } @else {
+    @error "Property does not exist in the default theme: #{$args}";
   }
 }
 
-/// Set a new or modify an existing property value in the $themes map. If a
-/// theme name is not provided, $theme-default will be used.
-/// @example - Set the foreground custom property for the default theme.
-///   @include theme.set("foreground", blue);
+/// Set a new or modify an existing property value in the $themes map.
 /// @example - Set the foreground custom property for the dark theme.
 ///   @include theme.set("dark", "foreground", blue);
 /// @output N/A
-/// @param {String} $args... [$theme-default] - The theme name or property key to set.
-/// @param {String} $args... - The property key or property value to set.
-/// @param {String} $args... - The property value to set.
+/// @param {String} $args... - The property keys and value to set.
 /// @require {Variable} $themes
 @mixin set($args...) {
-  @if length($args) == 2 {
-    $theme: $theme-default;
-    $key: list.nth($args, 1);
-    $value: list.nth($args, 2);
-    $themes: map.set($themes, $theme, $key, $value) !global;
-  } @else if length($args) == 3 {
-    $theme: list.nth($args, 1);
-    $key: list.nth($args, 2);
-    $value: list.nth($args, 3);
-    $themes: map.set($themes, $theme, $key, $value) !global;
-  }
+  $themes: map.set($themes, $args...) !global;
 }
 
-/// Remove a custom property in the $themes map. If a theme name is not
-/// provided, $theme-default will be used.
-/// @example - Remove the border-color property from the default theme.
-///   @include theme.remove("border-color");
+/// Remove a custom property in the $themes map.
 /// @example - Remove the border-color property from the dark theme.
 ///   @include theme.remove("dark", "border-color");
 /// @output N/A
-/// @param {String} $args... [$theme-default] - The theme name or property key to remove.
 /// @param {String} $args... - The property key to remove.
 /// @require {Variable} $themes
 @mixin remove($args...) {
-  @if length($args) == 1 {
-    $theme: $theme-default;
-    $key: list.nth($args, 1);
-    $themes: map.deep-remove($themes, $theme, $key) !global;
-  } @else if length($args) == 2 {
-    $theme: list.nth($args, 1);
-    $key: list.nth($args, 2);
-    $themes: map.deep-remove($themes, $theme, $key) !global;
-  }
+  $themes: map.deep-remove($themes, $args...) !global;
 }
 
 /// Allows adding a custom map of property and value pairs to a theme in the
-/// $themes map. If a theme name is not provided, $theme-default will be used.
-/// @example - Add a custom prop/value map to the default theme.
-///   @include theme.add((
-///     "background": white,
-///     "foreground": black
-///   ));
-/// @example - Add a custom prop/value map the the dark theme.
+/// $themes map.
+/// @example - Add a custom prop/value map as the dark theme.
 ///   @include theme.add("dark", (
 ///     "background": black,
 ///     "foreground": white,
 ///     "color-scheme": dark
 ///   ));
 /// @output N/A
-/// @param {String | Map} $args... [$theme-default] - The theme name or map of property/value pairs to add.
-/// @param {Map} $args... - The map of property/value pairs to add to the provided theme.
+/// @param {String} $name - The theme name to add.
+/// @param {Map} $map - The map of property/value pairs to add to the provided theme.
 /// @require {Variable} $themes
-@mixin add($args...) {
-  @if length($args) == 1 {
-    $name: $theme-default;
-    $map: list.nth($args, 1);
-    $themes: map.deep-merge($themes, ($name: $map)) !global;
-  } @else if length($args) == 2 {
-    $name: list.nth($args, 1);
-    $map: list.nth($args, 2);
-    $themes: map.deep-merge($themes, ($name: $map)) !global;
-  }
+@mixin add($name, $map) {
+  $themes: map.deep-merge($themes, ($name: $map)) !global;
 }
 
-/// Output all the custom properties and values of a theme.
+/// Output all the custom properties and values of a theme or a component theme.
 /// @example - Output the custom properties of the default theme.
 ///   @include theme.output();
 /// @example - Output the custom properties of the dark theme.
 ///   @include theme.output("dark");
-/// @example - Output the custom properties of the green theme from a custom themes map.
-///   $custom-themes: (
-///     "blue": (),
-///     "green": (),
-///     ...
-///   );
-///   @include theme.output("green", $custom-themes);
+/// @example - Output the custom properties of the light theme for the button component.
+///   @include theme.output("light", "button");
 /// @output Custom properties with their associated values of a theme.
 /// @param {String} $theme [$theme-default] - The theme name to output.
-/// @param {Map} $themes [$themes] - The themes map containing the theme name to output.
-@mixin output($theme: $theme-default, $themes: $themes) {
+/// @param {String} $component [null] - The name of component themes to output.
+@mixin output($theme: $theme-default, $component: null) {
   // Check if the key exists on the provided $themes map.
   @if map.has-key($themes, $theme) {
-    // Init the color scheme var.
+    // Initial color scheme variable.
     $color-scheme: null;
 
+    // Initial themes map and override if component is passed.
+    $map: map.get($themes, $theme);
+    @if $component {
+      $map: map.get($themes, $theme, $component);
+    }
+
     // Loop through all theme entries and output their custom properties.
-    @each $key, $value in map.get($themes, $theme) {
-      @if $key != 'color-scheme' {
-        --#{$_v}#{$key}: #{$value};
-      } @else {
-        $color-scheme: #{$value};
+    @each $key, $value in $map {
+      @if meta.type-of($value) != 'map' {
+        // Initial prop value and override if two arguments are passed.
+        $prop: --#{$_v}#{$key};
+        @if $component {
+          $prop: --#{$_v}#{$component}-#{$key};
+        }
+
+        // Output property or store the color scheme.
+        @if $key != 'color-scheme' {
+          #{$prop}: #{$value};
+        } @else {
+          $color-scheme: #{$value};
+        }
       }
     }
 
@@ -206,44 +178,41 @@ $themes: (
     @if $color-scheme {
       color-scheme: #{$color-scheme};
     }
+  } @else {
+    @error "Theme does not exist in themes map: #{$theme}";
   }
 }
 
 /// Output all the custom properties and values of every theme in the provided 
-/// $themes map or pass a custom themes map. Each theme will be wrapped in their
-/// own selector using the set $theme-prefix. The $root-selector is used to wrap
-/// the $theme-default. Themes named "light" or "dark" are also output in the
-/// `prefers-color-scheme` media query.
+/// $themes map or pass a specific component name to output. Each theme will be 
+/// wrapped in their own selector using the set $theme-prefix and theme key. The
+/// $root-selector is used to wrap the $theme-default. Themes named "light" or
+/// "dark" are also output in the `prefers-color-scheme` media query.
 /// @example
 ///   @include theme.output-themes();
-/// @example - Output the custom properties of a custom themes map.
-///   $custom-themes: (
-///     "blue": (),
-///     "green": (),
-///     ...
-///   );
-///   @include theme.output-themes($custom-themes);
+/// @example - Output the custom properties of the notice component.
+///   @include theme.output-themes("notice");
 /// @output
 ///   Custom properties with their associated values of a theme wrapped with
 ///   their associated theme classes.
-/// @param {Map} $themes [$themes] - The themes map containing all themes to output.
+/// @param {String} $component [null] - The name of component themes to output.
 /// @require {Mixin} output - Used internally to output individual themes.
-@mixin output-themes($themes: $themes) {
+@mixin output-themes($component: null) {
   // Output the default theme in the root selector.
   #{$root-selector} {
-    @include output();
+    @include output($theme-default, $component);
   
     // If the default them is not light mode, output the prefers light media query.
     @if $theme-default != 'light' {
       @media (prefers-color-scheme: light) {
-        @include output("light");
+        @include output("light", $component);
       }
     }
     
     // If the default them is not dark mode, output the prefers dark media query.
     @if $theme-default != 'dark' {
       @media (prefers-color-scheme: dark) {
-        @include output("dark");
+        @include output("dark", $component);
       }
     }
   }
@@ -251,7 +220,7 @@ $themes: (
   // Run the output function on all 
   @each $key, $value in $themes {
     .#{$theme-prefix}#{$key} {
-      @include output($key);
+      @include output($key, $component);
     }
   }
 }

--- a/packages/core/src/scss/_theme.scss
+++ b/packages/core/src/scss/_theme.scss
@@ -6,15 +6,17 @@
 @use "./prefix";
 @use "./palette";
 
-/// Set the prefix for custom properties.
+/// Prefix for custom properties.
 /// @access private
 /// @alias prefix.$variable
 /// @type String
 $_v: prefix.$variable;
 
-/// Set the prefix for theme classes.
+/// Prefix for theme classes.
+/// @access private
+/// @alias prefix.$theme
 /// @type String
-$theme-prefix: prefix.$theme !default;
+$_t: prefix.$theme;
 
 /// Set the default theme. Should match an existing theme in the $themes map.
 /// @type String
@@ -22,11 +24,12 @@ $theme-default: "light" !default;
 
 /// CSS selector to use for outputting the root CSS custom properties.
 /// @type String
-$root-selector: ":root, .#{$theme-prefix}root" !default;
+$root-selector: ":root, .#{$_t}root" !default;
 
 /// Stores the theme maps used to build theme classes and CSS custom property
 /// output. Each entry should contain the name of the theme along with all its
-/// custom properties and values. Optionally set `color-scheme` property for
+/// custom properties and values. Themes may also contain component maps for
+/// component specific theming. Optionally set `color-scheme` property for
 /// outputting the `color-scheme: (light | dark);` property.
 /// @example
 ///   "high-contrast": (
@@ -204,7 +207,7 @@ $themes: (
 
 /// Output all the custom properties and values of every theme in the provided 
 /// $themes map or pass a specific component name to output. Each theme will be 
-/// wrapped in their own selector using the set $theme-prefix and theme key. The
+/// wrapped in their own selector using the set theme prefix and theme key. The
 /// $root-selector is used to wrap the $theme-default. Themes named "light" or
 /// "dark" are also output in the `prefers-color-scheme` media query.
 /// @example
@@ -238,7 +241,7 @@ $themes: (
   
   // Run the output function on all 
   @each $key, $value in $themes {
-    .#{$theme-prefix}#{$key} {
+    .#{$_t}#{$key} {
       @include output($key, $component);
     }
   }

--- a/packages/core/src/scss/_theme.scss
+++ b/packages/core/src/scss/_theme.scss
@@ -20,7 +20,7 @@ $_t: prefix.$theme;
 
 /// Set the default theme. Should match an existing theme in the $themes map.
 /// @type String
-$theme-default: "light" !default;
+$default: "light" !default;
 
 /// CSS selector to use for outputting the root CSS custom properties.
 /// @type String
@@ -98,7 +98,7 @@ $themes: (
 /// @require {Variable} $themes
 /// @return {CSS Var} - The var() CSS function with the value of the requested custom property.
 @function get($args...) {
-  @if map.has-key($themes, $theme-default, $args...) {
+  @if map.has-key($themes, $default, $args...) {
     // Initial prop value and override if two arguments are passed.
     $prop: #{list.nth($args, 1)};
     @if list.length($args) == 2 {
@@ -106,7 +106,7 @@ $themes: (
     }
 
     // Get the fallback value.
-    $fallback: map.get($themes, $theme-default, $args...);
+    $fallback: map.get($themes, $default, $args...);
 
     // Return var() CSS function with the a fallback value.
     @if $fallback {
@@ -115,7 +115,7 @@ $themes: (
       @return var(--#{$_v}#{$prop});
     }
   } @else {
-    @error "Property does not exist in the default theme: (#{$theme-default}, #{$args})";
+    @error "Property does not exist in the default theme: (#{$default}, #{$args})";
   }
 }
 
@@ -166,9 +166,9 @@ $themes: (
 /// @example - Output the custom properties of the light theme for the button component.
 ///   @include theme.output("light", "button");
 /// @output Custom properties with their associated values of a theme.
-/// @param {String} $theme [$theme-default] - The theme name to output.
+/// @param {String} $theme [$default] - The theme name to output.
 /// @param {String} $component [null] - The name of component themes to output.
-@mixin output($theme: $theme-default, $component: null) {
+@mixin output($theme: $default, $component: null) {
   // Check if the key exists on the provided $themes map.
   @if map.has-key($themes, $theme) {
 
@@ -215,7 +215,7 @@ $themes: (
 /// Output all the custom properties and values of every theme in the provided 
 /// $themes map or pass a specific component name to output. Each theme will be 
 /// wrapped in their own selector using the set theme prefix and theme key. The
-/// $root-selector is used to wrap the $theme-default. Themes named "light" or
+/// $root-selector is used to wrap the $default. Themes named "light" or
 /// "dark" are also output in the `prefers-color-scheme` media query.
 /// @example
 ///   @include theme.output-themes();
@@ -229,17 +229,17 @@ $themes: (
 @mixin output-themes($component: null) {
   // Output the default theme in the root selector.
   #{$root-selector} {
-    @include output($theme-default, $component);
+    @include output($default, $component);
   
     // If the default them is not light mode, output the prefers light media query.
-    @if $theme-default != 'light' {
+    @if $default != 'light' {
       @media (prefers-color-scheme: light) {
         @include output("light", $component);
       }
     }
     
     // If the default them is not dark mode, output the prefers dark media query.
-    @if $theme-default != 'dark' {
+    @if $default != 'dark' {
       @media (prefers-color-scheme: dark) {
         @include output("dark", $component);
       }

--- a/packages/core/src/scss/_theme.scss
+++ b/packages/core/src/scss/_theme.scss
@@ -87,7 +87,7 @@ $themes: (
   @if map.has-key($themes, $theme-default, $args...) {
     // Initial prop value and override if two arguments are passed.
     $prop: #{list.nth($args, 1)};
-    @if length($args) == 2 {
+    @if list.length($args) == 2 {
       $prop: #{list.nth($args, 1)}-#{list.nth($args, 2)};
     }
 
@@ -105,7 +105,26 @@ $themes: (
 /// @param {String} $args... - The property keys and value to set.
 /// @require {Variable} $themes
 @mixin set($args...) {
-  $themes: map.set($themes, $args...) !global;
+  // Get the last item in the $args list.
+  $value: list.nth($args, -1);
+
+  // Get the props list.
+  $props: fun.remove-nth($args, -1);
+
+  // If the value is replacing a map, handle the deep-merge.
+  @if (meta.type-of($value) == "map") {
+    $new: $value;
+    $old: map.get($themes, $props...);
+    @if (meta.type-of($old) == "map") {
+      $new: map.deep-merge($old, $value);
+    }
+    $themes: map.set($themes, list.append($props, $new)...) !global;
+  }
+  
+  // Otherwise, just add the value using the $args list.
+  @else {
+    $themes: map.set($themes, $args...) !global;
+  }
 }
 
 /// Remove a custom property in the $themes map.

--- a/packages/core/src/scss/_theme.scss
+++ b/packages/core/src/scss/_theme.scss
@@ -158,22 +158,6 @@ $themes: (
   $themes: map.deep-remove($themes, $args...) !global;
 }
 
-/// Allows adding a custom map of property and value pairs to a theme in the
-/// $themes map.
-/// @example - Add a custom prop/value map as the dark theme.
-///   @include theme.add("dark", (
-///     "background": black,
-///     "foreground": white,
-///     "color-scheme": dark
-///   ));
-/// @output N/A
-/// @param {String} $name - The theme name to add.
-/// @param {Map} $map - The map of property/value pairs to add to the provided theme.
-/// @require {Variable} $themes
-@mixin add($name, $map) {
-  $themes: map.deep-merge($themes, ($name: $map)) !global;
-}
-
 /// Output all the custom properties and values of a theme or a component theme.
 /// @example - Output the custom properties of the default theme.
 ///   @include theme.output();

--- a/packages/core/src/scss/_theme.scss
+++ b/packages/core/src/scss/_theme.scss
@@ -31,12 +31,23 @@ $root-selector: ":root, .#{$_t}root" !default;
 /// custom properties and values. Themes may also contain component maps for
 /// component specific theming. Optionally set `color-scheme` property for
 /// outputting the `color-scheme: (light | dark);` property.
-/// @example
+/// @example - Themes map with a high-contrast theme.
 ///   "high-contrast": (
 ///     "background": white,
 ///     "foreground": black,
 ///     ...
-///   )
+///   );
+/// @example - Themes map with a component theme.
+///   "dark": (
+///     "background": teal,
+///     "foreground": pink,
+///     ...
+///     "button": (
+///       "background": gray,
+///       "foreground": blue,
+///       ...
+///     )
+///   );
 /// @prop {Map} name - The name of the theme (key) and a map of property/value pairs.
 /// @prop {Any} name.prop - The name of the custom property and its value.
 /// @type Map
@@ -78,7 +89,7 @@ $themes: (
 ) !default;
 
 /// Function to return the CSS variable with fallback of an entry within the
-/// $themes map.
+/// $themes map. Requested property must exist in the default theme.
 /// @example - Return the background var() from the dark theme.
 ///   background: theme.get("dark", "background");
 /// @example - Return the foreground var() from the card dark theme.

--- a/packages/core/src/scss/_theme.scss
+++ b/packages/core/src/scss/_theme.scss
@@ -108,7 +108,7 @@ $themes: (
     // Return var() CSS function with the a fallback value.
     @return var(--#{$_v}#{$prop}, map.get($themes, $theme-default, $args...));
   } @else {
-    @error "Property does not exist in the default theme: #{$args}";
+    @error "Property does not exist in the default theme: (#{$theme-default}, #{$args})";
   }
 }
 

--- a/packages/core/src/scss/_theme.scss
+++ b/packages/core/src/scss/_theme.scss
@@ -91,9 +91,9 @@ $themes: (
 /// Function to return the CSS variable with fallback of an entry within the
 /// $themes map. Requested property must exist in the default theme.
 /// @example - Return the background var() from the dark theme.
-///   background: theme.get("dark", "background");
+///   background: theme.get("background");
 /// @example - Return the foreground var() from the card dark theme.
-///   background: theme.get("dark", "card", "background");
+///   background: theme.get("card", "background");
 /// @param {String} $args... - The property key to return.
 /// @require {Variable} $themes
 /// @return {CSS Var} - The var() CSS function with the value of the requested custom property.

--- a/packages/core/src/scss/_theme.scss
+++ b/packages/core/src/scss/_theme.scss
@@ -105,8 +105,15 @@ $themes: (
       $prop: #{list.nth($args, 1)}-#{list.nth($args, 2)};
     }
 
+    // Get the fallback value.
+    $fallback: map.get($themes, $theme-default, $args...);
+
     // Return var() CSS function with the a fallback value.
-    @return var(--#{$_v}#{$prop}, map.get($themes, $theme-default, $args...));
+    @if $fallback {
+      @return var(--#{$_v}#{$prop}, $fallback);
+    } @else {
+      @return var(--#{$_v}#{$prop});
+    }
   } @else {
     @error "Property does not exist in the default theme: (#{$theme-default}, #{$args})";
   }
@@ -180,6 +187,7 @@ $themes: (
 @mixin output($theme: $theme-default, $component: null) {
   // Check if the key exists on the provided $themes map.
   @if map.has-key($themes, $theme) {
+
     // Initial color scheme variable.
     $color-scheme: null;
 
@@ -189,20 +197,24 @@ $themes: (
       $map: map.get($themes, $theme, $component);
     }
 
-    // Loop through all theme entries and output their custom properties.
-    @each $key, $value in $map {
-      @if meta.type-of($value) != 'map' {
-        // Initial prop value and override if two arguments are passed.
-        $prop: --#{$_v}#{$key};
-        @if $component {
-          $prop: --#{$_v}#{$component}-#{$key};
-        }
+    // If a map exists...
+    @if $map {
+      // Loop through all theme entries and output their custom properties.
+      @each $key, $value in $map {
+        // Check if a value exists and if it's not a map.
+        @if $value and meta.type-of($value) != 'map' {
+          // Initial prop value and override if two arguments are passed.
+          $prop: --#{$_v}#{$key};
+          @if $component {
+            $prop: --#{$_v}#{$component}-#{$key};
+          }
 
-        // Output property or store the color scheme.
-        @if $key != 'color-scheme' {
-          #{$prop}: #{$value};
-        } @else {
-          $color-scheme: #{$value};
+          // Output property or store the color scheme.
+          @if $key != 'color-scheme' {
+            #{$prop}: #{$value};
+          } @else {
+            $color-scheme: #{$value};
+          }
         }
       }
     }

--- a/packages/notice/index.html
+++ b/packages/notice/index.html
@@ -49,6 +49,22 @@
           <p>notice vb-theme-dark</p>
         </div>
 
+        <div class="notice notice_theme_primary">
+          <p>notice notice_theme_primary</p>
+        </div>
+
+        <div class="notice notice_theme_secondary">
+          <p>notice notice_theme_secondary</p>
+        </div>
+
+        <div class="notice notice_theme_neutral">
+          <p>notice notice_theme_neutral</p>
+        </div>
+
+        <div class="notice notice_theme_important">
+          <p>notice notice_theme_important</p>
+        </div>
+
       </div>
     </section>
   </main>

--- a/packages/notice/index.html
+++ b/packages/notice/index.html
@@ -38,31 +38,15 @@
       <div class="section__container max-width-xs gap-y">
 
         <div class="notice">
-          <p>...</p>
+          <p>notice</p>
         </div>
 
         <div class="notice vb-theme-light">
-          <p>...</p>
+          <p>notice vb-theme-light</p>
         </div>
 
         <div class="notice vb-theme-dark">
-          <p>...</p>
-        </div>
-
-        <div class="notice notice_theme_primary">
-          <p>...</p>
-        </div>
-
-        <div class="notice notice_theme_secondary">
-          <p>...</p>
-        </div>
-
-        <div class="notice notice_theme_neutral">
-          <p>...</p>
-        </div>
-
-        <div class="notice notice_theme_important">
-          <p>...</p>
+          <p>notice vb-theme-dark</p>
         </div>
 
       </div>

--- a/packages/notice/index.html
+++ b/packages/notice/index.html
@@ -37,7 +37,33 @@
     <section class="section">
       <div class="section__container max-width-xs gap-y">
 
-        <p>...</p>
+        <div class="notice">
+          <p>...</p>
+        </div>
+
+        <div class="notice vb-theme-light">
+          <p>...</p>
+        </div>
+
+        <div class="notice vb-theme-dark">
+          <p>...</p>
+        </div>
+
+        <div class="notice notice_theme_primary">
+          <p>...</p>
+        </div>
+
+        <div class="notice notice_theme_secondary">
+          <p>...</p>
+        </div>
+
+        <div class="notice notice_theme_neutral">
+          <p>...</p>
+        </div>
+
+        <div class="notice notice_theme_important">
+          <p>...</p>
+        </div>
 
       </div>
     </section>

--- a/packages/notice/index.scss
+++ b/packages/notice/index.scss
@@ -1,3 +1,4 @@
 @forward "./src/variables";
 @forward "./src/notice";
 @forward "./src/notice_theme";
+@forward "./src/root";

--- a/packages/notice/src/_notice.scss
+++ b/packages/notice/src/_notice.scss
@@ -5,10 +5,19 @@
 $_b: var.$prefix-block;
 $_e: var.$prefix-element;
 
-@include theme.set("light", "notice", "background", blue);
-@include theme.set("light", "notice", "foreground", white);
-@include theme.set("dark", "notice", "background", green);
-@include theme.set("dark", "notice", "foreground", white);
+@include theme.set("light", "notice", "background", teal);
+@include theme.set("light", "notice", "foreground", yellow);
+@include theme.set("light", "notice", "border", 1px solid orange);
+
+@include theme.set("light", "notice", (
+  "background": pink,
+  "foreground": teal
+));
+
+@include theme.set("dark", "notice", (
+  "background": teal,
+  "foreground": pink
+));
 
 .#{$_b}notice {
   @include core.gap(var.$gap, "y");

--- a/packages/notice/src/_notice.scss
+++ b/packages/notice/src/_notice.scss
@@ -16,8 +16,8 @@ $_e: var.$prefix-element;
   border: var.$border;
   border-radius: var.$border-radius;
   background: theme.get("notice", "background");
-  color: theme.get("notice", "foreground");
   box-shadow: var.$shadow;
+  color: theme.get("notice", "foreground");
 }
 
 .#{$_b}notice#{$_e}title {

--- a/packages/notice/src/_notice.scss
+++ b/packages/notice/src/_notice.scss
@@ -1,15 +1,22 @@
+@use "@vrembem/core/theme";
 @use "@vrembem/core";
 @use "./variables" as var;
 
 $_b: var.$prefix-block;
 $_e: var.$prefix-element;
 
+@include theme.set("light", "notice", "background", blue);
+@include theme.set("light", "notice", "foreground", white);
+@include theme.set("dark", "notice", "background", green);
+@include theme.set("dark", "notice", "foreground", white);
+
 .#{$_b}notice {
   @include core.gap(var.$gap, "y");
   padding: var.$padding;
   border: var.$border;
   border-radius: var.$border-radius;
-  background: var.$background;
+  background: theme.get("notice", "background");
+  color: theme.get("notice", "foreground");
   box-shadow: var.$shadow;
 }
 

--- a/packages/notice/src/_notice.scss
+++ b/packages/notice/src/_notice.scss
@@ -1,31 +1,17 @@
-@use "@vrembem/core/theme";
 @use "@vrembem/core";
+@use "@vrembem/core/theme";
 @use "./variables" as var;
 
 $_b: var.$prefix-block;
 $_e: var.$prefix-element;
 
-@include theme.set("light", "notice", "background", teal);
-@include theme.set("light", "notice", "foreground", yellow);
-@include theme.set("light", "notice", "border", 1px solid orange);
-
-@include theme.set("light", "notice", (
-  "background": pink,
-  "foreground": teal
-));
-
-@include theme.set("dark", "notice", (
-  "background": teal,
-  "foreground": pink
-));
-
 .#{$_b}notice {
   @include core.gap(var.$gap, "y");
   padding: var.$padding;
-  border: var.$border;
+  border: theme.get("notice", "border");
   border-radius: var.$border-radius;
   background: theme.get("notice", "background");
-  box-shadow: var.$shadow;
+  box-shadow: theme.get("notice", "shadow");
   color: theme.get("notice", "foreground");
 }
 

--- a/packages/notice/src/_root.scss
+++ b/packages/notice/src/_root.scss
@@ -1,0 +1,3 @@
+@use "@vrembem/core/theme";
+
+@include theme.output-themes("notice");

--- a/packages/notice/src/_variables.scss
+++ b/packages/notice/src/_variables.scss
@@ -8,12 +8,15 @@ $prefix-modifier-value: core.$prefix-modifier-value !default;
 
 $gap: 0.5em !default;
 $padding: 1em !default;
-$border: null !default;
 $border-radius: core.$border-radius !default;
-$background: theme.get("background-dark") !default;
-$shadow: null !default;
 
-// notice__title
 $title-font-size: core.$font-size-lg !default;
 $title-font-weight: core.$font-weight-semi-bold !default;
 $title-line-height: core.$line-height-lg !default;
+
+@include theme.set(theme.$theme-default, "notice", (
+  "background": theme.get("background-dark"),
+  "foreground": theme.get("foreground"),
+  "border": null,
+  "shadow": null
+));

--- a/packages/notice/src/_variables.scss
+++ b/packages/notice/src/_variables.scss
@@ -14,9 +14,11 @@ $title-font-size: core.$font-size-lg !default;
 $title-font-weight: core.$font-weight-semi-bold !default;
 $title-line-height: core.$line-height-lg !default;
 
-@include theme.set(theme.$theme-default, "notice", (
+$theme: (
   "background": theme.get("background-dark"),
   "foreground": theme.get("foreground"),
   "border": null,
   "shadow": null
-));
+) !default;
+
+@include theme.set(theme.$theme-default, "notice", $theme);

--- a/packages/notice/src/_variables.scss
+++ b/packages/notice/src/_variables.scss
@@ -21,4 +21,4 @@ $theme: (
   "shadow": null
 ) !default;
 
-@include theme.set(theme.$theme-default, "notice", $theme);
+@include theme.set(theme.$default, "notice", $theme);

--- a/packages/vrembem/index.scss
+++ b/packages/vrembem/index.scss
@@ -1,5 +1,4 @@
 @forward "@vrembem/core" as core-*;
-@forward "@vrembem/core/root";
 @forward "@vrembem/base" as base-*;
 @forward "@vrembem/button" as button-*;
 @forward "@vrembem/card" as card-*;
@@ -20,3 +19,4 @@
 @forward "@vrembem/switch" as switch-*;
 @forward "@vrembem/table" as table-*;
 @forward "@vrembem/utility" as utility-*;
+@forward "@vrembem/core/root";


### PR DESCRIPTION
## What changed?

This PR is a re-write of the themes module to allow it to handle component theming using the `$themes` map and related mixins/functions. With this update, most theme module mixins and the get function can now take a `$component` argument for component theme operations.