### PR TITLE
Add "Suggest changes to this page" link to bottom of content

### DIFF
--- a/docs/src/components/CollectionPagi.astro
+++ b/docs/src/components/CollectionPagi.astro
@@ -19,28 +19,25 @@ entries.find((entry, index) => {
 });
 ---
 
-<div class="pagi-container">
-  <hr class="sep" />
-  <div class="pagi">
-    <div class="pagi_prev">
-      {
-        pagi.prev && (
-          <a class="pagi_link" href={`/${collection}/${pagi.prev.slug}`}>
-            <div class="pagi_label">Previous</div>
-            <div class="pagi_title">{pagi.prev.data.title}</div>
-          </a>
-        )
-      }
-    </div>
-    <div class="pagi_next">
-      {
-        pagi.next && (
-          <a class="pagi_link" href={`/${collection}/${pagi.next.slug}`}>
-            <div class="pagi_label">Next</div>
-            <div class="pagi_title">{pagi.next.data.title}</div>
-          </a>
-        )
-      }
-    </div>
+<div class="pagi">
+  <div class="pagi_prev">
+    {
+      pagi.prev && (
+        <a class="pagi_link" href={`/${collection}/${pagi.prev.slug}`}>
+          <div class="pagi_label">Previous</div>
+          <div class="pagi_title">{pagi.prev.data.title}</div>
+        </a>
+      )
+    }
+  </div>
+  <div class="pagi_next">
+    {
+      pagi.next && (
+        <a class="pagi_link" href={`/${collection}/${pagi.next.slug}`}>
+          <div class="pagi_label">Next</div>
+          <div class="pagi_title">{pagi.next.data.title}</div>
+        </a>
+      )
+    }
   </div>
 </div>

--- a/docs/src/components/LinkEditPage.astro
+++ b/docs/src/components/LinkEditPage.astro
@@ -3,13 +3,20 @@ import Icon from "./Icon.vue";
 
 interface Props {
   dir?: string;
+  filename?: string;
   ext?: string;
 }
 
 const { dir = "content", ext = ".mdx" } = Astro.props;
 
+let { filename = "" } = Astro.props;
+
+if (filename) {
+  filename = "/" + filename;
+}
+
 const ghPath = "https://github.com/sebnitu/vrembem/blob/next/docs/src/";
-const url = `${ghPath}${dir}${Astro.url.pathname}${ext}`;
+const url = `${ghPath}${dir}${Astro.url.pathname}${filename}${ext}`;
 ---
 
 <a

--- a/docs/src/components/LinkEditPage.astro
+++ b/docs/src/components/LinkEditPage.astro
@@ -1,0 +1,22 @@
+---
+import Icon from "./Icon.vue";
+
+interface Props {
+  dir?: string;
+  ext?: string;
+}
+
+const { dir = "content", ext = ".mdx" } = Astro.props;
+
+const ghPath = "https://github.com/sebnitu/vrembem/blob/next/docs/src/";
+const url = `${ghPath}${dir}${Astro.url.pathname}${ext}`;
+---
+
+<a
+  href={url}
+  target="_blank"
+  class="link flex-inline flex-align-center gap-x-sm"
+>
+  <Icon name="edit" iconClass="icon_size_sm" />
+  <span>Suggest changes to this page</span>
+</a>

--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -16,6 +16,11 @@ interface Props {
 }
 
 const { title, layout = {} } = Astro.props;
+
+const ghPath = "https://github.com/sebnitu/vrembem/blob/next/docs/src/";
+const dir = "content"; // TODO: Check if it's a collection. Use 'content' else 'pages'.
+const ext = ".mdx";
+console.log(`${ghPath}${dir}${Astro.url.pathname}${ext}`);
 ---
 
 <Root {title} {layout}>

--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -55,11 +55,23 @@ const { title, layout = {} } = Astro.props;
               </div>
             )
           }
-          <slot name="prepend" />
+          {
+            Astro.slots.has("prepend") && (
+              <div class="layout__prepend">
+                <slot name="prepend" />
+              </div>
+            )
+          }
           <div class="type gap-y">
             <slot />
           </div>
-          <slot name="append" />
+          {
+            Astro.slots.has("append") && (
+              <div class="layout__append">
+                <slot name="append" />
+              </div>
+            )
+          }
         </div>
         <Footer classes="layout__footer" />
       </div>

--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -16,11 +16,6 @@ interface Props {
 }
 
 const { title, layout = {} } = Astro.props;
-
-const ghPath = "https://github.com/sebnitu/vrembem/blob/next/docs/src/";
-const dir = "content"; // TODO: Check if it's a collection. Use 'content' else 'pages'.
-const ext = ".mdx";
-console.log(`${ghPath}${dir}${Astro.url.pathname}${ext}`);
 ---
 
 <Root {title} {layout}>

--- a/docs/src/layouts/Page.astro
+++ b/docs/src/layouts/Page.astro
@@ -37,7 +37,7 @@ const layout = {
       </div>
     )
   }
-  <div slot="prepend">
+  <div slot="append">
     <LinkEditPage dir="pages" {filename} />
   </div>
   <slot />

--- a/docs/src/layouts/Page.astro
+++ b/docs/src/layouts/Page.astro
@@ -14,7 +14,7 @@ interface Props {
 
 const entries = await getCollection("packages");
 const { headings } = Astro.props;
-const { title, collection } = Astro.props.frontmatter || Astro.props;
+const { title, collection, filename } = Astro.props.frontmatter || Astro.props;
 
 const layout = {
   hasDrawer: !!collection,
@@ -38,7 +38,7 @@ const layout = {
     )
   }
   <div slot="prepend">
-    <LinkEditPage dir="pages" />
+    <LinkEditPage dir="pages" {filename} />
   </div>
   <slot />
 </Base>

--- a/docs/src/layouts/Page.astro
+++ b/docs/src/layouts/Page.astro
@@ -4,6 +4,7 @@ import { getCollection } from "astro:content";
 import Base from "./Base.astro";
 import Navi from "../components/CollectionNavi.astro";
 import OnThisPage from "../components/OnThisPage.astro";
+import LinkEditPage from "../components/LinkEditPage.astro";
 
 interface Props {
   entry: CollectionEntry<"packages">;
@@ -36,6 +37,9 @@ const layout = {
       </div>
     )
   }
+  <div slot="prepend">
+    <LinkEditPage dir="pages" />
+  </div>
   <slot />
 </Base>
 

--- a/docs/src/pages/packages/[slug].astro
+++ b/docs/src/pages/packages/[slug].astro
@@ -39,8 +39,9 @@ const layout = {
     <OnThisPage {headings} />
   </div>
   <Content components={{ pre: Pre, table: Table }} />
-  <div slot="append">
+  <div slot="append" class="gap-y-xl">
     <LinkEditPage />
+    <hr class="sep" />
     <Pagi {entries} collection="packages" />
   </div>
 </Base>

--- a/docs/src/pages/packages/[slug].astro
+++ b/docs/src/pages/packages/[slug].astro
@@ -5,6 +5,7 @@ import Base from "../../layouts/Base.astro";
 import Navi from "../../components/CollectionNavi.astro";
 import Pagi from "../../components/CollectionPagi.astro";
 import OnThisPage from "../../components/OnThisPage.astro";
+import LinkEditPage from "../../components/LinkEditPage.astro";
 import Pre from "../../components/Pre.astro";
 import Table from "../../components/Table.astro";
 
@@ -39,6 +40,7 @@ const layout = {
   </div>
   <Content components={{ pre: Pre, table: Table }} />
   <div slot="append">
+    <LinkEditPage />
     <Pagi {entries} collection="packages" />
   </div>
 </Base>

--- a/docs/src/pages/packages/index.mdx
+++ b/docs/src/pages/packages/index.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/Page.astro
 title: Packages
 collection: packages
+filename: index
 ---
 
 # Packages

--- a/docs/src/styles/_layout.scss
+++ b/docs/src/styles/_layout.scss
@@ -1,3 +1,4 @@
+@use "@vrembem/core";
 @use "./root";
 
 .layout {
@@ -71,6 +72,30 @@
 
   @media (min-width: root.$bp-aside) {
     width: calc(100% - (var(--vb-aside-width) + 4rem));
+  }
+}
+
+.layout__prepend {
+  margin-bottom: 2rem;
+
+  @include core.media-min("md") {
+    margin-bottom: 3rem;
+  }
+
+  @include core.media-min("lg") {
+    margin-bottom: 4rem;
+  }
+}
+
+.layout__append {
+  margin-top: 2rem;
+
+  @include core.media-min("md") {
+    margin-top: 3rem;
+  }
+
+  @include core.media-min("lg") {
+    margin-top: 4rem;
   }
 }
 

--- a/docs/src/styles/_pagi.scss
+++ b/docs/src/styles/_pagi.scss
@@ -2,22 +2,6 @@
 @use "@vrembem/core/theme";
 @use "@vrembem/core";
 
-.pagi-container {
-  margin: 2rem 0 0;
-
-  .sep {
-    margin: 2rem 0;
-  }
-
-  @include core.media-min("md") {
-    margin: 3rem 0 0;
-  }
-
-  @include core.media-min("lg") {
-    margin: 4rem 0 0;
-  }
-}
-
 .pagi {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What changed?

This PR adds the a new "Suggest changes to this page" link at the bottom of content pages allowing users to make suggestions for changes on GitHub for documentation pages. This is rendered using the updated `append` layout slot and is either displayed by itself or above the page navigation component.