### PR TITLE
Apply new BEM and CSS Variable functions/mixins to components

### DIFF
--- a/docs/src/content/packages/button.mdx
+++ b/docs/src/content/packages/button.mdx
@@ -178,44 +178,53 @@ Adjust the size of a button by increasing or decreasing its padding and font-siz
 
 ## Customization
 
-Buttons are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable either globally via the `core` module or per component.
+Buttons are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable via the `core` module.
 
 <DocBlock name="CSS Variables" type="file" src="button/src/_root.scss">
 
   ```scss
+  @use "@vrembem/core";
   @use "@vrembem/core/theme";
   @use "./variables" as var;
 
-  $_v: var.$prefix-variable;
-
-  :root {
+  #{theme.$root-selector} {
     // Size properties
-    --#{$_v}button-size: #{var.$size};
-    --#{$_v}button-padding: #{var.$padding};
-    --#{$_v}button-gap: #{var.$gap};
-    --#{$_v}button-border-width: #{var.$border-width};
-    --#{$_v}button-border-radius: #{var.$border-radius};
-    --#{$_v}button-font-size: #{var.$font-size};
-    --#{$_v}button-font-weight: #{var.$font-weight};
-    --#{$_v}button-line-height: #{var.$line-height};
+    @include core.css("button-size", var.$size);
+    @include core.css("button-padding", var.$padding);
+    @include core.css("button-gap", var.$gap);
+    @include core.css("button-border-width", var.$border-width);
+    @include core.css("button-border-radius", var.$border-radius);
+    @include core.css("button-font-size", var.$font-size);
+    @include core.css("button-font-weight", var.$font-weight);
+    @include core.css("button-line-height", var.$line-height);
+
+    // Theme properties
+    @include core.css("button-background", var.$background);
+    @include core.css("button-background-hover", var.$background-hover);
+    @include core.css("button-background-active", var.$background-active);
+    @include core.css("button-foreground", var.$foreground);
+    @include core.css("button-foreground-hover", var.$foreground-hover);
+    @include core.css("button-foreground-active", var.$foreground-active);
+    @include core.css("button-border-color", var.$border-color);
+    @include core.css("button-border-color-hover", var.$border-color-hover);
+    @include core.css("button-border-color-active", var.$border-color-active);
+    @include core.css("button-box-shadow", var.$box-shadow);
+    @include core.css("button-box-shadow-focus", var.$box-shadow-focus);
 
     // Transition properties
-    --#{$_v}button-transition-property: #{var.$transition-property};
-    --#{$_v}button-transition-duration: #{var.$transition-duration};
-    --#{$_v}button-transition-timing-function: #{var.$transition-timing-function};
+    @include core.css("button-transition-property", var.$transition-property);
+    @include core.css("button-transition-duration", var.$transition-duration);
+    @include core.css("button-transition-timing-function", var.$transition-timing-function);
     
     // Disabled
-    --#{$_v}button-disabled-opacity: #{var.$disabled-opacity};
+    @include core.css("button-disabled-opacity", var.$disabled-opacity);
     
     // is-loading
-    --#{$_v}button-loading-size: #{var.$loading-size};
-    --#{$_v}button-loading-border: #{var.$loading-border};
-    --#{$_v}button-loading-animation-duration: #{var.$loading-animation-duration};
-    --#{$_v}button-loading-animation-timing-function: #{var.$loading-animation-timing-function};
+    @include core.css("button-loading-size", var.$loading-size);
+    @include core.css("button-loading-border", var.$loading-border);
+    @include core.css("button-loading-animation-duration", var.$loading-animation-duration);
+    @include core.css("button-loading-animation-timing-function", var.$loading-animation-timing-function);
   }
-
-  // Theme properties
-  @include theme.output-themes("button");
   ```
 </DocBlock>
 
@@ -225,13 +234,6 @@ Buttons are primarily customized using CSS variables but can also be modified us
   @use "sass:list";
   @use "@vrembem/core";
   @use "@vrembem/core/theme";
-
-  // Prefix variables
-  $prefix-variable: core.$prefix-variable !default;
-  $prefix-block: core.$prefix-block !default;
-  $prefix-element: core.$prefix-element !default;
-  $prefix-modifier: core.$prefix-modifier !default;
-  $prefix-modifier-value: core.$prefix-modifier-value !default;
 
   // Size properties
   $size: core.$form-control-size !default;
@@ -243,6 +245,19 @@ Buttons are primarily customized using CSS variables but can also be modified us
   $font-weight: inherit !default;
   $line-height: 1.6 !default;
   $breakpoints: core.$breakpoints !default;
+
+  // Theme properties
+  $background: transparent;
+  $background-hover: transparent;
+  $background-active: transparent;
+  $foreground: theme.get("foreground");
+  $foreground-hover: theme.get("foreground");
+  $foreground-active: theme.get("foreground");
+  $border-color: theme.get("border-color-dark");
+  $border-color-hover: theme.get("border-color-darker");
+  $border-color-active: theme.get("border-color-darker");
+  $box-shadow: 0 0 0 0 rgb(0 0 0 / 0%);
+  $box-shadow-focus: 0 0 0 0.2rem rgb(0 0 0 / 15%);
 
   // Transition properties
   $transition-property: background, color, border-color, box-shadow !default;
@@ -275,23 +290,6 @@ Buttons are primarily customized using CSS variables but can also be modified us
   $size-lg-padding: calc(#{list.nth(core.$padding-lg, 1)} - 1px) list.nth(core.$padding-lg, 2) !default;
   $size-lg-font-size: core.$font-size-lg !default;
   $size-lg-line-height: core.$line-height-lg !default;
-
-  // Theme properties
-  $theme: (
-    "background": transparent,
-    "background-hover": transparent,
-    "background-active": transparent,
-    "foreground": theme.get("foreground"),
-    "foreground-hover": theme.get("foreground"),
-    "foreground-active": theme.get("foreground"),
-    "border-color": theme.get("border-color-dark"),
-    "border-color-hover": theme.get("border-color-darker"),
-    "border-color-active": theme.get("border-color-darker"),
-    "box-shadow": 0 0 0 0 rgba(black, 0),
-    "box-shadow-focus": 0 0 0 0.2rem rgba(black, 0.15),
-  ) !default;
-
-  @include theme.set(theme.$default, "button", $theme);
   ```
 </DocBlock>
 

--- a/docs/src/content/packages/button.mdx
+++ b/docs/src/content/packages/button.mdx
@@ -161,13 +161,13 @@ Adjust the size of a button by increasing or decreasing its padding and font-siz
 
 <CodeExample>
   <div slot="output" class="level">
-    <button class="button button_size_lg">Button</button>
-    <button class="button">Button</button>
     <button class="button button_size_sm">Button</button>
+    <button class="button">Button</button>
+    <button class="button button_size_lg">Button</button>
   </div>
   ```html
-  <button class="button button_size_lg">Button</button>
   <button class="button button_size_sm">Button</button>
+  <button class="button button_size_lg">Button</button>
   ```
 </CodeExample>
 
@@ -188,17 +188,9 @@ Buttons are primarily customized using CSS variables but can also be modified us
   @use "./variables" as var;
 
   #{theme.$root-selector} {
-    // Size properties
     @include core.css("button-size", var.$size);
     @include core.css("button-padding", var.$padding);
     @include core.css("button-gap", var.$gap);
-    @include core.css("button-border-width", var.$border-width);
-    @include core.css("button-border-radius", var.$border-radius);
-    @include core.css("button-font-size", var.$font-size);
-    @include core.css("button-font-weight", var.$font-weight);
-    @include core.css("button-line-height", var.$line-height);
-
-    // Theme properties
     @include core.css("button-background", var.$background);
     @include core.css("button-background-hover", var.$background-hover);
     @include core.css("button-background-active", var.$background-active);
@@ -208,18 +200,17 @@ Buttons are primarily customized using CSS variables but can also be modified us
     @include core.css("button-border-color", var.$border-color);
     @include core.css("button-border-color-hover", var.$border-color-hover);
     @include core.css("button-border-color-active", var.$border-color-active);
+    @include core.css("button-border-width", var.$border-width);
+    @include core.css("button-border-radius", var.$border-radius);
     @include core.css("button-box-shadow", var.$box-shadow);
     @include core.css("button-box-shadow-focus", var.$box-shadow-focus);
-
-    // Transition properties
+    @include core.css("button-font-size", var.$font-size);
+    @include core.css("button-font-weight", var.$font-weight);
+    @include core.css("button-line-height", var.$line-height);
     @include core.css("button-transition-property", var.$transition-property);
     @include core.css("button-transition-duration", var.$transition-duration);
     @include core.css("button-transition-timing-function", var.$transition-timing-function);
-    
-    // Disabled
     @include core.css("button-disabled-opacity", var.$disabled-opacity);
-    
-    // is-loading
     @include core.css("button-loading-size", var.$loading-size);
     @include core.css("button-loading-border", var.$loading-border);
     @include core.css("button-loading-animation-duration", var.$loading-animation-duration);
@@ -235,31 +226,28 @@ Buttons are primarily customized using CSS variables but can also be modified us
   @use "@vrembem/core";
   @use "@vrembem/core/theme";
 
-  // Size properties
+  $breakpoints: core.$breakpoints !default;
   $size: core.$form-control-size !default;
   $padding: calc(#{list.nth(core.$padding, 1)} - 1px) list.nth(core.$padding, 2) !default;
   $gap: 0.5rem !default;
+  $background: transparent !default;
+  $background-hover: transparent !default;
+  $background-active: transparent !default;
+  $foreground: theme.get("foreground") !default;
+  $foreground-hover: theme.get("foreground") !default;
+  $foreground-active: theme.get("foreground") !default;
+  $border-color: theme.get("border-color-dark") !default;
+  $border-color-hover: theme.get("border-color-darker") !default;
+  $border-color-active: theme.get("border-color-darker") !default;
   $border-width: 1px !default;
   $border-radius: core.$border-radius !default;
+  $box-shadow: 0 0 0 0 rgb(0 0 0 / 0%) !default;
+  $box-shadow-focus: 0 0 0 0.2rem rgb(0 0 0 / 15%) !default;
   $font-size: 1em !default;
   $font-weight: inherit !default;
   $line-height: 1.6 !default;
-  $breakpoints: core.$breakpoints !default;
 
-  // Theme properties
-  $background: transparent;
-  $background-hover: transparent;
-  $background-active: transparent;
-  $foreground: theme.get("foreground");
-  $foreground-hover: theme.get("foreground");
-  $foreground-active: theme.get("foreground");
-  $border-color: theme.get("border-color-dark");
-  $border-color-hover: theme.get("border-color-darker");
-  $border-color-active: theme.get("border-color-darker");
-  $box-shadow: 0 0 0 0 rgb(0 0 0 / 0%);
-  $box-shadow-focus: 0 0 0 0.2rem rgb(0 0 0 / 15%);
-
-  // Transition properties
+  // Transition
   $transition-property: background, color, border-color, box-shadow !default;
   $transition-duration: core.$transition-duration-short !default;
   $transition-timing-function: core.$transition-timing-function !default;

--- a/docs/src/content/packages/card.mdx
+++ b/docs/src/content/packages/card.mdx
@@ -171,16 +171,16 @@ Cards are primarily customized using CSS variables but can also be modified usin
     @include core.css("card-box-shadow", var.$box-shadow);
     @include core.css("card-screen-background", var.$screen-background);
     @include core.css("card-screen-opacity", var.$screen-opacity);
-    @include core.css("card-transition-property", var.$transition-property);
-    @include core.css("card-transition-duration", var.$transition-duration);
-    @include core.css("card-transition-timing-function", var.$transition-timing-function);
+    @include core.css("card-link-box-shadow", var.$link-box-shadow);
+    @include core.css("card-link-box-shadow-hover", var.$link-box-shadow-hover);
+    @include core.css("card-link-offset", var.$link-offset);
     @include core.css("card-title-color", var.$title-color);
     @include core.css("card-title-font-size", var.$title-font-size);
     @include core.css("card-title-line-height", var.$title-line-height);
     @include core.css("card-title-font-weight", var.$title-font-weight);
-    @include core.css("card-link-box-shadow", var.$link-box-shadow);
-    @include core.css("card-link-box-shadow-hover", var.$link-box-shadow-hover);
-    @include core.css("card-link-offset", var.$link-offset);
+    @include core.css("card-transition-property", var.$transition-property);
+    @include core.css("card-transition-duration", var.$transition-duration);
+    @include core.css("card-transition-timing-function", var.$transition-timing-function);
   }
 
   @include theme.output-themes("card");
@@ -201,19 +201,28 @@ Cards are primarily customized using CSS variables but can also be modified usin
   $sep-border: null !default;
   $border-radius: core.$border-radius !default;
   $box-shadow: core.$shadow-1 !default;
+
+  // Screen
   $screen-background: null !default;
   $screen-opacity: null !default;
-  $transition-property: background-color, border-color, box-shadow, transform !default;
-  $transition-duration: core.$transition-duration !default;
-  $transition-timing-function: core.$transition-timing-function !default;
-  $title-color: null !default;
-  $title-font-size: core.$font-size-lg !default;
-  $title-line-height: core.$line-height-lg !default;
-  $title-font-weight: core.$font-weight-semi-bold !default;
+
+  // Link
   $link-box-shadow: core.$shadow-2 !default;
   $link-box-shadow-hover: core.$shadow-3 !default;
   $link-offset: -0.25em !default;
 
+  // Title
+  $title-color: null !default;
+  $title-font-size: core.$font-size-lg !default;
+  $title-line-height: core.$line-height-lg !default;
+  $title-font-weight: core.$font-weight-semi-bold !default;
+
+  // Transition
+  $transition-property: background-color, border-color, box-shadow, transform !default;
+  $transition-duration: core.$transition-duration !default;
+  $transition-timing-function: core.$transition-timing-function !default;
+
+  // Themes
   $theme-light: (
     "background": theme.get("background"),
     "foreground": theme.get("foreground-light"),

--- a/docs/src/content/packages/card.mdx
+++ b/docs/src/content/packages/card.mdx
@@ -152,39 +152,37 @@ When creating a card using the `<a>` element, additional styles are applied to m
 
 ## Customization
 
-Cards are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable either globally via the `core` module or per component.
+Cards are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable via the `core` module.
 
 <DocBlock name="CSS Variables" type="file" src="card/src/_root.scss">
 
   ```scss
+  @use "@vrembem/core";
   @use "@vrembem/core/theme";
   @use "./variables" as var;
 
-  $_v: var.$prefix-variable;
-
-  :root {
-    // Size properties
-    --#{$_v}card-padding: #{var.$padding};
-    --#{$_v}card-border-radius: #{var.$border-radius};
-    --#{$_v}card-box-shadow: #{var.$box-shadow};
-
-    // Transition properties
-    --#{$_v}card-transition-property: #{var.$transition-property};
-    --#{$_v}card-transition-duration: #{var.$transition-duration};
-    --#{$_v}card-transition-timing-function: #{var.$transition-timing-function};
-
-    // Title properties
-    --#{$_v}card-title-font-size: #{var.$title-font-size};
-    --#{$_v}card-title-line-height: #{var.$title-line-height};
-    --#{$_v}card-title-font-weight: #{var.$title-font-weight};
-
-    // Link properties
-    --#{$_v}card-link-box-shadow: #{var.$link-box-shadow};
-    --#{$_v}card-link-box-shadow-hover: #{var.$link-box-shadow-hover};
-    --#{$_v}card-link-offset: #{var.$link-offset};
+  #{theme.$root-selector} {
+    @include core.css("card-padding", var.$padding);
+    @include core.css("card-background", var.$background);
+    @include core.css("card-foreground", var.$foreground);
+    @include core.css("card-border", var.$border);
+    @include core.css("card-sep-border", var.$sep-border);
+    @include core.css("card-border-radius", var.$border-radius);
+    @include core.css("card-box-shadow", var.$box-shadow);
+    @include core.css("card-screen-background", var.$screen-background);
+    @include core.css("card-screen-opacity", var.$screen-opacity);
+    @include core.css("card-transition-property", var.$transition-property);
+    @include core.css("card-transition-duration", var.$transition-duration);
+    @include core.css("card-transition-timing-function", var.$transition-timing-function);
+    @include core.css("card-title-color", var.$title-color);
+    @include core.css("card-title-font-size", var.$title-font-size);
+    @include core.css("card-title-line-height", var.$title-line-height);
+    @include core.css("card-title-font-weight", var.$title-font-weight);
+    @include core.css("card-link-box-shadow", var.$link-box-shadow);
+    @include core.css("card-link-box-shadow-hover", var.$link-box-shadow-hover);
+    @include core.css("card-link-offset", var.$link-offset);
   }
 
-  // Theme properties
   @include theme.output-themes("card");
   ```
 </DocBlock>
@@ -196,34 +194,26 @@ Cards are primarily customized using CSS variables but can also be modified usin
   @use "@vrembem/core/theme";
   @use "@vrembem/core/palette";
 
-  // Prefix variables
-  $prefix-variable: core.$prefix-variable !default;
-  $prefix-block: core.$prefix-block !default;
-  $prefix-element: core.$prefix-element !default;
-  $prefix-modifier: core.$prefix-modifier !default;
-  $prefix-modifier-value: core.$prefix-modifier-value !default;
-
-  // Size properties
   $padding: 1.25em !default;
+  $background: null !default;
+  $foreground: null !default;
+  $border: null !default;
+  $sep-border: null !default;
   $border-radius: core.$border-radius !default;
   $box-shadow: core.$shadow-1 !default;
-
-  // Transition properties
+  $screen-background: null !default;
+  $screen-opacity: null !default;
   $transition-property: background-color, border-color, box-shadow, transform !default;
   $transition-duration: core.$transition-duration !default;
   $transition-timing-function: core.$transition-timing-function !default;
-
-  // Title properties
+  $title-color: null !default;
   $title-font-size: core.$font-size-lg !default;
   $title-line-height: core.$line-height-lg !default;
   $title-font-weight: core.$font-weight-semi-bold !default;
-
-  // Link properties
   $link-box-shadow: core.$shadow-2 !default;
   $link-box-shadow-hover: core.$shadow-3 !default;
   $link-offset: -0.25em !default;
 
-  // Theme properties
   $theme-light: (
     "background": theme.get("background"),
     "foreground": theme.get("foreground-light"),

--- a/docs/src/content/packages/checkbox.mdx
+++ b/docs/src/content/packages/checkbox.mdx
@@ -193,7 +193,10 @@ Checkboxes are primarily customized using CSS variables but can also be modified
   #{theme.$root-selector} {
     @include core.css("checkbox-size", var.$size);
     @include core.css("checkbox-box-size", var.$box-size);
+    @include core.css("checkbox-icon-size", var.$icon-size);
     @include core.css("checkbox-color", var.$color);
+    @include core.css("checkbox-icon-color", var.$icon-color);
+    @include core.css("checkbox-icon-stroke", var.$icon-stroke);
     @include core.css("checkbox-fill", var.$fill);
     @include core.css("checkbox-border-color", var.$border-color);
     @include core.css("checkbox-border-width", var.$border-width);
@@ -205,9 +208,6 @@ Checkboxes are primarily customized using CSS variables but can also be modified
     @include core.css("checkbox-background-opacity-active", var.$background-opacity-active);
     @include core.css("checkbox-transition-duration", var.$transition-duration);
     @include core.css("checkbox-transition-timing-function", var.$transition-timing-function);
-    @include core.css("checkbox-icon-size", var.$icon-size);
-    @include core.css("checkbox-icon-color", var.$icon-color);
-    @include core.css("checkbox-icon-stroke", var.$icon-stroke);
   }
 
   @include theme.output-themes("checkbox");
@@ -221,10 +221,12 @@ Checkboxes are primarily customized using CSS variables but can also be modified
   @use "@vrembem/core/palette";
   @use "@vrembem/core/theme";
 
-  // Checkbox properties
   $size: core.$form-control-size !default;
   $box-size: 18px !default;
+  $icon-size: 12px !default;
   $color: palette.get("primary") !default;
+  $icon-color: null !default;
+  $icon-stroke: 2.5 !default;
   $fill: null !default;
   $border-color: null !default;
   $border-width: 2px !default;
@@ -234,27 +236,26 @@ Checkboxes are primarily customized using CSS variables but can also be modified
   $background-opacity-hover: 20% !default;
   $background-opacity-focus: 20% !default;
   $background-opacity-active: 30% !default;
+
+  // Transition
   $transition-duration: core.$transition-duration-short !default;
   $transition-timing-function: core.$transition-timing-function !default;
 
-  // Icon properties
-  $icon-size: 12px !default;
-  $icon-color: null !default;
-  $icon-stroke: 2.5 !default;
-
-  // Size modifier properties
+  // checkbox_size_sm
   $size-sm: core.$form-control-size-sm !default;
   $size-sm-border-width: 2px !default;
   $size-sm-box: 14px !default;
   $size-sm-icon: 10px !default;
   $size-sm-icon-stroke: 2.5 !default;
+
+  // checkbox_size_lg
   $size-lg: core.$form-control-size-lg !default;
   $size-lg-border-width: 2.5px !default;
   $size-lg-box: 24px !default;
   $size-lg-icon: 18px !default;
   $size-lg-icon-stroke: 2 !default;
 
-  // Theme properties
+  // Themes
   $theme-light: (
     "fill": white,
     "border-color": palette.get("neutral"),

--- a/docs/src/content/packages/checkbox.mdx
+++ b/docs/src/content/packages/checkbox.mdx
@@ -191,23 +191,23 @@ Checkboxes are primarily customized using CSS variables but can also be modified
   @use "./variables" as var;
 
   #{theme.$root-selector} {
-    @include core.css-var("checkbox-size", var.$size);
-    @include core.css-var("checkbox-box-size", var.$box-size);
-    @include core.css-var("checkbox-color", var.$color);
-    @include core.css-var("checkbox-fill", var.$fill);
-    @include core.css-var("checkbox-border-color", var.$border-color);
-    @include core.css-var("checkbox-border-width", var.$border-width);
-    @include core.css-var("checkbox-border-radius", var.$border-radius);
-    @include core.css-var("checkbox-background-border-radius", var.$background-border-radius);
-    @include core.css-var("checkbox-background-opacity", var.$background-opacity);
-    @include core.css-var("checkbox-background-opacity-hover", var.$background-opacity-hover);
-    @include core.css-var("checkbox-background-opacity-focus", var.$background-opacity-focus);
-    @include core.css-var("checkbox-background-opacity-active", var.$background-opacity-active);
-    @include core.css-var("checkbox-transition-duration", var.$transition-duration);
-    @include core.css-var("checkbox-transition-timing-function", var.$transition-timing-function);
-    @include core.css-var("checkbox-icon-size", var.$icon-size);
-    @include core.css-var("checkbox-icon-color", var.$icon-color);
-    @include core.css-var("checkbox-icon-stroke", var.$icon-stroke);
+    @include core.css("checkbox-size", var.$size);
+    @include core.css("checkbox-box-size", var.$box-size);
+    @include core.css("checkbox-color", var.$color);
+    @include core.css("checkbox-fill", var.$fill);
+    @include core.css("checkbox-border-color", var.$border-color);
+    @include core.css("checkbox-border-width", var.$border-width);
+    @include core.css("checkbox-border-radius", var.$border-radius);
+    @include core.css("checkbox-background-border-radius", var.$background-border-radius);
+    @include core.css("checkbox-background-opacity", var.$background-opacity);
+    @include core.css("checkbox-background-opacity-hover", var.$background-opacity-hover);
+    @include core.css("checkbox-background-opacity-focus", var.$background-opacity-focus);
+    @include core.css("checkbox-background-opacity-active", var.$background-opacity-active);
+    @include core.css("checkbox-transition-duration", var.$transition-duration);
+    @include core.css("checkbox-transition-timing-function", var.$transition-timing-function);
+    @include core.css("checkbox-icon-size", var.$icon-size);
+    @include core.css("checkbox-icon-color", var.$icon-color);
+    @include core.css("checkbox-icon-stroke", var.$icon-stroke);
   }
 
   @include theme.output-themes("checkbox");

--- a/docs/src/content/packages/radio.mdx
+++ b/docs/src/content/packages/radio.mdx
@@ -201,7 +201,9 @@ Radios are primarily customized using CSS variables but can also be modified usi
   #{theme.$root-selector} {
     @include core.css("radio-size", var.$size);
     @include core.css("radio-circle-size", var.$circle-size);
+    @include core.css("radio-dot-size", var.$dot-size);
     @include core.css("radio-color", var.$color);
+    @include core.css("radio-dot-color", var.$dot-color);
     @include core.css("radio-fill", var.$fill);
     @include core.css("radio-border-color", var.$border-color);
     @include core.css("radio-border-width", var.$border-width);
@@ -212,8 +214,6 @@ Radios are primarily customized using CSS variables but can also be modified usi
     @include core.css("radio-background-opacity-active", var.$background-opacity-active);
     @include core.css("radio-transition-duration", var.$transition-duration);
     @include core.css("radio-transition-timing-function", var.$transition-timing-function);
-    @include core.css("radio-dot-size", var.$dot-size);
-    @include core.css("radio-dot-color", var.$dot-color);
   }
 
   @include theme.output-themes("radio");
@@ -227,10 +227,11 @@ Radios are primarily customized using CSS variables but can also be modified usi
   @use "@vrembem/core/palette";
   @use "@vrembem/core/theme";
 
-  // Radio properties
   $size: core.$form-control-size !default;
   $circle-size: 20px !default;
+  $dot-size: 8px !default;
   $color: palette.get("primary") !default;
+  $dot-color: null !default;
   $fill: null !default;
   $border-color: null !default;
   $border-width: 2px !default;
@@ -239,24 +240,24 @@ Radios are primarily customized using CSS variables but can also be modified usi
   $background-opacity-hover: 20% !default;
   $background-opacity-focus: 20% !default;
   $background-opacity-active: 30% !default;
+
+  // Transition
   $transition-duration: core.$transition-duration-short !default;
   $transition-timing-function: core.$transition-timing-function !default;
 
-  // Dot properties
-  $dot-size: 8px !default;
-  $dot-color: null !default;
-
-  // Size modifier properties
+  // radio_size_sm
   $size-sm: core.$form-control-size-sm !default;
   $size-sm-border-width: 2px !default;
   $size-sm-circle: 16px !default;
   $size-sm-dot: 6px !default;
+
+  // radio_size_lg
   $size-lg: core.$form-control-size-lg !default;
   $size-lg-border-width: 2.5px !default;
   $size-lg-circle: 26px !default;
   $size-lg-dot: 10px !default;
 
-  // Theme properties
+  // Themes
   $theme-light: (
     "fill": white,
     "border-color": palette.get("neutral"),

--- a/docs/src/content/packages/radio.mdx
+++ b/docs/src/content/packages/radio.mdx
@@ -199,21 +199,21 @@ Radios are primarily customized using CSS variables but can also be modified usi
   @use "./variables" as var;
 
   #{theme.$root-selector} {
-    @include core.css-var("radio-size", var.$size);
-    @include core.css-var("radio-circle-size", var.$circle-size);
-    @include core.css-var("radio-color", var.$color);
-    @include core.css-var("radio-fill", var.$fill);
-    @include core.css-var("radio-border-color", var.$border-color);
-    @include core.css-var("radio-border-width", var.$border-width);
-    @include core.css-var("radio-background-border-radius", var.$background-border-radius);
-    @include core.css-var("radio-background-opacity", var.$background-opacity);
-    @include core.css-var("radio-background-opacity-hover", var.$background-opacity-hover);
-    @include core.css-var("radio-background-opacity-focus", var.$background-opacity-focus);
-    @include core.css-var("radio-background-opacity-active", var.$background-opacity-active);
-    @include core.css-var("radio-transition-duration", var.$transition-duration);
-    @include core.css-var("radio-transition-timing-function", var.$transition-timing-function);
-    @include core.css-var("radio-dot-size", var.$dot-size);
-    @include core.css-var("radio-dot-color", var.$dot-color);
+    @include core.css("radio-size", var.$size);
+    @include core.css("radio-circle-size", var.$circle-size);
+    @include core.css("radio-color", var.$color);
+    @include core.css("radio-fill", var.$fill);
+    @include core.css("radio-border-color", var.$border-color);
+    @include core.css("radio-border-width", var.$border-width);
+    @include core.css("radio-background-border-radius", var.$background-border-radius);
+    @include core.css("radio-background-opacity", var.$background-opacity);
+    @include core.css("radio-background-opacity-hover", var.$background-opacity-hover);
+    @include core.css("radio-background-opacity-focus", var.$background-opacity-focus);
+    @include core.css("radio-background-opacity-active", var.$background-opacity-active);
+    @include core.css("radio-transition-duration", var.$transition-duration);
+    @include core.css("radio-transition-timing-function", var.$transition-timing-function);
+    @include core.css("radio-dot-size", var.$dot-size);
+    @include core.css("radio-dot-color", var.$dot-color);
   }
 
   @include theme.output-themes("radio");

--- a/docs/src/content/packages/switch.mdx
+++ b/docs/src/content/packages/switch.mdx
@@ -167,21 +167,21 @@ Switches are primarily customized using CSS variables but can also be modified u
   @use "./variables" as var;
 
   #{theme.$root-selector} {
-    @include core.css-var("switch-size", var.$size);
-    @include core.css-var("switch-track-size", var.$track-size);
-    @include core.css-var("switch-color", var.$color);
-    @include core.css-var("switch-thumb-fill", var.$thumb-fill);
-    @include core.css-var("switch-track-fill", var.$track-fill);
-    @include core.css-var("switch-border-color", var.$border-color);
-    @include core.css-var("switch-border-width", var.$border-width);
-    @include core.css-var("switch-border-radius", var.$border-radius);
-    @include core.css-var("switch-background-border-radius", var.$background-border-radius);
-    @include core.css-var("switch-background-opacity", var.$background-opacity);
-    @include core.css-var("switch-background-opacity-hover", var.$background-opacity-hover);
-    @include core.css-var("switch-background-opacity-focus", var.$background-opacity-focus);
-    @include core.css-var("switch-background-opacity-active", var.$background-opacity-active);
-    @include core.css-var("switch-transition-duration", var.$transition-duration);
-    @include core.css-var("switch-transition-timing-function", var.$transition-timing-function);
+    @include core.css("switch-size", var.$size);
+    @include core.css("switch-track-size", var.$track-size);
+    @include core.css("switch-color", var.$color);
+    @include core.css("switch-thumb-fill", var.$thumb-fill);
+    @include core.css("switch-track-fill", var.$track-fill);
+    @include core.css("switch-border-color", var.$border-color);
+    @include core.css("switch-border-width", var.$border-width);
+    @include core.css("switch-border-radius", var.$border-radius);
+    @include core.css("switch-background-border-radius", var.$background-border-radius);
+    @include core.css("switch-background-opacity", var.$background-opacity);
+    @include core.css("switch-background-opacity-hover", var.$background-opacity-hover);
+    @include core.css("switch-background-opacity-focus", var.$background-opacity-focus);
+    @include core.css("switch-background-opacity-active", var.$background-opacity-active);
+    @include core.css("switch-transition-duration", var.$transition-duration);
+    @include core.css("switch-transition-timing-function", var.$transition-timing-function);
   }
 
   @include theme.output-themes("switch");

--- a/docs/src/content/packages/switch.mdx
+++ b/docs/src/content/packages/switch.mdx
@@ -195,7 +195,6 @@ Switches are primarily customized using CSS variables but can also be modified u
   @use "@vrembem/core/palette";
   @use "@vrembem/core/theme";
 
-  // Switch properties
   $size: core.$form-control-size !default;
   $track-size: 20px !default;
   $color: palette.get("primary") !default;
@@ -209,18 +208,22 @@ Switches are primarily customized using CSS variables but can also be modified u
   $background-opacity-hover: 20% !default;
   $background-opacity-focus: 20% !default;
   $background-opacity-active: 30% !default;
+
+  // Transition
   $transition-duration: core.$transition-duration-short !default;
   $transition-timing-function: core.$transition-timing-function !default;
 
-  // Size modifier properties
+  // switch_size_sm
   $size-sm: core.$form-control-size-sm !default;
   $size-sm-border-width: 2px !default;
   $size-sm-track: 16px !default;
+
+  // switch_size_lg
   $size-lg: core.$form-control-size-lg !default;
   $size-lg-border-width: 2.5px !default;
   $size-lg-track: 26px !default;
 
-  // Theme properties
+  // Themes
   $theme-light: (
     "thumb-fill": white,
     "track-fill": palette.get("neutral", 50%, 20%),

--- a/docs/src/pages/packages/index.mdx
+++ b/docs/src/pages/packages/index.mdx
@@ -7,7 +7,7 @@ filename: index
 
 # Packages
 
-Vrembem is organized into a set of packages. These packages all consist of a SCSS module and some also contain corresponding JavaScript ES modules. Most packages can be considered their own self enclosed components but there are some unique packages to consider.
+Vrembem is a collection of packages that consist of a SCSS modules and some JavaScript ES modules when needed. Most packages can be considered their own self enclosed components but there are some unique packages to consider.
 
 The core module (`@vrembem/core`) is used by all packages and is the central place that shared configurations and settings live. To make Vrembem wide changes (such as adjusting prefix values or color palettes), the core module is the place to do that.
 
@@ -17,18 +17,18 @@ Lastly the Vrembem package (simply named `vrembem`) is setup so that users can i
 
 ## Prefixes
 
-There are a number of ways to alter prefixes in Vrembem and they can all be changed either on a per-component bases or globally using the core module. The following prefixes can be set:
+There are a number prefixes used in Vrembem that can be changed globally using the core module. Vrembem prefixes include:
 
 - `$variable` (default `"vb-"`): Sets the prefix for all CSS variables.
 - `$theme` (default `"vb-theme-"`): Sets the prefix of theme classes.
-- `$block` (default `null`): Set the prefix of BEM CSS class blocks.
-- `$element` (default `"__"`): Set the prefix of BEM CSS class elements.
-- `$modifier` (default `"_"`): Set the prefix of BEM CSS class modifiers.
-- `$modifier-value` (default `"_"`): Set the prefix of BEM CSS class modifier values.
+- `$block` (default `null`): Set the prefix of BEM class blocks.
+- `$element` (default `"__"`): Set the prefix of BEM class elements.
+- `$modifier` (default `"_"`): Set the prefix of BEM class modifiers.
+- `$modifier-value` (default `"_"`): Set the prefix of BEM class modifier values.
 
 ## Palette Module
 
-The palette module is used to manage Vrembem's colors and their CSS variable output. These can be used directly in components or assigned to theme alias to make them more flexible using the theme system.
+The palette module is used to manage Vrembem's colors and their CSS variable output. These can be used directly in components or assigned to theme aliases to make them more flexible when using the theme system.
 
 By default, the palette module ships with four colors with a wide range of lightness values. This includes:
 

--- a/packages/button/src/_button.scss
+++ b/packages/button/src/_button.scss
@@ -1,60 +1,55 @@
 @use "@vrembem/core";
 @use "./variables" as var;
 
-$_v: var.$prefix-variable;
-$_b: var.$prefix-block;
-
-.#{$_b}button {
+#{core.bem("button")} {
   position: relative;
   display: inline-flex;
-  gap: var(--#{$_v}button-gap);
+  gap: core.css("button-gap");
   align-items: center;
   justify-content: center;
-  min-width: var(--#{$_v}button-size);
-  height: var(--#{$_v}button-size);
-  padding: var(--#{$_v}button-padding);
-  transition-property: var(--#{$_v}button-transition-property);
-  transition-duration: var(--#{$_v}button-transition-duration);
-  transition-timing-function: var(--#{$_v}button-transition-timing-function);
+  min-width: core.css("button-size");
+  height: core.css("button-size");
+  padding: core.css("button-padding");
+  transition-property: core.css("button-transition-property");
+  transition-duration: core.css("button-transition-duration");
+  transition-timing-function: core.css("button-transition-timing-function");
   outline: none;
-  border: var(--#{$_v}button-border-width) solid var(--#{$_v}button-border-color);
-  border-radius: var(--#{$_v}button-border-radius);
-  background: var(--#{$_v}button-background);
+  border: core.css("button-border-width") solid core.css("button-border-color");
+  border-radius: core.css("button-border-radius");
+  background: core.css("button-background");
   background-clip: border-box;
-  box-shadow: var(--#{$_v}button-box-shadow);
-  color: var(--#{$_v}button-foreground);
+  box-shadow: core.css("button-box-shadow");
+  color: core.css("button-foreground");
   font-family: inherit;
-  font-size: var(--#{$_v}button-font-size);
-  font-weight: var(--#{$_v}button-font-weight);
-  line-height: var(--#{$_v}button-line-height);
+  font-size: core.css("button-font-size");
+  font-weight: core.css("button-font-weight");
+  line-height: core.css("button-line-height");
   text-decoration: none;
   white-space: nowrap;
   cursor: pointer;
 
   &:disabled:not(.is-loading) {
-    opacity: var(--#{$_v}button-disabled-opacity);
+    opacity: core.css("button-disabled-opacity");
     pointer-events: none;
   }
 
-  &:hover {
-    border-color: var(--#{$_v}button-border-color-hover);
-    background-color: var(--#{$_v}button-background-hover);
-    box-shadow: var(--#{$_v}button-box-shadow-hover);
-    color: var(--#{$_v}button-foreground-hover);
+  &:hover,
+  &:focus-visible {
+    border-color: core.css("button-border-color-hover");
+    background-color: core.css("button-background-hover");
+    box-shadow: core.css("button-box-shadow");
+    color: core.css("button-foreground-hover");
   }
 
   &:focus-visible {
-    border-color: var(--#{$_v}button-border-color-hover);
-    background-color: var(--#{$_v}button-background-hover);
-    box-shadow: var(--#{$_v}button-box-shadow-focus);
-    color: var(--#{$_v}button-foreground-hover);
+    box-shadow: core.css("button-box-shadow-focus");
   }
 
   &:active {
-    border-color: var(--#{$_v}button-border-color-active);
-    background-color: var(--#{$_v}button-background-active);
-    box-shadow: var(--#{$_v}button-box-shadow-active);
-    color: var(--#{$_v}button-foreground-active);
+    border-color: core.css("button-border-color-active");
+    background-color: core.css("button-background-active");
+    box-shadow: core.css("button-box-shadow-active");
+    color: core.css("button-foreground-active");
   }
 
   &.is-loading {
@@ -62,15 +57,15 @@ $_b: var.$prefix-block;
     pointer-events: none;
 
     &::after {
-      @include core.size(var(--#{$_v}button-loading-size));
+      @include core.size(core.css("button-loading-size"));
       content: "";
       position: absolute;
-      top: calc(50% - (var(--#{$_v}button-loading-size) * 0.5));
-      left: calc(50% - (var(--#{$_v}button-loading-size) * 0.5));
-      animation: spin var(--#{$_v}button-loading-animation-duration) infinite var(--#{$_v}button-loading-animation-timing-function);
-      border: var(--#{$_v}button-loading-border);
+      top: calc(50% - calc(core.css("button-loading-size") * 0.5));
+      left: calc(50% - calc(core.css("button-loading-size") * 0.5));
+      animation: spin core.css("button-loading-animation-duration") infinite core.css("button-loading-animation-timing-function");
+      border: core.css("button-loading-border");
       border-radius: core.$border-radius-circle;
-      border-color: core.set-border-color(var.$loading-border-tpl, var(--#{$_v}button-foreground));
+      border-color: core.set-border-color(var.$loading-border-tpl, core.css("button-foreground"));
     }
   }
 }

--- a/packages/button/src/_button_block.scss
+++ b/packages/button/src/_button_block.scss
@@ -1,23 +1,19 @@
 @use "@vrembem/core";
 @use "./variables" as var;
 
-$_b: var.$prefix-block;
-$_m: var.$prefix-modifier;
-$_v: var.$prefix-modifier-value;
-
-.#{$_b}button#{$_m}block {
+#{core.bem("button", null, "block")} {
   display: flex;
   width: 100%;
 }
 
 @each $key, $value in var.$breakpoints {
-  .#{$_b}button#{$_m}block#{$_v}#{$key} {
+  #{core.bem("button", null, "block", $key)} {
     display: flex;
     width: 100%;
   }
 
   @include core.media-min($value) {
-    .#{$_b}button#{$_m}block#{$_v}#{$key} {
+    #{core.bem("button", null, "block", $key)} {
       display: inline-flex;
       width: auto;
     }

--- a/packages/button/src/_button_color.scss
+++ b/packages/button/src/_button_color.scss
@@ -1,23 +1,18 @@
-@use "@vrembem/core/palette";
-@use "./variables" as var;
+@use "@vrembem/core";
 @use "./mixins" as mix;
 
-$_b: var.$prefix-block;
-$_m: var.$prefix-modifier;
-$_v: var.$prefix-modifier-value;
-
-.#{$_b}button#{$_m}color#{$_v}primary {
+#{core.bem("button", null, "color", "primary")} {
   @include mix.button-variant(white, "primary");
 }
 
-.#{$_b}button#{$_m}color#{$_v}secondary {
+#{core.bem("button", null, "color", "secondary")} {
   @include mix.button-variant(white, "secondary");
 }
 
-.#{$_b}button#{$_m}color#{$_v}neutral {
+#{core.bem("button", null, "color", "neutral")} {
   @include mix.button-variant(white, "neutral");
 }
 
-.#{$_b}button#{$_m}color#{$_v}important {
+#{core.bem("button", null, "color", "important")} {
   @include mix.button-variant(white, "important");
 }

--- a/packages/button/src/_button_icon.scss
+++ b/packages/button/src/_button_icon.scss
@@ -1,19 +1,14 @@
-@use "sass:list";
+@use "@vrembem/core";
 @use "./variables" as var;
 
-$_v: var.$prefix-variable;
-$_b: var.$prefix-block;
-$_m: var.$prefix-modifier;
-$_mv: var.$prefix-modifier-value;
+#{core.bem("button", null, "icon")} {
+  @include core.css("button-padding", var.$icon-padding);
 
-.#{$_b}button#{$_m}icon {
-  --#{$_v}button-padding: #{var.$icon-padding};
-
-  &.#{$_b}button#{$_m}size#{$_mv}sm {
-    --#{$_v}button-padding: #{var.$icon-padding-sm};
+  &#{core.bem("button", null, "size", "sm")} {
+    @include core.css("button-padding", var.$icon-padding-sm);
   }
 
-  &.#{$_b}button#{$_m}size#{$_mv}lg {
-    --#{$_v}button-padding: #{var.$icon-padding-lg};
+  &#{core.bem("button", null, "size", "lg")} {
+    @include core.css("button-padding", var.$icon-padding-lg);
   }
 }

--- a/packages/button/src/_button_size.scss
+++ b/packages/button/src/_button_size.scss
@@ -1,21 +1,16 @@
 @use "@vrembem/core";
 @use "./variables" as var;
 
-$_v: var.$prefix-variable;
-$_b: var.$prefix-block;
-$_m: var.$prefix-modifier;
-$_mv: var.$prefix-modifier-value;
-
-.#{$_b}button#{$_m}size#{$_mv}sm {
-  --#{$_v}button-size: #{var.$size-sm};
-  --#{$_v}button-padding: #{var.$size-sm-padding};
-  --#{$_v}button-font-size: #{var.$size-sm-font-size};
-  --#{$_v}button-line-height: #{var.$size-sm-line-height};
+#{core.bem("button", null, "size", "sm")} {
+  @include core.css("button-size", var.$size-sm);
+  @include core.css("button-padding", var.$size-sm-padding);
+  @include core.css("button-font-size", var.$size-sm-font-size);
+  @include core.css("button-line-height", var.$size-sm-line-height);
 }
 
-.#{$_b}button#{$_m}size#{$_mv}lg {
-  --#{$_v}button-size: #{var.$size-lg};
-  --#{$_v}button-padding: #{var.$size-lg-padding};
-  --#{$_v}button-font-size: #{var.$size-lg-font-size};
-  --#{$_v}button-line-height: #{var.$size-lg-line-height};
+#{core.bem("button", null, "size", "lg")} {
+  @include core.css("button-size", var.$size-lg);
+  @include core.css("button-padding", var.$size-lg-padding);
+  @include core.css("button-font-size", var.$size-lg-font-size);
+  @include core.css("button-line-height", var.$size-lg-line-height);
 }

--- a/packages/button/src/_mixins.scss
+++ b/packages/button/src/_mixins.scss
@@ -1,22 +1,20 @@
+@use "@vrembem/core";
 @use "@vrembem/core/palette";
-@use "./variables" as var;
-
-$_v: var.$prefix-variable;
 
 /// Creates a button variant using CSS variables and the palette module.
 /// @param {Color} $foreground - A color for the foreground of the button.
 /// @param {String} $background - The color key for the background of the button (should exist in palette map).
 /// @output Outputs theme CSS variables based on the provided foreground and background.
 @mixin button-variant($foreground, $background) {
-  --#{$_v}button-background: #{palette.get($background)};
-  --#{$_v}button-background-hover: #{palette.get($background, 40)};
-  --#{$_v}button-background-active: #{palette.get($background, 30)};
-  --#{$_v}button-foreground: #{$foreground};
-  --#{$_v}button-foreground-hover: #{$foreground};
-  --#{$_v}button-foreground-active: #{$foreground};
-  --#{$_v}button-border-color: transparent;
-  --#{$_v}button-border-color-hover: transparent;
-  --#{$_v}button-border-color-active: transparent;
-  --#{$_v}button-box-shadow: 0 0 0 0 #{palette.get($background, 50%, 0%)};
-  --#{$_v}button-box-shadow-focus: 0 0 0 0.2rem #{palette.get($background, 50%, 50%)};
+  @include core.css("button-background", palette.get($background));
+  @include core.css("button-background-hover", palette.get($background, 40));
+  @include core.css("button-background-active", palette.get($background, 30));
+  @include core.css("button-foreground", $foreground);
+  @include core.css("button-foreground-hover", $foreground);
+  @include core.css("button-foreground-active", $foreground);
+  @include core.css("button-border-color", transparent);
+  @include core.css("button-border-color-hover", transparent);
+  @include core.css("button-border-color-active", transparent);
+  @include core.css("button-box-shadow", 0 0 0 0 #{palette.get($background, 50%, 0%)});
+  @include core.css("button-box-shadow-focus", 0 0 0 0.2rem #{palette.get($background, 50%, 50%)});
 }

--- a/packages/button/src/_root.scss
+++ b/packages/button/src/_root.scss
@@ -1,33 +1,42 @@
+@use "@vrembem/core";
 @use "@vrembem/core/theme";
 @use "./variables" as var;
 
-$_v: var.$prefix-variable;
-
-:root {
+#{theme.$root-selector} {
   // Size properties
-  --#{$_v}button-size: #{var.$size};
-  --#{$_v}button-padding: #{var.$padding};
-  --#{$_v}button-gap: #{var.$gap};
-  --#{$_v}button-border-width: #{var.$border-width};
-  --#{$_v}button-border-radius: #{var.$border-radius};
-  --#{$_v}button-font-size: #{var.$font-size};
-  --#{$_v}button-font-weight: #{var.$font-weight};
-  --#{$_v}button-line-height: #{var.$line-height};
+  @include core.css("button-size", var.$size);
+  @include core.css("button-padding", var.$padding);
+  @include core.css("button-gap", var.$gap);
+  @include core.css("button-border-width", var.$border-width);
+  @include core.css("button-border-radius", var.$border-radius);
+  @include core.css("button-font-size", var.$font-size);
+  @include core.css("button-font-weight", var.$font-weight);
+  @include core.css("button-line-height", var.$line-height);
+
+  // Theme properties
+  @include core.css("button-background", var.$background);
+  @include core.css("button-background-hover", var.$background-hover);
+  @include core.css("button-background-active", var.$background-active);
+  @include core.css("button-foreground", var.$foreground);
+  @include core.css("button-foreground-hover", var.$foreground-hover);
+  @include core.css("button-foreground-active", var.$foreground-active);
+  @include core.css("button-border-color", var.$border-color);
+  @include core.css("button-border-color-hover", var.$border-color-hover);
+  @include core.css("button-border-color-active", var.$border-color-active);
+  @include core.css("button-box-shadow", var.$box-shadow);
+  @include core.css("button-box-shadow-focus", var.$box-shadow-focus);
 
   // Transition properties
-  --#{$_v}button-transition-property: #{var.$transition-property};
-  --#{$_v}button-transition-duration: #{var.$transition-duration};
-  --#{$_v}button-transition-timing-function: #{var.$transition-timing-function};
+  @include core.css("button-transition-property", var.$transition-property);
+  @include core.css("button-transition-duration", var.$transition-duration);
+  @include core.css("button-transition-timing-function", var.$transition-timing-function);
   
   // Disabled
-  --#{$_v}button-disabled-opacity: #{var.$disabled-opacity};
+  @include core.css("button-disabled-opacity", var.$disabled-opacity);
   
   // is-loading
-  --#{$_v}button-loading-size: #{var.$loading-size};
-  --#{$_v}button-loading-border: #{var.$loading-border};
-  --#{$_v}button-loading-animation-duration: #{var.$loading-animation-duration};
-  --#{$_v}button-loading-animation-timing-function: #{var.$loading-animation-timing-function};
+  @include core.css("button-loading-size", var.$loading-size);
+  @include core.css("button-loading-border", var.$loading-border);
+  @include core.css("button-loading-animation-duration", var.$loading-animation-duration);
+  @include core.css("button-loading-animation-timing-function", var.$loading-animation-timing-function);
 }
-
-// Theme properties
-@include theme.output-themes("button");

--- a/packages/button/src/_root.scss
+++ b/packages/button/src/_root.scss
@@ -3,17 +3,9 @@
 @use "./variables" as var;
 
 #{theme.$root-selector} {
-  // Size properties
   @include core.css("button-size", var.$size);
   @include core.css("button-padding", var.$padding);
   @include core.css("button-gap", var.$gap);
-  @include core.css("button-border-width", var.$border-width);
-  @include core.css("button-border-radius", var.$border-radius);
-  @include core.css("button-font-size", var.$font-size);
-  @include core.css("button-font-weight", var.$font-weight);
-  @include core.css("button-line-height", var.$line-height);
-
-  // Theme properties
   @include core.css("button-background", var.$background);
   @include core.css("button-background-hover", var.$background-hover);
   @include core.css("button-background-active", var.$background-active);
@@ -23,18 +15,17 @@
   @include core.css("button-border-color", var.$border-color);
   @include core.css("button-border-color-hover", var.$border-color-hover);
   @include core.css("button-border-color-active", var.$border-color-active);
+  @include core.css("button-border-width", var.$border-width);
+  @include core.css("button-border-radius", var.$border-radius);
   @include core.css("button-box-shadow", var.$box-shadow);
   @include core.css("button-box-shadow-focus", var.$box-shadow-focus);
-
-  // Transition properties
+  @include core.css("button-font-size", var.$font-size);
+  @include core.css("button-font-weight", var.$font-weight);
+  @include core.css("button-line-height", var.$line-height);
   @include core.css("button-transition-property", var.$transition-property);
   @include core.css("button-transition-duration", var.$transition-duration);
   @include core.css("button-transition-timing-function", var.$transition-timing-function);
-  
-  // Disabled
   @include core.css("button-disabled-opacity", var.$disabled-opacity);
-  
-  // is-loading
   @include core.css("button-loading-size", var.$loading-size);
   @include core.css("button-loading-border", var.$loading-border);
   @include core.css("button-loading-animation-duration", var.$loading-animation-duration);

--- a/packages/button/src/_variables.scss
+++ b/packages/button/src/_variables.scss
@@ -2,18 +2,10 @@
 @use "@vrembem/core";
 @use "@vrembem/core/theme";
 
-// Size properties
+$breakpoints: core.$breakpoints !default;
 $size: core.$form-control-size !default;
 $padding: calc(#{list.nth(core.$padding, 1)} - 1px) list.nth(core.$padding, 2) !default;
 $gap: 0.5rem !default;
-$border-width: 1px !default;
-$border-radius: core.$border-radius !default;
-$font-size: 1em !default;
-$font-weight: inherit !default;
-$line-height: 1.6 !default;
-$breakpoints: core.$breakpoints !default;
-
-// Theme properties
 $background: transparent !default;
 $background-hover: transparent !default;
 $background-active: transparent !default;
@@ -23,10 +15,15 @@ $foreground-active: theme.get("foreground") !default;
 $border-color: theme.get("border-color-dark") !default;
 $border-color-hover: theme.get("border-color-darker") !default;
 $border-color-active: theme.get("border-color-darker") !default;
+$border-width: 1px !default;
+$border-radius: core.$border-radius !default;
 $box-shadow: 0 0 0 0 rgb(0 0 0 / 0%) !default;
 $box-shadow-focus: 0 0 0 0.2rem rgb(0 0 0 / 15%) !default;
+$font-size: 1em !default;
+$font-weight: inherit !default;
+$line-height: 1.6 !default;
 
-// Transition properties
+// Transition
 $transition-property: background, color, border-color, box-shadow !default;
 $transition-duration: core.$transition-duration-short !default;
 $transition-timing-function: core.$transition-timing-function !default;

--- a/packages/button/src/_variables.scss
+++ b/packages/button/src/_variables.scss
@@ -2,13 +2,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/theme";
 
-// Prefix variables
-$prefix-variable: core.$prefix-variable !default;
-$prefix-block: core.$prefix-block !default;
-$prefix-element: core.$prefix-element !default;
-$prefix-modifier: core.$prefix-modifier !default;
-$prefix-modifier-value: core.$prefix-modifier-value !default;
-
 // Size properties
 $size: core.$form-control-size !default;
 $padding: calc(#{list.nth(core.$padding, 1)} - 1px) list.nth(core.$padding, 2) !default;
@@ -19,6 +12,19 @@ $font-size: 1em !default;
 $font-weight: inherit !default;
 $line-height: 1.6 !default;
 $breakpoints: core.$breakpoints !default;
+
+// Theme properties
+$background: transparent;
+$background-hover: transparent;
+$background-active: transparent;
+$foreground: theme.get("foreground");
+$foreground-hover: theme.get("foreground");
+$foreground-active: theme.get("foreground");
+$border-color: theme.get("border-color-dark");
+$border-color-hover: theme.get("border-color-darker");
+$border-color-active: theme.get("border-color-darker");
+$box-shadow: 0 0 0 0 rgb(0 0 0 / 0%);
+$box-shadow-focus: 0 0 0 0.2rem rgb(0 0 0 / 15%);
 
 // Transition properties
 $transition-property: background, color, border-color, box-shadow !default;
@@ -51,20 +57,3 @@ $size-lg: core.$form-control-size-lg !default;
 $size-lg-padding: calc(#{list.nth(core.$padding-lg, 1)} - 1px) list.nth(core.$padding-lg, 2) !default;
 $size-lg-font-size: core.$font-size-lg !default;
 $size-lg-line-height: core.$line-height-lg !default;
-
-// Theme properties
-$theme: (
-  "background": transparent,
-  "background-hover": transparent,
-  "background-active": transparent,
-  "foreground": theme.get("foreground"),
-  "foreground-hover": theme.get("foreground"),
-  "foreground-active": theme.get("foreground"),
-  "border-color": theme.get("border-color-dark"),
-  "border-color-hover": theme.get("border-color-darker"),
-  "border-color-active": theme.get("border-color-darker"),
-  "box-shadow": 0 0 0 0 rgb(0 0 0 / 0%),
-  "box-shadow-focus": 0 0 0 0.2rem rgb(0 0 0 / 15%),
-) !default;
-
-@include theme.set(theme.$default, "button", $theme);

--- a/packages/button/src/_variables.scss
+++ b/packages/button/src/_variables.scss
@@ -14,17 +14,17 @@ $line-height: 1.6 !default;
 $breakpoints: core.$breakpoints !default;
 
 // Theme properties
-$background: transparent;
-$background-hover: transparent;
-$background-active: transparent;
-$foreground: theme.get("foreground");
-$foreground-hover: theme.get("foreground");
-$foreground-active: theme.get("foreground");
-$border-color: theme.get("border-color-dark");
-$border-color-hover: theme.get("border-color-darker");
-$border-color-active: theme.get("border-color-darker");
-$box-shadow: 0 0 0 0 rgb(0 0 0 / 0%);
-$box-shadow-focus: 0 0 0 0.2rem rgb(0 0 0 / 15%);
+$background: transparent !default;
+$background-hover: transparent !default;
+$background-active: transparent !default;
+$foreground: theme.get("foreground") !default;
+$foreground-hover: theme.get("foreground") !default;
+$foreground-active: theme.get("foreground") !default;
+$border-color: theme.get("border-color-dark") !default;
+$border-color-hover: theme.get("border-color-darker") !default;
+$border-color-active: theme.get("border-color-darker") !default;
+$box-shadow: 0 0 0 0 rgb(0 0 0 / 0%) !default;
+$box-shadow-focus: 0 0 0 0.2rem rgb(0 0 0 / 15%) !default;
 
 // Transition properties
 $transition-property: background, color, border-color, box-shadow !default;

--- a/packages/card/src/_card.scss
+++ b/packages/card/src/_card.scss
@@ -1,110 +1,105 @@
 @use "@vrembem/core";
-@use "./variables" as var;
 
-$_v: var.$prefix-variable;
-$_b: var.$prefix-block;
-$_e: var.$prefix-element;
-
-.#{$_b}card {
+#{core.bem("card")} {
   position: relative;
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  transition-property: var(--#{$_v}card-transition-property);
-  transition-duration: var(--#{$_v}card-transition-duration);
-  transition-timing-function: var(--#{$_v}card-transition-timing-function);
-  border: var(--#{$_v}card-border);
-  border-radius: var(--#{$_v}card-border-radius);
-  background: var(--#{$_v}card-background);
+  transition-property: core.css("card-transition-property");
+  transition-duration: core.css("card-transition-duration");
+  transition-timing-function: core.css("card-transition-timing-function");
+  border: core.css("card-border");
+  border-radius: core.css("card-border-radius");
+  background: core.css("card-background");
   background-clip: padding-box;
-  box-shadow: var(--#{$_v}card-box-shadow);
-  color: var(--#{$_v}card-foreground);
+  box-shadow: core.css("card-box-shadow");
+  color: core.css("card-foreground");
 }
 
-a.#{$_b}card {
+a#{core.bem("card")} {
   transform: translate(0, 0);
-  box-shadow: var(--#{$_v}card-link-box-shadow);
+  box-shadow: core.css("card-link-box-shadow");
 
   &:hover,
   &:focus,
   &:focus-within {
-    transform: translate(0, var(--#{$_v}card-link-offset));
-    box-shadow: var(--#{$_v}card-link-box-shadow-hover);
+    transform: translate(0, core.css("card-link-offset"));
+    box-shadow: core.css("card-link-box-shadow-hover");
   }
 }
 
-.#{$_b}card#{$_e}header,
-.#{$_b}card#{$_e}body,
-.#{$_b}card#{$_e}footer,
-.#{$_b}card#{$_e}image {
+#{core.bem("card", "header")},
+#{core.bem("card", "body")},
+#{core.bem("card", "footer")},
+#{core.bem("card", "image")} {
   position: relative;
   z-index: 3;
 
   &:first-child {
-    border-top-left-radius: var(--#{$_v}card-border-radius);
-    border-top-right-radius: var(--#{$_v}card-border-radius);
+    border-top-left-radius: core.css("card-border-radius");
+    border-top-right-radius: core.css("card-border-radius");
   }
 
   &:last-child {
-    border-bottom-left-radius: var(--#{$_v}card-border-radius);
-    border-bottom-right-radius: var(--#{$_v}card-border-radius);
+    border-bottom-left-radius: core.css("card-border-radius");
+    border-bottom-right-radius: core.css("card-border-radius");
   }
 }
 
-.#{$_b}card#{$_e}body,
-.#{$_b}card#{$_e}header,
-.#{$_b}card#{$_e}footer {
-  padding: var(--#{$_v}card-padding);
+#{core.bem("card", "header")},
+#{core.bem("card", "body")},
+#{core.bem("card", "footer")} {
+  padding: core.css("card-padding");
 }
 
-.#{$_b}card#{$_e}body {
+#{core.bem("card", "body")} {
   flex: 1 1 auto;
 
   & + & {
-    border-top: var(--#{$_v}card-sep-border);
+    border-top: core.css("card-sep-border");
   }
 }
 
-.#{$_b}card#{$_e}header {
-  border-bottom: var(--#{$_v}card-sep-border);
+#{core.bem("card", "header")} {
+  border-bottom: core.css("card-sep-border");
 }
 
-.#{$_b}card#{$_e}footer {
-  border-top: var(--#{$_v}card-sep-border);
+#{core.bem("card", "footer")} {
+  border-top: core.css("card-sep-border");
 }
 
-.#{$_b}card#{$_e}image {
+#{core.bem("card", "image")} {
   flex: 0 1 auto;
   width: 100%;
   height: auto;
 }
 
-.#{$_b}card#{$_e}title {
+#{core.bem("card", "title")} {
   flex-grow: 1;
-  color: var(--#{$_v}card-title-color);
-  font-size: var(--#{$_v}card-title-font-size);
-  font-weight: var(--#{$_v}card-title-font-weight);
-  line-height: var(--#{$_v}card-title-line-height);
+  color: core.css("card-title-color");
+  font-size: core.css("card-title-font-size");
+  font-weight: core.css("card-title-font-weight");
+  line-height: core.css("card-title-line-height");
 }
 
-.#{$_b}card#{$_e}background,
-.#{$_b}card#{$_e}screen {
+#{core.bem("card", "background")},
+#{core.bem("card", "screen")} {
   @include core.size(100%);
   position: absolute;
   inset: 0;
-  transition-property: var(--#{$_v}card-transition-property);
-  transition-duration: var(--#{$_v}card-transition-duration);
-  transition-timing-function: var(--#{$_v}card-transition-timing-function);
-  border-radius: var(--#{$_v}card-border-radius);
+  transition-property: core.css("card-transition-property");
+  transition-duration: core.css("card-transition-duration");
+  transition-timing-function: core.css("card-transition-timing-function");
+  border-radius: core.css("card-border-radius");
 }
 
-.#{$_b}card#{$_e}background {
+#{core.bem("card", "background")} {
   object-fit: cover;
   z-index: 1;
 }
 
-.#{$_b}card#{$_e}screen {
+#{core.bem("card", "screen")} {
   z-index: 2;
-  background: var(--#{$_v}card-screen-background);
-  opacity: var(--#{$_v}card-screen-opacity);
+  background: core.css("card-screen-background");
+  opacity: core.css("card-screen-opacity");
 }

--- a/packages/card/src/_root.scss
+++ b/packages/card/src/_root.scss
@@ -1,29 +1,27 @@
+@use "@vrembem/core";
 @use "@vrembem/core/theme";
 @use "./variables" as var;
 
-$_v: var.$prefix-variable;
-
-:root {
-  // Size properties
-  --#{$_v}card-padding: #{var.$padding};
-  --#{$_v}card-border-radius: #{var.$border-radius};
-  --#{$_v}card-box-shadow: #{var.$box-shadow};
-
-  // Transition properties
-  --#{$_v}card-transition-property: #{var.$transition-property};
-  --#{$_v}card-transition-duration: #{var.$transition-duration};
-  --#{$_v}card-transition-timing-function: #{var.$transition-timing-function};
-
-  // Title properties
-  --#{$_v}card-title-font-size: #{var.$title-font-size};
-  --#{$_v}card-title-line-height: #{var.$title-line-height};
-  --#{$_v}card-title-font-weight: #{var.$title-font-weight};
-
-  // Link properties
-  --#{$_v}card-link-box-shadow: #{var.$link-box-shadow};
-  --#{$_v}card-link-box-shadow-hover: #{var.$link-box-shadow-hover};
-  --#{$_v}card-link-offset: #{var.$link-offset};
+#{theme.$root-selector} {
+  @include core.css("card-padding", var.$padding);
+  @include core.css("card-background", var.$background);
+  @include core.css("card-foreground", var.$foreground);
+  @include core.css("card-border", var.$border);
+  @include core.css("card-sep-border", var.$sep-border);
+  @include core.css("card-border-radius", var.$border-radius);
+  @include core.css("card-box-shadow", var.$box-shadow);
+  @include core.css("card-screen-background", var.$screen-background);
+  @include core.css("card-screen-opacity", var.$screen-opacity);
+  @include core.css("card-transition-property", var.$transition-property);
+  @include core.css("card-transition-duration", var.$transition-duration);
+  @include core.css("card-transition-timing-function", var.$transition-timing-function);
+  @include core.css("card-title-color", var.$title-color);
+  @include core.css("card-title-font-size", var.$title-font-size);
+  @include core.css("card-title-line-height", var.$title-line-height);
+  @include core.css("card-title-font-weight", var.$title-font-weight);
+  @include core.css("card-link-box-shadow", var.$link-box-shadow);
+  @include core.css("card-link-box-shadow-hover", var.$link-box-shadow-hover);
+  @include core.css("card-link-offset", var.$link-offset);
 }
 
-// Theme properties
 @include theme.output-themes("card");

--- a/packages/card/src/_root.scss
+++ b/packages/card/src/_root.scss
@@ -12,16 +12,16 @@
   @include core.css("card-box-shadow", var.$box-shadow);
   @include core.css("card-screen-background", var.$screen-background);
   @include core.css("card-screen-opacity", var.$screen-opacity);
-  @include core.css("card-transition-property", var.$transition-property);
-  @include core.css("card-transition-duration", var.$transition-duration);
-  @include core.css("card-transition-timing-function", var.$transition-timing-function);
+  @include core.css("card-link-box-shadow", var.$link-box-shadow);
+  @include core.css("card-link-box-shadow-hover", var.$link-box-shadow-hover);
+  @include core.css("card-link-offset", var.$link-offset);
   @include core.css("card-title-color", var.$title-color);
   @include core.css("card-title-font-size", var.$title-font-size);
   @include core.css("card-title-line-height", var.$title-line-height);
   @include core.css("card-title-font-weight", var.$title-font-weight);
-  @include core.css("card-link-box-shadow", var.$link-box-shadow);
-  @include core.css("card-link-box-shadow-hover", var.$link-box-shadow-hover);
-  @include core.css("card-link-offset", var.$link-offset);
+  @include core.css("card-transition-property", var.$transition-property);
+  @include core.css("card-transition-duration", var.$transition-duration);
+  @include core.css("card-transition-timing-function", var.$transition-timing-function);
 }
 
 @include theme.output-themes("card");

--- a/packages/card/src/_variables.scss
+++ b/packages/card/src/_variables.scss
@@ -9,19 +9,28 @@ $border: null !default;
 $sep-border: null !default;
 $border-radius: core.$border-radius !default;
 $box-shadow: core.$shadow-1 !default;
+
+// Screen
 $screen-background: null !default;
 $screen-opacity: null !default;
-$transition-property: background-color, border-color, box-shadow, transform !default;
-$transition-duration: core.$transition-duration !default;
-$transition-timing-function: core.$transition-timing-function !default;
-$title-color: null !default;
-$title-font-size: core.$font-size-lg !default;
-$title-line-height: core.$line-height-lg !default;
-$title-font-weight: core.$font-weight-semi-bold !default;
+
+// Link
 $link-box-shadow: core.$shadow-2 !default;
 $link-box-shadow-hover: core.$shadow-3 !default;
 $link-offset: -0.25em !default;
 
+// Title
+$title-color: null !default;
+$title-font-size: core.$font-size-lg !default;
+$title-line-height: core.$line-height-lg !default;
+$title-font-weight: core.$font-weight-semi-bold !default;
+
+// Transition
+$transition-property: background-color, border-color, box-shadow, transform !default;
+$transition-duration: core.$transition-duration !default;
+$transition-timing-function: core.$transition-timing-function !default;
+
+// Themes
 $theme-light: (
   "background": theme.get("background"),
   "foreground": theme.get("foreground-light"),

--- a/packages/card/src/_variables.scss
+++ b/packages/card/src/_variables.scss
@@ -2,34 +2,26 @@
 @use "@vrembem/core/theme";
 @use "@vrembem/core/palette";
 
-// Prefix variables
-$prefix-variable: core.$prefix-variable !default;
-$prefix-block: core.$prefix-block !default;
-$prefix-element: core.$prefix-element !default;
-$prefix-modifier: core.$prefix-modifier !default;
-$prefix-modifier-value: core.$prefix-modifier-value !default;
-
-// Size properties
 $padding: 1.25em !default;
+$background: null !default;
+$foreground: null !default;
+$border: null !default;
+$sep-border: null !default;
 $border-radius: core.$border-radius !default;
 $box-shadow: core.$shadow-1 !default;
-
-// Transition properties
+$screen-background: null !default;
+$screen-opacity: null !default;
 $transition-property: background-color, border-color, box-shadow, transform !default;
 $transition-duration: core.$transition-duration !default;
 $transition-timing-function: core.$transition-timing-function !default;
-
-// Title properties
+$title-color: null !default;
 $title-font-size: core.$font-size-lg !default;
 $title-line-height: core.$line-height-lg !default;
 $title-font-weight: core.$font-weight-semi-bold !default;
-
-// Link properties
 $link-box-shadow: core.$shadow-2 !default;
 $link-box-shadow-hover: core.$shadow-3 !default;
 $link-offset: -0.25em !default;
 
-// Theme properties
 $theme-light: (
   "background": theme.get("background"),
   "foreground": theme.get("foreground-light"),

--- a/packages/checkbox/src/_checkbox_size.scss
+++ b/packages/checkbox/src/_checkbox_size.scss
@@ -3,11 +3,11 @@
 @use "./functions" as fun;
 
 #{core.bem("checkbox", null, "size", "sm")} {
-  @include core.css-var("checkbox-size", var.$size-sm);
-  @include core.css-var("checkbox-border-width", var.$size-sm-border-width);
-  @include core.css-var("checkbox-box-size", var.$size-sm-box);
-  @include core.css-var("checkbox-icon-size", var.$size-sm-icon);
-  @include core.css-var("checkbox-icon-stroke", var.$size-sm-icon-stroke);
+  @include core.css("checkbox-size", var.$size-sm);
+  @include core.css("checkbox-border-width", var.$size-sm-border-width);
+  @include core.css("checkbox-box-size", var.$size-sm-box);
+  @include core.css("checkbox-icon-size", var.$size-sm-icon);
+  @include core.css("checkbox-icon-stroke", var.$size-sm-icon-stroke);
 
   #{core.bem("checkbox", "icon")} {
     mask-image: url("#{fun.icon-check(var.$icon-size, var.$size-sm-icon-stroke)}");
@@ -19,11 +19,11 @@
 }
 
 #{core.bem("checkbox", null, "size", "lg")} {
-  @include core.css-var("checkbox-size", var.$size-lg);
-  @include core.css-var("checkbox-border-width", var.$size-lg-border-width);
-  @include core.css-var("checkbox-box-size", var.$size-lg-box);
-  @include core.css-var("checkbox-icon-size", var.$size-lg-icon);
-  @include core.css-var("checkbox-icon-stroke", var.$size-lg-icon-stroke);
+  @include core.css("checkbox-size", var.$size-lg);
+  @include core.css("checkbox-border-width", var.$size-lg-border-width);
+  @include core.css("checkbox-box-size", var.$size-lg-box);
+  @include core.css("checkbox-icon-size", var.$size-lg-icon);
+  @include core.css("checkbox-icon-stroke", var.$size-lg-icon-stroke);
 
   #{core.bem("checkbox", "icon")} {
     mask-image: url("#{fun.icon-check(var.$icon-size, var.$size-lg-icon-stroke)}");

--- a/packages/checkbox/src/_root.scss
+++ b/packages/checkbox/src/_root.scss
@@ -3,23 +3,23 @@
 @use "./variables" as var;
 
 #{theme.$root-selector} {
-  @include core.css-var("checkbox-size", var.$size);
-  @include core.css-var("checkbox-box-size", var.$box-size);
-  @include core.css-var("checkbox-color", var.$color);
-  @include core.css-var("checkbox-fill", var.$fill);
-  @include core.css-var("checkbox-border-color", var.$border-color);
-  @include core.css-var("checkbox-border-width", var.$border-width);
-  @include core.css-var("checkbox-border-radius", var.$border-radius);
-  @include core.css-var("checkbox-background-border-radius", var.$background-border-radius);
-  @include core.css-var("checkbox-background-opacity", var.$background-opacity);
-  @include core.css-var("checkbox-background-opacity-hover", var.$background-opacity-hover);
-  @include core.css-var("checkbox-background-opacity-focus", var.$background-opacity-focus);
-  @include core.css-var("checkbox-background-opacity-active", var.$background-opacity-active);
-  @include core.css-var("checkbox-transition-duration", var.$transition-duration);
-  @include core.css-var("checkbox-transition-timing-function", var.$transition-timing-function);
-  @include core.css-var("checkbox-icon-size", var.$icon-size);
-  @include core.css-var("checkbox-icon-color", var.$icon-color);
-  @include core.css-var("checkbox-icon-stroke", var.$icon-stroke);
+  @include core.css("checkbox-size", var.$size);
+  @include core.css("checkbox-box-size", var.$box-size);
+  @include core.css("checkbox-color", var.$color);
+  @include core.css("checkbox-fill", var.$fill);
+  @include core.css("checkbox-border-color", var.$border-color);
+  @include core.css("checkbox-border-width", var.$border-width);
+  @include core.css("checkbox-border-radius", var.$border-radius);
+  @include core.css("checkbox-background-border-radius", var.$background-border-radius);
+  @include core.css("checkbox-background-opacity", var.$background-opacity);
+  @include core.css("checkbox-background-opacity-hover", var.$background-opacity-hover);
+  @include core.css("checkbox-background-opacity-focus", var.$background-opacity-focus);
+  @include core.css("checkbox-background-opacity-active", var.$background-opacity-active);
+  @include core.css("checkbox-transition-duration", var.$transition-duration);
+  @include core.css("checkbox-transition-timing-function", var.$transition-timing-function);
+  @include core.css("checkbox-icon-size", var.$icon-size);
+  @include core.css("checkbox-icon-color", var.$icon-color);
+  @include core.css("checkbox-icon-stroke", var.$icon-stroke);
 }
 
 @include theme.output-themes("checkbox");

--- a/packages/checkbox/src/_root.scss
+++ b/packages/checkbox/src/_root.scss
@@ -5,7 +5,10 @@
 #{theme.$root-selector} {
   @include core.css("checkbox-size", var.$size);
   @include core.css("checkbox-box-size", var.$box-size);
+  @include core.css("checkbox-icon-size", var.$icon-size);
   @include core.css("checkbox-color", var.$color);
+  @include core.css("checkbox-icon-color", var.$icon-color);
+  @include core.css("checkbox-icon-stroke", var.$icon-stroke);
   @include core.css("checkbox-fill", var.$fill);
   @include core.css("checkbox-border-color", var.$border-color);
   @include core.css("checkbox-border-width", var.$border-width);
@@ -17,9 +20,6 @@
   @include core.css("checkbox-background-opacity-active", var.$background-opacity-active);
   @include core.css("checkbox-transition-duration", var.$transition-duration);
   @include core.css("checkbox-transition-timing-function", var.$transition-timing-function);
-  @include core.css("checkbox-icon-size", var.$icon-size);
-  @include core.css("checkbox-icon-color", var.$icon-color);
-  @include core.css("checkbox-icon-stroke", var.$icon-stroke);
 }
 
 @include theme.output-themes("checkbox");

--- a/packages/checkbox/src/_variables.scss
+++ b/packages/checkbox/src/_variables.scss
@@ -2,10 +2,12 @@
 @use "@vrembem/core/palette";
 @use "@vrembem/core/theme";
 
-// Checkbox properties
 $size: core.$form-control-size !default;
 $box-size: 18px !default;
+$icon-size: 12px !default;
 $color: palette.get("primary") !default;
+$icon-color: null !default;
+$icon-stroke: 2.5 !default;
 $fill: null !default;
 $border-color: null !default;
 $border-width: 2px !default;
@@ -15,27 +17,26 @@ $background-opacity: 0% !default;
 $background-opacity-hover: 20% !default;
 $background-opacity-focus: 20% !default;
 $background-opacity-active: 30% !default;
+
+// Transition
 $transition-duration: core.$transition-duration-short !default;
 $transition-timing-function: core.$transition-timing-function !default;
 
-// Icon properties
-$icon-size: 12px !default;
-$icon-color: null !default;
-$icon-stroke: 2.5 !default;
-
-// Size modifier properties
+// checkbox_size_sm
 $size-sm: core.$form-control-size-sm !default;
 $size-sm-border-width: 2px !default;
 $size-sm-box: 14px !default;
 $size-sm-icon: 10px !default;
 $size-sm-icon-stroke: 2.5 !default;
+
+// checkbox_size_lg
 $size-lg: core.$form-control-size-lg !default;
 $size-lg-border-width: 2.5px !default;
 $size-lg-box: 24px !default;
 $size-lg-icon: 18px !default;
 $size-lg-icon-stroke: 2 !default;
 
-// Theme properties
+// Themes
 $theme-light: (
   "fill": white,
   "border-color": palette.get("neutral"),

--- a/packages/core/src/scss/_mixins.scss
+++ b/packages/core/src/scss/_mixins.scss
@@ -13,6 +13,11 @@
   }
 }
 
+// TODO: Maybe change mixin names css-var -> css.
+@mixin css($name, $value) {
+  @include css-var($name, $value);
+}
+
 /// A media query mixin that defines a query using max-width. You can pass in a
 /// key to the `$breakpoints()` maps to access that value, or pass a value to
 /// create your media query. This mixin will shave a pixel off your breakpoint

--- a/packages/core/src/scss/_mixins.scss
+++ b/packages/core/src/scss/_mixins.scss
@@ -7,15 +7,10 @@
 /// @param {String} $name - The name to use in the CSS variable property.
 /// @param {All} $value - The value of the CSS variable. Can be any valid CSS property value.
 /// @output CSS Variable or nothing.
-@mixin css-var($name, $value) {
+@mixin css($name, $value) {
   @if ($value) {
     --#{prefix.$variable}#{$name}: #{$value};
   }
-}
-
-// TODO: Maybe change mixin names css-var -> css.
-@mixin css($name, $value) {
-  @include css-var($name, $value);
 }
 
 /// A media query mixin that defines a query using max-width. You can pass in a

--- a/packages/radio/src/_radio_size.scss
+++ b/packages/radio/src/_radio_size.scss
@@ -2,15 +2,15 @@
 @use "./variables" as var;
 
 #{core.bem("radio", null, "size", "sm")} {
-  @include core.css-var("radio-size", var.$size-sm);
-  @include core.css-var("radio-border-width", var.$size-sm-border-width);
-  @include core.css-var("radio-circle-size", var.$size-sm-circle);
-  @include core.css-var("radio-dot-size", var.$size-sm-dot);
+  @include core.css("radio-size", var.$size-sm);
+  @include core.css("radio-border-width", var.$size-sm-border-width);
+  @include core.css("radio-circle-size", var.$size-sm-circle);
+  @include core.css("radio-dot-size", var.$size-sm-dot);
 }
 
 #{core.bem("radio", null, "size", "lg")} {
-  @include core.css-var("radio-size", var.$size-lg);
-  @include core.css-var("radio-border-width", var.$size-lg-border-width);
-  @include core.css-var("radio-circle-size", var.$size-lg-circle);
-  @include core.css-var("radio-dot-size", var.$size-lg-dot);
+  @include core.css("radio-size", var.$size-lg);
+  @include core.css("radio-border-width", var.$size-lg-border-width);
+  @include core.css("radio-circle-size", var.$size-lg-circle);
+  @include core.css("radio-dot-size", var.$size-lg-dot);
 }

--- a/packages/radio/src/_root.scss
+++ b/packages/radio/src/_root.scss
@@ -3,21 +3,21 @@
 @use "./variables" as var;
 
 #{theme.$root-selector} {
-  @include core.css-var("radio-size", var.$size);
-  @include core.css-var("radio-circle-size", var.$circle-size);
-  @include core.css-var("radio-color", var.$color);
-  @include core.css-var("radio-fill", var.$fill);
-  @include core.css-var("radio-border-color", var.$border-color);
-  @include core.css-var("radio-border-width", var.$border-width);
-  @include core.css-var("radio-background-border-radius", var.$background-border-radius);
-  @include core.css-var("radio-background-opacity", var.$background-opacity);
-  @include core.css-var("radio-background-opacity-hover", var.$background-opacity-hover);
-  @include core.css-var("radio-background-opacity-focus", var.$background-opacity-focus);
-  @include core.css-var("radio-background-opacity-active", var.$background-opacity-active);
-  @include core.css-var("radio-transition-duration", var.$transition-duration);
-  @include core.css-var("radio-transition-timing-function", var.$transition-timing-function);
-  @include core.css-var("radio-dot-size", var.$dot-size);
-  @include core.css-var("radio-dot-color", var.$dot-color);
+  @include core.css("radio-size", var.$size);
+  @include core.css("radio-circle-size", var.$circle-size);
+  @include core.css("radio-color", var.$color);
+  @include core.css("radio-fill", var.$fill);
+  @include core.css("radio-border-color", var.$border-color);
+  @include core.css("radio-border-width", var.$border-width);
+  @include core.css("radio-background-border-radius", var.$background-border-radius);
+  @include core.css("radio-background-opacity", var.$background-opacity);
+  @include core.css("radio-background-opacity-hover", var.$background-opacity-hover);
+  @include core.css("radio-background-opacity-focus", var.$background-opacity-focus);
+  @include core.css("radio-background-opacity-active", var.$background-opacity-active);
+  @include core.css("radio-transition-duration", var.$transition-duration);
+  @include core.css("radio-transition-timing-function", var.$transition-timing-function);
+  @include core.css("radio-dot-size", var.$dot-size);
+  @include core.css("radio-dot-color", var.$dot-color);
 }
 
 @include theme.output-themes("radio");

--- a/packages/radio/src/_root.scss
+++ b/packages/radio/src/_root.scss
@@ -5,7 +5,9 @@
 #{theme.$root-selector} {
   @include core.css("radio-size", var.$size);
   @include core.css("radio-circle-size", var.$circle-size);
+  @include core.css("radio-dot-size", var.$dot-size);
   @include core.css("radio-color", var.$color);
+  @include core.css("radio-dot-color", var.$dot-color);
   @include core.css("radio-fill", var.$fill);
   @include core.css("radio-border-color", var.$border-color);
   @include core.css("radio-border-width", var.$border-width);
@@ -16,8 +18,6 @@
   @include core.css("radio-background-opacity-active", var.$background-opacity-active);
   @include core.css("radio-transition-duration", var.$transition-duration);
   @include core.css("radio-transition-timing-function", var.$transition-timing-function);
-  @include core.css("radio-dot-size", var.$dot-size);
-  @include core.css("radio-dot-color", var.$dot-color);
 }
 
 @include theme.output-themes("radio");

--- a/packages/radio/src/_variables.scss
+++ b/packages/radio/src/_variables.scss
@@ -2,10 +2,11 @@
 @use "@vrembem/core/palette";
 @use "@vrembem/core/theme";
 
-// Radio properties
 $size: core.$form-control-size !default;
 $circle-size: 20px !default;
+$dot-size: 8px !default;
 $color: palette.get("primary") !default;
+$dot-color: null !default;
 $fill: null !default;
 $border-color: null !default;
 $border-width: 2px !default;
@@ -14,24 +15,24 @@ $background-opacity: 0% !default;
 $background-opacity-hover: 20% !default;
 $background-opacity-focus: 20% !default;
 $background-opacity-active: 30% !default;
+
+// Transition
 $transition-duration: core.$transition-duration-short !default;
 $transition-timing-function: core.$transition-timing-function !default;
 
-// Dot properties
-$dot-size: 8px !default;
-$dot-color: null !default;
-
-// Size modifier properties
+// radio_size_sm
 $size-sm: core.$form-control-size-sm !default;
 $size-sm-border-width: 2px !default;
 $size-sm-circle: 16px !default;
 $size-sm-dot: 6px !default;
+
+// radio_size_lg
 $size-lg: core.$form-control-size-lg !default;
 $size-lg-border-width: 2.5px !default;
 $size-lg-circle: 26px !default;
 $size-lg-dot: 10px !default;
 
-// Theme properties
+// Themes
 $theme-light: (
   "fill": white,
   "border-color": palette.get("neutral"),

--- a/packages/switch/src/_root.scss
+++ b/packages/switch/src/_root.scss
@@ -3,21 +3,21 @@
 @use "./variables" as var;
 
 #{theme.$root-selector} {
-  @include core.css-var("switch-size", var.$size);
-  @include core.css-var("switch-track-size", var.$track-size);
-  @include core.css-var("switch-color", var.$color);
-  @include core.css-var("switch-thumb-fill", var.$thumb-fill);
-  @include core.css-var("switch-track-fill", var.$track-fill);
-  @include core.css-var("switch-border-color", var.$border-color);
-  @include core.css-var("switch-border-width", var.$border-width);
-  @include core.css-var("switch-border-radius", var.$border-radius);
-  @include core.css-var("switch-background-border-radius", var.$background-border-radius);
-  @include core.css-var("switch-background-opacity", var.$background-opacity);
-  @include core.css-var("switch-background-opacity-hover", var.$background-opacity-hover);
-  @include core.css-var("switch-background-opacity-focus", var.$background-opacity-focus);
-  @include core.css-var("switch-background-opacity-active", var.$background-opacity-active);
-  @include core.css-var("switch-transition-duration", var.$transition-duration);
-  @include core.css-var("switch-transition-timing-function", var.$transition-timing-function);
+  @include core.css("switch-size", var.$size);
+  @include core.css("switch-track-size", var.$track-size);
+  @include core.css("switch-color", var.$color);
+  @include core.css("switch-thumb-fill", var.$thumb-fill);
+  @include core.css("switch-track-fill", var.$track-fill);
+  @include core.css("switch-border-color", var.$border-color);
+  @include core.css("switch-border-width", var.$border-width);
+  @include core.css("switch-border-radius", var.$border-radius);
+  @include core.css("switch-background-border-radius", var.$background-border-radius);
+  @include core.css("switch-background-opacity", var.$background-opacity);
+  @include core.css("switch-background-opacity-hover", var.$background-opacity-hover);
+  @include core.css("switch-background-opacity-focus", var.$background-opacity-focus);
+  @include core.css("switch-background-opacity-active", var.$background-opacity-active);
+  @include core.css("switch-transition-duration", var.$transition-duration);
+  @include core.css("switch-transition-timing-function", var.$transition-timing-function);
 }
 
 @include theme.output-themes("switch");

--- a/packages/switch/src/_switch_size.scss
+++ b/packages/switch/src/_switch_size.scss
@@ -2,13 +2,13 @@
 @use "./variables" as var;
 
 #{core.bem("switch", null, "size", "sm")} {
-  @include core.css-var("switch-size", var.$size-sm);
-  @include core.css-var("switch-border-width", var.$size-sm-border-width);
-  @include core.css-var("switch-track-size", var.$size-sm-track);
+  @include core.css("switch-size", var.$size-sm);
+  @include core.css("switch-border-width", var.$size-sm-border-width);
+  @include core.css("switch-track-size", var.$size-sm-track);
 }
 
 #{core.bem("switch", null, "size", "lg")} {
-  @include core.css-var("switch-size", var.$size-lg);
-  @include core.css-var("switch-border-width", var.$size-lg-border-width);
-  @include core.css-var("switch-track-size", var.$size-lg-track);
+  @include core.css("switch-size", var.$size-lg);
+  @include core.css("switch-border-width", var.$size-lg-border-width);
+  @include core.css("switch-track-size", var.$size-lg-track);
 }

--- a/packages/switch/src/_variables.scss
+++ b/packages/switch/src/_variables.scss
@@ -2,7 +2,6 @@
 @use "@vrembem/core/palette";
 @use "@vrembem/core/theme";
 
-// Switch properties
 $size: core.$form-control-size !default;
 $track-size: 20px !default;
 $color: palette.get("primary") !default;
@@ -16,18 +15,22 @@ $background-opacity: 0% !default;
 $background-opacity-hover: 20% !default;
 $background-opacity-focus: 20% !default;
 $background-opacity-active: 30% !default;
+
+// Transition
 $transition-duration: core.$transition-duration-short !default;
 $transition-timing-function: core.$transition-timing-function !default;
 
-// Size modifier properties
+// switch_size_sm
 $size-sm: core.$form-control-size-sm !default;
 $size-sm-border-width: 2px !default;
 $size-sm-track: 16px !default;
+
+// switch_size_lg
 $size-lg: core.$form-control-size-lg !default;
 $size-lg-border-width: 2.5px !default;
 $size-lg-track: 26px !default;
 
-// Theme properties
+// Themes
 $theme-light: (
   "thumb-fill": white,
   "track-fill": palette.get("neutral", 50%, 20%),


### PR DESCRIPTION
## What changed?

This PR refactors recently update components to use the new `core.bem` function for outputting BEM classes and removing the need for manually applying core prefixes. We also now apply the new `core.css` function and mixin (previously named `core.css-var`) for setting and using CSS variables. Docs are updated as needed.