### PR TITLE
Add missing component value in astro directive

### DIFF
--- a/docs/src/components/Navibar.astro
+++ b/docs/src/components/Navibar.astro
@@ -32,7 +32,7 @@ const { classes = "" } = Astro.props;
   </div>
 </header>
 
-<Modal client:only id="modal-navi" modalClass="modal_pos_top">
+<Modal client:only="vue" id="modal-navi" modalClass="modal_pos_top">
   <div class="dialog__header">
     <h2 class="dialog__title">Menu</h2>
     <button data-modal-close class="button button_icon dialog__close">


### PR DESCRIPTION
## What changed?

This PR adds a missing framework value to the modal component and `client:only` directive.