### PR TITLE
Update checkbox documentation and expanded documentation features

### DIFF
--- a/docs/src/components/CodeExample.astro
+++ b/docs/src/components/CodeExample.astro
@@ -1,9 +1,11 @@
 ---
 interface Props {
   lang?: string;
+  tabs?: boolean;
 }
 
-const { lang = "html" } = Astro.props;
+const { lang = "html", tabs = false } = Astro.props;
+const uid = JSON.stringify(Math.floor(Math.random() * Date.now()));
 ---
 
 <div class="code-example">
@@ -14,8 +16,85 @@ const { lang = "html" } = Astro.props;
       </div>
     )
   }
-  <div class="code-example__input">
-    <div class="code-example__toolbar">{lang}</div>
-    <slot />
-  </div>
+
+  {
+    !tabs ? (
+      <div class="code-example__toolbar">{lang}</div>
+      <div class="code-example__input">
+        <slot />
+      </div>
+    ) : (
+      <div 
+        class="code-example__toolbar" 
+        role="tablist" 
+        aria-label="Code examples">
+        {
+          Astro.slots.has("tab-html") && (
+          <button 
+            class="tab"
+            id={`tab-html-${uid}`}
+            role="tab"
+            aria-controls={`tabpanel-html-${uid}`}
+            aria-selected="false">HTML</button>
+            )
+        }
+        {
+          Astro.slots.has("tab-scss") && (
+          <button 
+            class="tab"
+            id={`tab-scss-${uid}`}
+            role="tab"
+            aria-controls={`tabpanel-scss-${uid}`}
+            aria-selected="false">SCSS</button>
+            )
+        }
+        {
+          Astro.slots.has("tab-js") && (
+          <button 
+            class="tab"
+            id={`tab-js-${uid}`}
+            role="tab"
+            aria-controls={`tabpanel-js-${uid}`}
+            aria-selected="false"
+            tabindex="-1">JS</button>
+          )
+        }
+      </div>
+    )
+  }
+
+  {
+    Astro.slots.has("tab-html") && (
+      <div
+        class="code-example__input"
+        id={`tabpanel-html-${uid}`}
+        role="tabpanel"
+        aria-labelledby={`tab-html-${uid}`}>
+        <slot name="tab-html" />
+      </div>
+    )
+  }
+  {
+    Astro.slots.has("tab-scss") && (
+      <div
+        class="code-example__input"
+        id={`tabpanel-scss-${uid}`}
+        role="tabpanel"
+        aria-labelledby={`tab-scss-${uid}`}>
+        <slot name="tab-scss" />
+      </div>
+    )
+  }
+  {
+    Astro.slots.has("tab-js") && (
+      <div
+        class="code-example__input"
+        id={`tabpanel-js-${uid}`}
+        role="tabpanel"
+        aria-labelledby={`tab-js-${uid}`}>
+        <slot name="tab-js" />
+      </div>
+    )
+  }
+
 </div>

--- a/docs/src/components/DocBlock.astro
+++ b/docs/src/components/DocBlock.astro
@@ -7,11 +7,12 @@ interface Props {
   type?: string;
   returns?: string;
   src?: string;
+  line?: string;
   args?: Array<Array<string>>;
   open?: boolean;
 }
 
-const { name, type, returns, src, args, open = false } = Astro.props;
+const { name, type, returns, src, line, args, open = false } = Astro.props;
 const id = makeSafeForCSS(`${name}-${type}`);
 const isFile = (type === 'file');
 ---
@@ -35,7 +36,7 @@ const isFile = (type === 'file');
       <div class="media__body flex flex-align-center flex-gap-x flex-wrap">
         <h3 id={id} class="foreground flex-grow-1">{name}</h3>
         <code>
-          <a class="link font-size-sm" target="_blank" href={`https://github.com/sebnitu/vrembem/blob/next/packages/${src}`}>
+          <a class="link font-size-sm" target="_blank" href={`https://github.com/sebnitu/vrembem/blob/next/packages/${src}${(line) ? `#L${line}` : ''}`}>
             {src}
           </a>
         </code>

--- a/docs/src/components/DocBlock.astro
+++ b/docs/src/components/DocBlock.astro
@@ -5,12 +5,13 @@ import { makeSafeForCSS } from "../modules/makeSafeForCSS";
 interface Props {
   name?: string;
   type?: string;
+  returns?: string;
   src?: string;
   args?: Array<Array<string>>;
   open?: boolean;
 }
 
-const { name, type, src, args, open = false } = Astro.props;
+const { name, type, returns, src, args, open = false } = Astro.props;
 const id = makeSafeForCSS(`${name}-${type}`);
 const isFile = (type === 'file');
 ---
@@ -55,7 +56,18 @@ const isFile = (type === 'file');
         </div>
       ) : (
         <div class="doc-block__intro">
-          <p>Type: <code>{type}</code></p>
+          <div class="doc-block__meta">
+            { 
+              type && (
+                <span>Type: <code>{type}</code></span>
+              )
+            }
+            { 
+              returns && (
+                <span>Returns: <code>{returns}</code></span>
+              )
+            }
+          </div>
           <slot />
         </div>
       )

--- a/docs/src/content/packages/button.mdx
+++ b/docs/src/content/packages/button.mdx
@@ -305,7 +305,7 @@ Buttons are primarily customized using CSS variables but can also be modified us
 
     ```scss
     .button-custom {
-      @include mix.button-variant(white, "secondary");
+      @include button-variant(white, "secondary");
     }
 
     // CSS Output

--- a/docs/src/content/packages/checkbox.mdx
+++ b/docs/src/content/packages/checkbox.mdx
@@ -237,7 +237,7 @@ Checkboxes are primarily customized using CSS variables but can also be modified
   ```
 </DocBlock>
 
-<DocBlock name="icon-check" type="function" returns="string" src="checkbox/src/_functions.scss" args={[
+<DocBlock name="icon-check" type="function" returns="string" src="checkbox/src/_functions.scss" line="9" args={[
   ["$size", "Number (with unit)", "Value for width and height attributes"],
   ["$color", "Color", "Value for stroke attribute"],
   ["$stroke", "Number (unitless)", "Value for stroke-width attribute"]
@@ -259,7 +259,7 @@ Checkboxes are primarily customized using CSS variables but can also be modified
   </Fragment>
 </DocBlock>
 
-<DocBlock name="icon-minus" type="function" returns="string" src="checkbox/src/_functions.scss" args={[
+<DocBlock name="icon-minus" type="function" returns="string" src="checkbox/src/_functions.scss" line="19" args={[
   ["$size", "Number (with unit)", "Value for width and height attributes"],
   ["$color", "Color", "Value for stroke attribute"],
   ["$stroke", "Number (unitless)", "Value for stroke-width attribute"]

--- a/docs/src/content/packages/checkbox.mdx
+++ b/docs/src/content/packages/checkbox.mdx
@@ -201,9 +201,9 @@ Checkboxes are primarily customized using CSS variables but can also be modified
   $transition-timing-function: core.$transition-timing-function !default;
 
   $background: transparent !default;
-  $background-hover: rgba($color, 0.1) !default;
-  $background-focus: rgba($color, 0.1) !default;
-  $background-active: rgba($color, 0.2) !default;
+  $background-hover: palette.get("primary", 95) !default;
+  $background-focus: palette.get("primary", 95) !default;
+  $background-active: palette.get("primary", 90) !default;
   $background-checked: null !default;
   $background-border-radius: core.$border-radius-circle !default;
 
@@ -235,4 +235,48 @@ Checkboxes are primarily customized using CSS variables but can also be modified
   $size-lg-icon: 18px !default;
   $size-lg-icon-stroke: 2 !default;
   ```
+</DocBlock>
+
+<DocBlock name="icon-check" type="function" returns="string" src="checkbox/src/_functions.scss" args={[
+  ["$size", "Number (with unit)", "Value for width and height attributes"],
+  ["$color", "Color", "Value for stroke attribute"],
+  ["$stroke", "Number (unitless)", "Value for stroke-width attribute"]
+]}>
+  <p>Outputs data image string for check SVG icon. Used as the value of <code>url()</code> in the <code>background-image</code> property.</p>
+
+  <Fragment slot="example">
+
+    ```scss
+    .check-icon {
+      background-image: url("#{icon-check(12px, black, 2.5)}");
+    }
+
+    // CSS Output
+    .check-icon {
+      background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="12px" height="12px" fill="none" stroke="%23000000" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9.5,3 4.5,8.5 2,6"></polyline></svg>');
+    }
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="icon-minus" type="function" returns="string" src="checkbox/src/_functions.scss" args={[
+  ["$size", "Number (with unit)", "Value for width and height attributes"],
+  ["$color", "Color", "Value for stroke attribute"],
+  ["$stroke", "Number (unitless)", "Value for stroke-width attribute"]
+]}>
+  <p>Outputs data image string for minus SVG icon. Used as the value of <code>url()</code> in the <code>background-image</code> property.</p>
+
+  <Fragment slot="example">
+
+    ```scss
+    .minus-icon {
+      background-image: url("#{icon-minus(12px, black, 2.5)}");
+    }
+
+    // CSS Output
+    .minus-icon {
+      background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="12px" height="12px" fill="none" stroke="%23000000" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="2" y1="6" x2="10" y2="6" /></svg>');
+    }
+    ```
+  </Fragment>
 </DocBlock>

--- a/docs/src/content/packages/checkbox.mdx
+++ b/docs/src/content/packages/checkbox.mdx
@@ -4,294 +4,232 @@ description: "Checkboxes allow the user to select multiple options from a set."
 package: "@vrembem/checkbox"
 ---
 
+import CodeExample from '../../components/CodeExample.astro';
+import DocBlock from '../../components/DocBlock.astro';
+
 # Checkbox
 
 Checkboxes allow the user to select multiple options from a set.
-
-[![npm version](https://img.shields.io/npm/v/%40vrembem%2Fcheckbox.svg)](https://www.npmjs.com/package/%40vrembem%2Fcheckbox)
-
-[Documentation](https://vrembem.com/packages/checkbox)
-
-## Installation
 
 ```sh
 npm install @vrembem/checkbox
 ```
 
-### Styles
+<CodeExample lang="scss">
+  ```scss
+  @use "@vrembem/checkbox";
+  ```
+</CodeExample>
 
-```scss
-@use "@vrembem/checkbox";
-```
-
-### JavaScript
-
-```js
-import Checkbox from '@vrembem/checkbox';
-const checkbox = new Checkbox({ autoInit: true });
-```
-
-### Markup
+## Basic usage
 
 Checkboxes are composed using a set of `<span>` elements alongside the native `<input type="checkbox">` element which should be given the `checkbox__native` class and come before the remaining presentational `<span>` elements.
 
-```html
-<span class="checkbox">
-  <input type="checkbox" class="checkbox__native">
-  <span class="checkbox__background">
-    <span class="checkbox__box">
-      <span class="checkbox__icon"></span>
+<CodeExample lang="html">
+  <div slot="output">
+    <span class="checkbox">
+      <input class="checkbox__native" type="checkbox" checked />
+      <span class="checkbox__background">
+        <span class="checkbox__box">
+          <span class="checkbox__icon"></span>
+        </span>
+      </span>
+    </span>
+    <span class="checkbox">
+      <input class="checkbox__native" type="checkbox" aria-checked="mixed" />
+      <span class="checkbox__background">
+        <span class="checkbox__box">
+          <span class="checkbox__icon"></span>
+        </span>
+      </span>
+    </span>
+    <span class="checkbox">
+      <input class="checkbox__native" type="checkbox" />
+      <span class="checkbox__background">
+        <span class="checkbox__box">
+          <span class="checkbox__icon"></span>
+        </span>
+      </span>
+    </span>
+  </div>
+  ```html
+  <span class="checkbox">
+    <input class="checkbox__native" type="checkbox" />
+    <span class="checkbox__background">
+      <span class="checkbox__box">
+        <span class="checkbox__icon"></span>
+      </span>
     </span>
   </span>
-</span>
-```
+  ```
+</CodeExample>
 
-> For indeterminate checkboxes, apply the `aria-checked="mixed"` attribute to the `<input type="checkbox">` element and initialize the checkbox component script.
+Indeterminate checkboxes need to be set in JavaScript though styling is provided by Vrembem for the indeterminate states (see example above). Review [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/:indeterminate) for more details.
 
-#### checkbox + label
+<CodeExample lang="js">
+  ```js
+  const checkboxes = document.querySelectorAll(
+    'input[type="checkbox"][aria-checked="mixed"]'
+  );
+  checkboxes.forEach((checkbox) => {
+    checkbox.indeterminate = true;
+  });
+  ```
+</CodeExample>
 
-For checkboxes with labels, just wrap the checkbox component along with label text using the `<label>` element.
+### Checkboxes with labels
 
-```html
-<label>
-  <span class="checkbox">
-    ...
-  </span>
-  Checkbox with a label
-</label>
-```
+For checkboxes with labels, wrap the checkbox component along with the text label using the `<label>` element.
 
-## Modifiers
+<CodeExample lang="html">
+  <div slot="output">
+    <label>
+      <span class="checkbox">
+        <input class="checkbox__native" type="checkbox" checked />
+        <span class="checkbox__background">
+          <span class="checkbox__box">
+            <span class="checkbox__icon"></span>
+          </span>
+        </span>
+      </span>
+      <span>Checkbox with a label</span>
+    </label>
+    <br />
+    <label>
+      <span class="checkbox">
+        <input class="checkbox__native" type="checkbox" aria-checked="mixed" />
+        <span class="checkbox__background">
+          <span class="checkbox__box">
+            <span class="checkbox__icon"></span>
+          </span>
+        </span>
+      </span>
+      <span>Checkbox with a label</span>
+    </label>
+    <br />
+    <label>
+      <span class="checkbox">
+        <input class="checkbox__native" type="checkbox" />
+        <span class="checkbox__background">
+          <span class="checkbox__box">
+            <span class="checkbox__icon"></span>
+          </span>
+        </span>
+      </span>
+      <span>Checkbox with a label</span>
+    </label>
+  </div>
+  ```html
+  <label>
+    <span class="checkbox">
+      ...
+    </span>
+    <span>Checkbox with a label</span>
+  </label>
+  ```
+</CodeExample>
 
-### `checkbox_size_[value]`
+## checkbox_size_[value]
 
 Adjust the size of a checkbox by increasing or decreasing its width and height. By default, the checkbox scale will provide a checkbox height of 30px (small `checkbox_size_sm`), 40px (default) and 50px (large `checkbox_size_lg`).
 
-```html
-<span class="checkbox checkbox_size_sm">
-  ...
-</span>
+<CodeExample lang="html">
+  <div slot="output">
+    <span class="checkbox checkbox_size_sm">
+      <input class="checkbox__native" type="checkbox" checked />
+      <span class="checkbox__background">
+        <span class="checkbox__box">
+          <span class="checkbox__icon"></span>
+        </span>
+      </span>
+    </span>
+    <span class="checkbox">
+      <input class="checkbox__native" type="checkbox" checked />
+      <span class="checkbox__background">
+        <span class="checkbox__box">
+          <span class="checkbox__icon"></span>
+        </span>
+      </span>
+    </span>
+    <span class="checkbox checkbox_size_lg">
+      <input class="checkbox__native" type="checkbox" checked />
+      <span class="checkbox__background">
+        <span class="checkbox__box">
+          <span class="checkbox__icon"></span>
+        </span>
+      </span>
+    </span>
+  </div>
+  ```html
+  <span class="checkbox checkbox_size_sm">
+    ...
+  </span>
 
-<span class="checkbox checkbox_size_lg">
-  ...
-</span>
-```
+  <span class="checkbox checkbox_size_lg">
+    ...
+  </span>
+  ```
+</CodeExample>
 
-#### Available Variations
+**Available Variations**
 
 - `checkbox_size_sm`
 - `checkbox_size_lg`
 
 ## Customization
 
-### Sass Variables
+Checkboxes are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable either globally via the `core` module or per component.
 
-| Variable                      | Default                            | Description                                                                                                    |
-| ----------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `$prefix-block`               | `null`                             | String to prefix blocks with.                                                                                  |
-| `$prefix-element`             | `"__"`                             | String to prefix elements with.                                                                                |
-| `$prefix-modifier`            | `"_"`                              | String to prefix modifiers with.                                                                               |
-| `$prefix-modifier-value`      | `"_"`                              | String to prefix modifier values with.                                                                         |
-| `$color`                      | `--vb-primary`                     | Sets the base color theme for the checkbox component.                                                          |
-| `$size`                       | `core.$form-control-size`          | Sets the width and height of the `checkbox__background` element.                                               |
-| `$border-width`               | `2px`                              | Sets the border-width property for the `checkbox__box` element.                                                |
-| `$transition-duration`        | `core.$transition-duration-short`  | Sets the transition-duration property for the `checkbox__icon` element.                                        |
-| `$transition-timing-function` | `core.$transition-timing-function` | Sets the transition-timing-function property for the `checkbox__icon` element.                                 |
-| `$background`                 | `transparent`                      | Sets the background-color property for the `checkbox__background` element.                                     |
-| `$background-hover`           | `rgba($color, 0.1)`                | Sets the background-color property on `:hover` state.                                                          |
-| `$background-focus`           | `rgba($color, 0.1)`                | Sets the background-color property on `:focus` state.                                                          |
-| `$background-active`          | `rgba($color, 0.2)`                | Sets the background-color property on `:active` state.                                                         |
-| `$background-checked`         | `null`                             | Sets the background-color property on `:checked` state.                                                        |
-| `$background-border-radius`   | `core.$border-radius-circle`       | Sets the border-radius property for the `checkbox__background` element.                                        |
-| `$box-size`                   | `18px`                             | Sets the width and height of the `checkbox__box` element.                                                      |
-| `$box-background`             | `white`                            | Sets the background-color property for the `checkbox__box` element.                                            |
-| `$box-background-hover`       | `null`                             | Sets the background-color property on `:hover` state.                                                          |
-| `$box-background-focus`       | `null`                             | Sets the background-color property on `:focus` state.                                                          |
-| `$box-background-active`      | `null`                             | Sets the background-color property on `:active` state.                                                         |
-| `$box-background-checked`     | `$color`                           | Sets the background-color property on `:checked` state.                                                        |
-| `$box-border-color`           | `core.$gray-400`                   | Sets the border-color property for the `checkbox__box` element.                                                |
-| `$box-border-color-hover`     | `$color`                           | Sets the border-color property on `:hover` state.                                                              |
-| `$box-border-color-focus`     | `$color`                           | Sets the border-color property on `:focus` state.                                                              |
-| `$box-border-color-active`    | `$color`                           | Sets the border-color property on `:active` state.                                                             |
-| `$box-border-color-checked`   | `$color`                           | Sets the border-color property on `:checked` state.                                                            |
-| `$box-border-radius`          | `core.$border-radius`              | Sets the border-radius property for the `checkbox__box` element.                                               |
-| `$icon-size`                  | `12px`                             | Sets the width and height property for the `checkbox__icon` svg data:image.                                    |
-| `$icon-color`                 | `white`                            | Sets the stroke property for the `checkbox__icon` svg data:image.                                              |
-| `$icon-stroke`                | `2.5`                              | Sets the stroke-width property for the `checkbox__icon` svg data:image.                                        |
-| `$size-sm`                    | `core.$form-control-size-sm`       | Sets the width and height of the `checkbox__background` element of the `checkbox_size_sm` modifier.            |
-| `$size-sm-border-width`       | `2px`                              | Sets the border-width property for the `checkbox__box` element of the `checkbox_size_sm` modifier.             |
-| `$size-sm-box`                | `14px`                             | Sets the width and height of the `checkbox__box` element of the `checkbox_size_sm` modifier.                   |
-| `$size-sm-icon`               | `10px`                             | Sets the width and height property for the `checkbox__icon` svg data:image of the `checkbox_size_sm` modifier. |
-| `$size-sm-icon-stroke`        | `2.5`                              | Sets the stroke-width property for the `checkbox__icon` svg data:image of the `checkbox_size_sm` modifier.     |
-| `$size-lg`                    | `core.$form-control-size-lg`       | Sets the width and height of the `checkbox__background` element of the `checkbox_size_lg` modifier.            |
-| `$size-lg-border-width`       | `2.5px`                            | Sets the border-width property for the `checkbox__box` element of the `checkbox_size_lg` modifier.             |
-| `$size-lg-box`                | `24px`                             | Sets the width and height of the `checkbox__box` element of the `checkbox_size_lg` modifier.                   |
-| `$size-lg-icon`               | `18px`                             | Sets the width and height property for the `checkbox__icon` svg data:image of the `checkbox_size_lg` modifier. |
-| `$size-lg-icon-stroke`        | `2`                                | Sets the stroke-width property for the `checkbox__icon` svg data:image of the `checkbox_size_lg` modifier.     |
+<DocBlock name="SCSS Variables" type="file" src="checkbox/src/_variables.scss">
 
-### JavaScript Options
+  ```scss
+  @use "@vrembem/core";
+  @use "@vrembem/core/palette";
 
-| Key          | Default          | Description                                                        |
-| ------------ | ---------------- | ------------------------------------------------------------------ |
-| `autoInit`   | `false`          | Automatically initializes the instance.                            |
-| `stateAttr`  | `'aria-checked'` | Attribute to check mixed state against.                            |
-| `StateValue` | `'mixed'`        | The mixed value to check for. Applied as the value of `stateAttr`. |
+  $prefix-block: core.$prefix-block !default;
+  $prefix-element: core.$prefix-element !default;
+  $prefix-modifier: core.$prefix-modifier !default;
+  $prefix-modifier-value: core.$prefix-modifier-value !default;
 
-## Sass Functions
+  $color: palette.get("primary") !default;
+  $size: core.$form-control-size !default;
+  $border-width: 2px !default;
+  $transition-duration: core.$transition-duration-short !default;
+  $transition-timing-function: core.$transition-timing-function !default;
 
-### `@function icon-check($size, $color, $stroke)`
+  $background: transparent !default;
+  $background-hover: rgba($color, 0.1) !default;
+  $background-focus: rgba($color, 0.1) !default;
+  $background-active: rgba($color, 0.2) !default;
+  $background-checked: null !default;
+  $background-border-radius: core.$border-radius-circle !default;
 
-Outputs data image string for check SVG icon. Used as the value of `url()` in background-image property.
+  $box-size: 18px !default;
+  $box-background: white !default;
+  $box-background-hover: null !default;
+  $box-background-focus: null !default;
+  $box-background-active: null !default;
+  $box-background-checked: $color !default;
+  $box-border-color: palette.get("neutral") !default;
+  $box-border-color-hover: $color !default;
+  $box-border-color-focus: $color !default;
+  $box-border-color-active: $color !default;
+  $box-border-color-checked: $color !default;
+  $box-border-radius: core.$border-radius !default;
 
-**Returns:** `String` - Data image string
+  $icon-size: 12px !default;
+  $icon-color: white !default;
+  $icon-stroke: 2.5 !default;
 
-**Arguments**
-
-| Variable  | Type                 | Description                            |
-| --------- | -------------------- | -------------------------------------- |
-| `$size`   | `number (with unit)` | Value for width and height attributes. |
-| `$color`  | `color`              | Value for stroke attribute.            |
-| `$stroke` | `number (unitless)`  | Value for stroke-width attribute.      |
-
-**Example**
-
-```scss
-.icon-check {
-  background-image: url(icon-check(18px, #fff, 2));
-}
-
-// CSS Output
-.icon-check {
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="18px" height="18px" fill="none" stroke="%23FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9.5,3 4.5,8.5 2,6"></polyline></svg>');
-}
-```
-
-### `@function icon-minus($size, $color, $stroke)`
-
-Outputs data image string for minus SVG icon. Used as the value of `url()` in background-image property.
-
-**Returns:** `String` - Data image string
-
-**Arguments**
-
-| Variable  | Type                 | Description                            |
-| --------- | -------------------- | -------------------------------------- |
-| `$size`   | `number (with unit)` | Value for width and height attributes. |
-| `$color`  | `color`              | Value for stroke attribute.            |
-| `$stroke` | `number (unitless)`  | Value for stroke-width attribute.      |
-
-**Example**
-
-```scss
-.icon-minus {
-  background-image: url(icon-minus(18px, #fff, 2));
-}
-
-// CSS Output
-.icon-minus {
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="18px" height="18px" fill="none" stroke="%23FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="2" y1="6" x2="10" y2="6" /></svg>');
-}
-```
-
-## API
-
-### `checkbox.init(options)`
-
-Initializes the checkbox instance. During initialization, the following processes are run:
-
-- Sets checkboxes to the `indeterminate` state that match the provided attribute and values.
-- Attaches the click event listener that handles switching off the indeterminate state.
-
-**Parameters**
-
-- `options [Object] (optional)` An options object for passing your custom settings.
-
-```js
-const checkbox = new Checkbox();
-checkbox.init();
-```
-
-### `checkbox.destroy()`
-
-Destroys and cleans up the checkbox instantiation. For the checkbox component, this just involves removing the `click` event listener.
-
-```js
-const checkbox = new Checkbox();
-checkbox.init();
-// ...
-checkbox.destroy();
-```
-
-### `checkbox.setAriaState(el, value)`
-
-Sets the aria attribute value for mixed checkboxes.
-
-**Parameters**
-
-- `el` The element or elements whose aria state should be set.
-- `value` `(Default: settings.stateValue)` The value that should be set to the aria attribute.
-
-> Example removes presentational `<span>` elements for brevity but should be included in your implementation.
-
-```html
-<!-- Initial HTML -->
-<input type="checkbox" class="checkbox__native">
-<input type="checkbox" class="checkbox__native">
-<input type="checkbox" class="checkbox__native">
-```
-
-```js
-const els = document.querySelectorAll('.checkbox__native');
-checkbox.setAriaState(els);
-```
-
-```html
-<!-- Result -->
-<input type="checkbox" class="checkbox__native" aria-checked="mixed">
-<input type="checkbox" class="checkbox__native" aria-checked="mixed">
-<input type="checkbox" class="checkbox__native" aria-checked="mixed">
-```
-
-### `checkbox.removeAriaState(el)`
-
-Removes the aria attribute value for mixed checkboxes.
-
-**Parameters**
-
-- `el` The element or elements whose aria state should be removed.
-
-> Example removes presentational `<span>` elements for brevity but should be included in your implementation.
-
-```html
-<!-- Initial HTML -->
-<input type="checkbox" class="checkbox__native" aria-checked="mixed">
-<input type="checkbox" class="checkbox__native" aria-checked="mixed">
-<input type="checkbox" class="checkbox__native" aria-checked="mixed">
-```
-
-```js
-const els = document.querySelectorAll('.checkbox__native');
-checkbox.removeAriaState(els);
-```
-
-```html
-<!-- Result -->
-<input type="checkbox" class="checkbox__native">
-<input type="checkbox" class="checkbox__native">
-<input type="checkbox" class="checkbox__native">
-```
-
-### `checkbox.setIndeterminate(el)`
-
-Sets the indeterminate state of a checkbox based on whether or not the `aria-checkbox` attribute is set to `"mixed"` if using the default settings.
-
-**Parameters**
-
-- `el` The element or elements whose indeterminate state should be set.
-
-```js
-const els = document.querySelectorAll('.checkbox__native');
-checkbox.setIndeterminate(els);
-```
-
-> To learn more about the indeterminate state, [click here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate). It's important to note that this state is set using the HTMLInputElement object's indeterminate property via JavaScript (it cannot be set using an HTML attribute).
+  $size-sm: core.$form-control-size-sm !default;
+  $size-sm-border-width: 2px !default;
+  $size-sm-box: 14px !default;
+  $size-sm-icon: 10px !default;
+  $size-sm-icon-stroke: 2.5 !default;
+  $size-lg: core.$form-control-size-lg !default;
+  $size-lg-border-width: 2.5px !default;
+  $size-lg-box: 24px !default;
+  $size-lg-icon: 18px !default;
+  $size-lg-icon-stroke: 2 !default;
+  ```
+</DocBlock>

--- a/docs/src/content/packages/checkbox.mdx
+++ b/docs/src/content/packages/checkbox.mdx
@@ -25,8 +25,8 @@ npm install @vrembem/checkbox
 
 Checkboxes are composed using a set of `<span>` elements alongside the native `<input type="checkbox">` element which should be given the `checkbox__native` class and come before the remaining presentational `<span>` elements.
 
-<CodeExample lang="html">
-  <div slot="output">
+<CodeExample tabs={true}>
+  <Fragment slot="output">
     <span class="checkbox">
       <input class="checkbox__native" type="checkbox" checked />
       <span class="checkbox__background">
@@ -51,38 +51,41 @@ Checkboxes are composed using a set of `<span>` elements alongside the native `<
         </span>
       </span>
     </span>
-  </div>
-  ```html
-  <span class="checkbox">
-    <input class="checkbox__native" type="checkbox" />
-    <span class="checkbox__background">
-      <span class="checkbox__box">
-        <span class="checkbox__icon"></span>
+  </Fragment>
+  <Fragment slot="tab-html">
+    ```html
+    <span class="checkbox">
+      <input class="checkbox__native" type="checkbox" />
+      <span class="checkbox__background">
+        <span class="checkbox__box">
+          <span class="checkbox__icon"></span>
+        </span>
       </span>
     </span>
-  </span>
-  ```
+    ```
+  </Fragment>
+  <Fragment slot="tab-js">
+    ```js
+    const checkboxes = document.querySelectorAll(
+      'input[type="checkbox"][aria-checked="mixed"]'
+    );
+
+    checkboxes.forEach((checkbox) => {
+      checkbox.indeterminate = true;
+    });
+    ```
+  </Fragment>
 </CodeExample>
 
 Indeterminate checkboxes need to be set in JavaScript though styling is provided by Vrembem for the indeterminate states (see example above). Review [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/:indeterminate) for more details.
 
-<CodeExample lang="js">
-  ```js
-  const checkboxes = document.querySelectorAll(
-    'input[type="checkbox"][aria-checked="mixed"]'
-  );
-  checkboxes.forEach((checkbox) => {
-    checkbox.indeterminate = true;
-  });
-  ```
-</CodeExample>
 
 ### Checkboxes with labels
 
 For checkboxes with labels, wrap the checkbox component along with the text label using the `<label>` element.
 
 <CodeExample lang="html">
-  <div slot="output">
+  <Fragment slot="output">
     <label>
       <span class="checkbox">
         <input class="checkbox__native" type="checkbox" checked />
@@ -118,7 +121,7 @@ For checkboxes with labels, wrap the checkbox component along with the text labe
       </span>
       <span>Checkbox with a label</span>
     </label>
-  </div>
+  </Fragment>
   ```html
   <label>
     <span class="checkbox">
@@ -134,7 +137,7 @@ For checkboxes with labels, wrap the checkbox component along with the text labe
 Adjust the size of a checkbox by increasing or decreasing its width and height. By default, the checkbox scale will provide a checkbox height of 30px (small `checkbox_size_sm`), 40px (default) and 50px (large `checkbox_size_lg`).
 
 <CodeExample lang="html">
-  <div slot="output">
+  <Fragment slot="output">
     <span class="checkbox checkbox_size_sm">
       <input class="checkbox__native" type="checkbox" checked />
       <span class="checkbox__background">
@@ -159,7 +162,7 @@ Adjust the size of a checkbox by increasing or decreasing its width and height. 
         </span>
       </span>
     </span>
-  </div>
+  </Fragment>
   ```html
   <span class="checkbox checkbox_size_sm">
     ...

--- a/docs/src/content/packages/checkbox.mdx
+++ b/docs/src/content/packages/checkbox.mdx
@@ -201,9 +201,9 @@ Checkboxes are primarily customized using CSS variables but can also be modified
   $transition-timing-function: core.$transition-timing-function !default;
 
   $background: transparent !default;
-  $background-hover: palette.get("primary", 95) !default;
-  $background-focus: palette.get("primary", 95) !default;
-  $background-active: palette.get("primary", 90) !default;
+  $background-hover: hsl(palette.get("primary", "var"), 50%, 20%) !default;
+  $background-focus: hsl(palette.get("primary", "var"), 50%, 20%) !default;
+  $background-active: hsl(palette.get("primary", "var"), 50%, 30%) !default;
   $background-checked: null !default;
   $background-border-radius: core.$border-radius-circle !default;
 

--- a/docs/src/modules/tabs.js
+++ b/docs/src/modules/tabs.js
@@ -1,0 +1,81 @@
+function selectTab(active, tabs) {
+  tabs.forEach((tab) => {
+    const tabpanel = document.querySelector(`#${tab.getAttribute('aria-controls')}`);
+    if (active === tab) {
+      tab.setAttribute('aria-selected', 'true');
+      tab.removeAttribute('tabindex');
+      tabpanel.classList.add('is-active');
+    } else {
+      tab.setAttribute('aria-selected', 'false');
+      tab.setAttribute('tabindex', '-1');
+      tabpanel.classList.remove('is-active');
+    }
+  });
+}
+
+function selectNextTab(tabs) {
+  let nextTab = document.activeElement.nextElementSibling;
+  nextTab = nextTab ? nextTab : tabs[0];
+  selectTab(nextTab, tabs);
+  nextTab.focus();
+}
+
+function selectPrevTab(tabs) {
+  let prevTab = document.activeElement.previousElementSibling;
+  prevTab = prevTab ? prevTab : tabs[tabs.length - 1];
+  selectTab(prevTab, tabs);
+  prevTab.focus();
+}
+
+function handlerKeydown(tabs, event) {
+  switch (event.key) {
+    case 'Down':
+    case 'ArrowDown':
+    case 'Right':
+    case 'ArrowRight':
+      event.preventDefault();
+      selectNextTab(tabs);
+      break;
+    case 'Up':
+    case 'ArrowUp':
+    case 'Left':
+    case 'ArrowLeft':
+      event.preventDefault();
+      selectPrevTab(tabs);
+      break;
+    default:
+      return;
+  }
+}
+
+const tabs = {
+  mount() {
+    // Get all the tablists.
+    const tablists = document.querySelectorAll('[role="tablist"]');
+    tablists.forEach((tablist) => {
+      const tabs = tablist.querySelectorAll('[role="tab"]');
+
+      // Select the first tab.
+      selectTab(tabs[0], tabs);
+
+      // Setup event listeners for tabs.
+      tabs.forEach((tab) => {
+        const __handlerKeydown = handlerKeydown.bind(null, tabs);
+
+        tab.addEventListener('click', () => {
+          selectTab(tab, tabs);
+        });
+
+        tab.addEventListener('focus', () => {
+          document.addEventListener('keydown', __handlerKeydown);
+        });
+
+        tab.addEventListener('blur', () => {
+          document.removeEventListener('keydown', __handlerKeydown);
+        });
+      });
+    });
+  }
+};
+
+export { tabs };

--- a/docs/src/pages/packages/[slug].astro
+++ b/docs/src/pages/packages/[slug].astro
@@ -52,4 +52,12 @@ const layout = {
 
   headerAnchor.mount();
   toggle.mount();
+
+  const checkboxes = document.querySelectorAll(
+    'input[type="checkbox"][aria-checked="mixed"]'
+  );
+  checkboxes.forEach((checkbox) => {
+    // @ts-ignore
+    checkbox.indeterminate = true;
+  });
 </script>

--- a/docs/src/pages/packages/[slug].astro
+++ b/docs/src/pages/packages/[slug].astro
@@ -48,9 +48,11 @@ const layout = {
 
 <script>
   import { headerAnchor } from "../../modules/headerAnchor";
+  import { tabs } from "../../modules/tabs";
   import { toggle } from "../../modules/toggle";
 
   headerAnchor.mount();
+  tabs.mount();
   toggle.mount();
 
   const checkboxes = document.querySelectorAll(

--- a/docs/src/styles/_code-example.scss
+++ b/docs/src/styles/_code-example.scss
@@ -39,7 +39,7 @@
   }
 
   .code-block__copy-button {
-    top: 0.25rem;
+    top: calc(-2.5rem + 1px);
     right: 0.5rem;
     background-color: transparent;
 
@@ -54,8 +54,13 @@
 }
 
 .code-example__toolbar {
+  display: flex;
+  gap: 0.5rem;
   padding: 0.5rem 1rem;
-  border-bottom: core.$border;
   color: theme.get("foreground-lighter");
   text-transform: uppercase;
+
+  > * + * {
+    margin-left: 1rem;
+  }
 }

--- a/docs/src/styles/_doc-block.scss
+++ b/docs/src/styles/_doc-block.scss
@@ -50,6 +50,12 @@
   border-top: core.$border;
 }
 
+.doc-block__meta {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
 .doc-block__intro,
 .doc-block__arguments,
 .doc-block__example {

--- a/docs/src/styles/_doc-block.scss
+++ b/docs/src/styles/_doc-block.scss
@@ -19,7 +19,7 @@
 
   &.is-active {
     border-color: palette.get("primary");
-    box-shadow: 0 0 0 0.2rem palette.get("primary", 90);
+    box-shadow: 0 0 0 0.2rem hsl(palette.get("primary", "var"), 50%, 20%);
   }
 
   @include core.media-max(root.$bp-code) {

--- a/docs/src/styles/_tabs.scss
+++ b/docs/src/styles/_tabs.scss
@@ -1,0 +1,37 @@
+@use "@vrembem/core/palette";
+@use "@vrembem/core/theme";
+
+[role="tab"] {
+  position: relative;
+  margin: -0.5rem 0;
+  padding: 0.5rem;
+  color: theme.get("foreground-lighter");
+
+  &::after {
+    content: "";
+    position: absolute;
+    inset: auto 0 -1px;
+    height: 3px;
+    background: transparent;
+  }
+
+  &:hover {
+    color: theme.get("foreground");
+  }
+
+  &[aria-selected="true"] {
+    color: palette.get("primary");
+
+    &::after {
+      background: palette.get("primary");
+    }
+  }
+}
+
+[role="tabpanel"] {
+  display: none;
+
+  &.is-active {
+    display: block;
+  }
+}

--- a/docs/src/styles/global.scss
+++ b/docs/src/styles/global.scss
@@ -20,6 +20,7 @@
 @use "./icon_external";
 @use "./pagi";
 @use "./swatch";
+@use "./tabs";
 @use "./theme-icons";
 @use "./toggle";
 

--- a/packages/checkbox/src/_functions.scss
+++ b/packages/checkbox/src/_functions.scss
@@ -1,7 +1,7 @@
 @use "@vrembem/core";
 
 /// Outputs data image string for check SVG icon. Used as the value of url() in
-/// background-image property.
+/// the background-image property.
 /// @param {Number (with unit)} $size - Value for width and height attributes
 /// @param {Color} $color - Value for stroke attribute
 /// @param {Number (unitless)} $stroke - Value for stroke-width attribute
@@ -11,7 +11,7 @@
 }
 
 /// Outputs data image string for minus SVG icon. Used as the value of url() in
-/// background-image property.
+/// the background-image property.
 /// @param {Number (with unit)} $size - Value for width and height attributes
 /// @param {Color} $color - Value for stroke attribute
 /// @param {Number (unitless)} $stroke - Value for stroke-width attribute

--- a/packages/checkbox/src/_variables.scss
+++ b/packages/checkbox/src/_variables.scss
@@ -13,9 +13,9 @@ $transition-duration: core.$transition-duration-short !default;
 $transition-timing-function: core.$transition-timing-function !default;
 
 $background: transparent !default;
-$background-hover: palette.get("primary", 95) !default;
-$background-focus: palette.get("primary", 95) !default;
-$background-active: palette.get("primary", 90) !default;
+$background-hover: hsl(palette.get("primary", "var"), 50%, 20%) !default;
+$background-focus: hsl(palette.get("primary", "var"), 50%, 20%) !default;
+$background-active: hsl(palette.get("primary", "var"), 50%, 30%) !default;
 $background-checked: null !default;
 $background-border-radius: core.$border-radius-circle !default;
 

--- a/packages/checkbox/src/_variables.scss
+++ b/packages/checkbox/src/_variables.scss
@@ -13,9 +13,9 @@ $transition-duration: core.$transition-duration-short !default;
 $transition-timing-function: core.$transition-timing-function !default;
 
 $background: transparent !default;
-$background-hover: rgba($color, 0.1) !default;
-$background-focus: rgba($color, 0.1) !default;
-$background-active: rgba($color, 0.2) !default;
+$background-hover: palette.get("primary", 95) !default;
+$background-focus: palette.get("primary", 95) !default;
+$background-active: palette.get("primary", 90) !default;
 $background-checked: null !default;
 $background-border-radius: core.$border-radius-circle !default;
 

--- a/packages/core/src/scss/_palette.scss
+++ b/packages/core/src/scss/_palette.scss
@@ -89,7 +89,7 @@ $lightness: 0, 5, 10, 12, 15, 20, 30, 40, 50, 60, 70, 80, 90, 95, 98, 100 !defau
 
   // If value is "var", return the hue and saturation values in css var function format.
   @else if ($value == "var") {
-    @return var(--#{$_v}#{$key}-hs, fun.get-hs(map.get($seeds, $key)));
+    @return var(--#{$_v}#{$key}-hs);
   }
 
   // Else, return the specified lightness value from the palette map.


### PR DESCRIPTION
## What changed?

This PR contains a complete rewrite of the Checkbox documentation and uses the new docs format. This PR also updates the values of Checkbox's variables to properly use the Palette module for applying hover, focus and active states. Lastly, the Palette module `get` function no longer returns a CSS variable fallback with the `var` method.

**Changes to CodeExample**

Code examples have been expanded to use tabs for displaying multiple language applications for an example. Currently supports an `html`, `scss` and `js` example per CodeExample wrapper. Tabs are enabled using the `tabs` attribute and applied using slots. The default slot is not used when tabs are enabled and all examples should be applied via a slot.

```html
<CodeExample tabs={true}>
  <Fragment slot="output">
    ...
  </Fragment>
  <Fragment slot="tab-html">
    ...
  </Fragment>
  <Fragment slot="tab-scss">
    ...
  </Fragment>
  <Fragment slot="tab-js">
    ...
  </Fragment>
</CodeExample>
```

**Changes to DocBlock**

CodeBlock now allows the use of `returns` and `line` attributes for rendering what a function returns as well as a specific line number in the `src` link respectively. DocBlock styles have also been updated to support light/dark mode in respect block highlighting.

```html
<DocBlock
  name="function-name"
  type="function"
  returns="string"
  src="functions.scss"
  line="9"
  args={[
    ["$asdf", "Number", "..."],
    ["$fdsa", "Boolean", "..."]
  ]}
>
  ...

  <Fragment slot="example">
    ...
  </Fragment>
</DocBlock>
```
