### PR TITLE
Package documentation state

### DIFF
--- a/docs/src/components/CollectionNavi.astro
+++ b/docs/src/components/CollectionNavi.astro
@@ -1,6 +1,7 @@
 ---
 import type { CollectionEntry } from "astro:content";
 import { currentPage } from "../modules/currentPage";
+import Icon from './Icon.astro';
 
 interface Props {
   entries: CollectionEntry<"packages">[];
@@ -14,6 +15,15 @@ const cp = currentPage(new URL(Astro.request.url).pathname, {
   classBase: "menu__action",
   classCurrent: "is-active",
 });
+
+entries.sort(function(a, b) { 
+  return a.data.state == "layers" ? -1 : b.data.state == "layers" ? 1 : 0;
+});
+
+entries.sort(function(a, b) { 
+  return a.data.state == "settings" ? -1 : b.data.state == "settings" ? 1 : 0;
+});
+
 ---
 
 <nav>
@@ -30,7 +40,12 @@ const cp = currentPage(new URL(Astro.request.url).pathname, {
             class={cp.classes(`/${collection}/${entry.slug}`)}
             href={`/${collection}/${entry.slug}`}
           >
-            {entry.data.title}
+            <span class="flex-grow-1">{entry.data.title}</span>
+            {
+              entry.data.state && (
+                <Icon name={entry.data.state} iconClass="icon_size_sm foreground-primary" />
+              )
+            }
           </a>
         </li>
       ))

--- a/docs/src/components/CollectionNavi.astro
+++ b/docs/src/components/CollectionNavi.astro
@@ -16,14 +16,6 @@ const cp = currentPage(new URL(Astro.request.url).pathname, {
   classCurrent: "is-active",
 });
 
-entries.sort(function(a, b) { 
-  return a.data.state == "layers" ? -1 : b.data.state == "layers" ? 1 : 0;
-});
-
-entries.sort(function(a, b) { 
-  return a.data.state == "settings" ? -1 : b.data.state == "settings" ? 1 : 0;
-});
-
 ---
 
 <nav>

--- a/docs/src/components/CollectionPagi.astro
+++ b/docs/src/components/CollectionPagi.astro
@@ -17,6 +17,7 @@ entries.find((entry, index) => {
     pagi.next = entries[index + 1];
   }
 });
+
 ---
 
 <div class="pagi">

--- a/docs/src/components/LayoutDrawer.astro
+++ b/docs/src/components/LayoutDrawer.astro
@@ -12,8 +12,11 @@
   import { drawer } from '../modules/useDrawer';
   const drawerItem = await drawer.register(document.getElementById('layout-drawer'));
   if (drawerItem.mode == 'inline') {
-    drawerItem.dialog.querySelector('.is-active').scrollIntoView(
-      { behavior: 'auto', block: 'nearest' }
-    );
+    const active = drawerItem.dialog.querySelector('.is-active');
+    const space = window.innerHeight - active.offsetTop;
+    console.log(space, active);
+    if (space < 80) {
+      active.scrollIntoView({ behavior: 'instant', block: 'center' });
+    }
   }
 </script>

--- a/docs/src/components/LayoutDrawer.astro
+++ b/docs/src/components/LayoutDrawer.astro
@@ -9,6 +9,11 @@
 <div class="layout__screen" data-drawer-close="layout-drawer"></div>
 
 <script>
-import { drawer } from '../modules/useDrawer';
-drawer.register(document.getElementById('layout-drawer'));
+  import { drawer } from '../modules/useDrawer';
+  const drawerItem = await drawer.register(document.getElementById('layout-drawer'));
+  if (drawerItem.mode == 'inline') {
+    drawerItem.dialog.querySelector('.is-active').scrollIntoView(
+      { behavior: 'auto', block: 'nearest' }
+    );
+  }
 </script>

--- a/docs/src/content/config.ts
+++ b/docs/src/content/config.ts
@@ -7,6 +7,7 @@ const packages = defineCollection({
     title: z.string(),
     description: z.string(),
     package: z.string(),
+    state: z.string().optional(),
   }),
 });
 

--- a/docs/src/content/packages/base.mdx
+++ b/docs/src/content/packages/base.mdx
@@ -11,23 +11,17 @@ import CodeExample from '../../components/CodeExample.astro';
 
 Includes useful default styles and base modules for common HTML elements.
 
-[![npm version](https://img.shields.io/npm/v/%40vrembem%2Fbase.svg)](https://www.npmjs.com/package/%40vrembem%2Fbase)
-
-[Documentation](https://vrembem.com/packages/base)
-
-## Installation
-
 ```sh
 npm install @vrembem/base
 ```
 
-### Styles
+<CodeExample lang="scss">
+  ```scss
+  @use "@vrembem/base";
+  ```
+</CodeExample>
 
-```scss
-@use "@vrembem/base";
-```
-
-### Markup
+## Basic usage
 
 Once loaded, the base component provides default styles for HTML elements and a number of output modules. Base also provides helpful variables and mixins for customizing the output.
 
@@ -64,7 +58,7 @@ Alternatively, you can disable CSS output using the `$output` and `$output-[modu
 );
 ```
 
-#### Global Variables
+## Customization
 
 Setting these variables will impact more than one or up to all base modules.
 
@@ -76,25 +70,7 @@ Setting these variables will impact more than one or up to all base modules.
 | `$prefix-modifier-value` | `"_"`   | String to prefix modifier values with.     |
 | `$output`                | `true`  | Toggles the default output of all modules. |
 
-## Modules
-
-The base component consists of a number of modules with their own set of specific customizable variables and output mixins.
-
-- [`base`](#base)
-- [`arrow`](#arrow)
-- [`blockquote`](#blockquote)
-- [`code`](#code)
-- [`heading`](#heading)
-- [`link`](#link)
-- [`list`](#list)
-- [`pre`](#pre)
-- [`scroll-box`](#scroll-box)
-- [`separator`](#separator)
-- [`type`](#type)
-
-> Modules are sorted by the order they're imported; alphabetically except for `base` having priority as first import.
-
-### `base`
+## base
 
 Outputs a number of base and reset element styles to help keep html elements predictable and easier to work with. Some more global options are set via the `@vrembem/core` component, while others that are specific to the base component are set directly here.
 
@@ -147,7 +123,7 @@ body {
 
 For a complete understanding of what this module does, checkout the source: [`_base.scss`](https://github.com/sebnitu/vrembem/blob/main/packages/base/src/_base.scss)
 
-### `arrow`
+## arrow
 
 The arrow (caret) module creates directional triangles drawn with CSS.
 
@@ -174,7 +150,7 @@ The arrow (caret) module creates directional triangles drawn with CSS.
 | `$arrow-size`   | `8px 6px`               | Sets the size of arrows. Can be a list where first number is the width of the "flat" side of the arrow and second is the width of the "pointer". |
 | `$arrow-radius` | `2px`                   | Applies a slightly rounded edge to the none pointer corners.                                                                                     |
 
-#### Example
+### Example
 
 Arrows are great indicators for buttons and menu items when interacting with them would toggle a popover or other togglable components.
 
@@ -185,7 +161,7 @@ Arrows are great indicators for buttons and menu items when interacting with the
 </button>
 ```
 
-#### `@mixin arrow($dir, $color, $size, $radius)`
+### @mixin arrow($dir, $color, $size, $radius)
 
 Output the styles for an arrow.
 
@@ -222,7 +198,7 @@ Output the styles for an arrow.
 }
 ```
 
-### `blockquote`
+## blockquote
 
 The HTML blockquote element is used for marking up extended quotations. This module helps style these elements in a distinct and appealing way by providing the `.blockquote` CSS class.
 
@@ -250,7 +226,7 @@ The HTML blockquote element is used for marking up extended quotations. This mod
 | `$blockquote-accent-offset` | `-1px`                  | Sets the offset of the accent CSS pseudo-element. Recommended to set negative of the border width.         |
 | `$blockquote-accent-color`  | `--vb-primary-50`       | Sets the color of the accent CSS pseudo-element.                                                           |
 
-#### `@mixin blockquote()`
+### @mixin blockquote()
 
 Output the styles for a blockquote element.
 
@@ -284,7 +260,7 @@ blockquote > * + * {
 }
 ```
 
-### `code`
+## code
 
 The HTML code element displays its contents styled in a fashion intended to indicate that the text is a short fragment of computer code. This module helps style these elements by providing the `.code` CSS class.
 
@@ -304,7 +280,7 @@ The HTML code element displays its contents styled in a fashion intended to indi
 | `$code-font-family`   | `core.$font-family-mono` | Sets the font-family property.                       |
 | `$code-font-size`     | `0.9em`                  | Sets the font-size property.                         |
 
-#### `@mixin code()`
+### @mixin code()
 
 Output the styles for a code element.
 
@@ -324,7 +300,7 @@ code {
 }
 ```
 
-### `heading`
+## heading
 
 Section headings in HTML are represented by the `<h1>` through `<h6>` elements. This module helps style these elements by providing the `.h1`-`.h6` CSS classes.
 
@@ -347,7 +323,7 @@ Section headings in HTML are represented by the `<h1>` through `<h6>` elements. 
 | `$heading-font-weight`  | `core.$font-weight-semi-bold`           | Sets the font-weight property.                                                                |
 | `$heading-scale`        | [`Sass Map` Ref &darr;](#heading-scale) | A map containing the font-size and optional line-height scale for HTML headings.              |
 
-#### `$heading-scale`
+### $heading-scale
 
 A map containing the font-size and optional line-height scale for HTML headings. The map should contain a key of the heading level and the value of a font-size and optional line-height space separated.
 
@@ -362,7 +338,7 @@ $heading-scale: (
 ) !default;
 ```
 
-#### `@mixin heading-base()`
+### @mixin heading-base()
 
 Output the shared base styles for heading elements.
 
@@ -381,7 +357,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 ```
 
-#### `@mixin heading-levels($map: $heading-scale, $prefix: null)`
+### @mixin heading-levels($map: $heading-scale, $prefix: null)
 
 Output all the heading styles set in the passed map which defaults to the [`$heading-scale`](#heading-scale) map.
 
@@ -422,7 +398,7 @@ $custom-heading-scale: (
 }
 ```
 
-#### `@mixin heading($level, $map: $heading-scale)`
+### @mixin heading($level, $map: $heading-scale)
 
 Output the specific styles for a heading level. Takes the heading level as an argument.
 
@@ -455,7 +431,7 @@ h1 {
 }
 ```
 
-### `link`
+## link
 
 A link—usually represented by an anchor (`<a>`) HTML element with `href` attribute—creates the styles for a hyperlink to anything a URL can address. This module helps style these elements by providing the `.link` CSS class as well as a few optional modifiers.
 
@@ -492,7 +468,7 @@ A link—usually represented by an anchor (`<a>`) HTML element with `href` attri
 | `$link-invert-subtle-border-color`       | `rgba(white, 0.5)`             | Sets the border-color property on invert-subtle modifier.             |
 | `$link-invert-subtle-border-color-hover` | `currentColor`                 | Sets the border-color property on invert-subtle modifier hover state. |
 
-#### `@mixin link()`
+### @mixin link()
 
 Output the styles for a link element.
 
@@ -523,7 +499,7 @@ a:focus {
 }
 ```
 
-#### `@mixin link-modifier($modifier)`
+### @mixin link-modifier($modifier)
 
 Output the styes for a specific link modifier. This is meant to be used in addition to a link's base styles.
 
@@ -552,7 +528,7 @@ a.subtle {
 }
 ```
 
-### `list`
+## list
 
 The list module helps add styles to unordered (`<ul>`) and ordered (`<ol>`) lists by providing the `.list` class.
 
@@ -581,7 +557,7 @@ The list module helps add styles to unordered (`<ul>`) and ordered (`<ol>`) list
 | `$list-gap`      | `1.5em`                 | Sets the margin-left property of list elements.      |
 | `$list-item-gap` | `0.5em`                 | Sets the top margin of list items.                   |
 
-#### `@mixin list()`
+### @mixin list()
 
 Output the styles for list elements.
 
@@ -612,7 +588,7 @@ ol li + li {
 }
 ```
 
-### `pre`
+## pre
 
 This module helps style the HTML `<pre>` element by providing the `.pre` CSS class. Whitespace inside this element is displayed as written.
 
@@ -639,7 +615,7 @@ This module helps style the HTML `<pre>` element by providing the `.pre` CSS cla
 | `$pre-border-radius` | `core.$border-radius`   | Sets the border-radius property.                    |
 | `$pre-color`         | `core.$color`           | Sets the text color property.                       |
 
-#### `@mixin pre()`
+### @mixin pre()
 
 Output the styles for a pre element.
 
@@ -667,7 +643,7 @@ pre code {
 }
 ```
 
-### `scroll-box`
+## scroll-box
 
 This module provides the `.scroll-box` CSS class to be applied as a wrapper around elements when they need a scrollable container.
 
@@ -682,7 +658,7 @@ This module provides the `.scroll-box` CSS class to be applied as a wrapper arou
 | `$output-scroll-box` | `$output` &rarr; `true` | Toggles the output of this module.                         |
 | `$class-scroll-box`  | `"scroll-box"`          | String to use for the class name of the scroll-box module. |
 
-#### `@mixin scroll-box()`
+### @mixin scroll-box()
 
 Output the styles for a scroll-box container.
 
@@ -702,7 +678,7 @@ Output the styles for a scroll-box container.
 }
 ```
 
-### `separator`
+## separator
 
 This module adds the `.sep` and `.sep-invert` CSS classes which visually renders a horizontal separator. This can be applied to an `<hr>` HTML element. It can also be applied to a more generic `<span>` or `<div>` depending on the semantic context.
 
@@ -723,7 +699,7 @@ This module adds the `.sep` and `.sep-invert` CSS classes which visually renders
 | `$separator-border`        | `1px solid core.$border-color`        | Sets the border property.                                 |
 | `$separator-border-invert` | `1px solid core.$border-color-invert` | Sets the border property on invert variant.               |
 
-#### `@mixin separator($border)`
+### @mixin separator($border)
 
 Output the separator styles.
 
@@ -749,7 +725,7 @@ Output the separator styles.
 }
 ```
 
-### `type`
+## type
 
 The type module provides the `.type` CSS class as a quick way to apply many base modules to HTML elements directly. Base module classes will override a parent `.type` application when explicitly set. Use `.type_invert` for when text sits on a dark background.
 
@@ -788,7 +764,7 @@ Modules that get mapped to HTML elements include:
 | `$type-line-height`  | `null`                  | Sets the line-height property.                              |
 | `$type-gap`          | `null`                  | Applies vertical gap between elements via the `gap` module. |
 
-#### `@mixin type()`
+### @mixin type()
 
 Output base type module styles.
 
@@ -800,7 +776,7 @@ Output base type module styles.
 }
 ```
 
-#### `@mixin type-invert($color)`
+### @mixin type-invert($color)
 
 Output invert modifier styles of the type module. Pass in the background color if you're not sure it will meet the lightness threshold set in `core.$lightness-threshold`.
 

--- a/docs/src/content/packages/base.mdx
+++ b/docs/src/content/packages/base.mdx
@@ -2,6 +2,7 @@
 title: Base
 description: "Includes useful default styles and base modules for common HTML elements."
 package: "@vrembem/base"
+state: "layers"
 ---
 
 import CodeExample from '../../components/CodeExample.astro';

--- a/docs/src/content/packages/button.mdx
+++ b/docs/src/content/packages/button.mdx
@@ -2,6 +2,7 @@
 title: Button
 description: "Buttons are a simple component that allow users to take actions."
 package: "@vrembem/button"
+state: "check"
 ---
 
 import CodeExample from '../../components/CodeExample.astro';

--- a/docs/src/content/packages/card.mdx
+++ b/docs/src/content/packages/card.mdx
@@ -2,6 +2,7 @@
 title: Card
 description: "The card component provides a flexible and highly composable content container."
 package: "@vrembem/card"
+state: "check"
 ---
 
 import CodeExample from '../../components/CodeExample.astro';

--- a/docs/src/content/packages/checkbox.mdx
+++ b/docs/src/content/packages/checkbox.mdx
@@ -2,6 +2,7 @@
 title: Checkbox
 description: "Checkboxes allow the user to select multiple options from a set."
 package: "@vrembem/checkbox"
+state: "check"
 ---
 
 import CodeExample from '../../components/CodeExample.astro';

--- a/docs/src/content/packages/core.mdx
+++ b/docs/src/content/packages/core.mdx
@@ -5,16 +5,24 @@ package: "@vrembem/core"
 state: "settings"
 ---
 
+import CodeExample from '../../components/CodeExample.astro';
+
 # Core
 
 Shared variables, functions and mixins for Vrembem components.
 
-[![npm version](https://img.shields.io/npm/v/%40vrembem%2Fcore.svg)](https://www.npmjs.com/package/%40vrembem%2Fcore)
-
-[Documentation](https://vrembem.com/packages/core)
-
-## Installation
-
 ```sh
 npm install @vrembem/core
 ```
+
+<CodeExample lang="scss">
+  ```scss
+  @use "@vrembem/core";
+  ```
+</CodeExample>
+
+<CodeExample lang="js">
+  ```js
+  import * as core from "@vrembem/core";
+  ```
+</CodeExample>

--- a/docs/src/content/packages/core.mdx
+++ b/docs/src/content/packages/core.mdx
@@ -2,6 +2,7 @@
 title: Core
 description: "Shared variables, functions and mixins for Vrembem components."
 package: "@vrembem/core"
+state: "settings"
 ---
 
 # Core

--- a/docs/src/content/packages/radio.mdx
+++ b/docs/src/content/packages/radio.mdx
@@ -2,6 +2,7 @@
 title: Radio
 description: "Radios allow the user to select a single option from a set."
 package: "@vrembem/radio"
+state: "check"
 ---
 
 import CodeExample from '../../components/CodeExample.astro';

--- a/docs/src/content/packages/switch.mdx
+++ b/docs/src/content/packages/switch.mdx
@@ -2,6 +2,7 @@
 title: Switch
 description: "Switches are a binary form element used to toggle between two options."
 package: "@vrembem/switch"
+state: "check"
 ---
 
 import CodeExample from '../../components/CodeExample.astro';

--- a/docs/src/content/packages/utility.mdx
+++ b/docs/src/content/packages/utility.mdx
@@ -2,6 +2,7 @@
 title: Utility
 description: "The utility component provides a set of atomic classes that specialize in a single function."
 package: "@vrembem/utility"
+state: "layers"
 ---
 
 import CodeExample from '../../components/CodeExample.astro';

--- a/docs/src/content/packages/utility.mdx
+++ b/docs/src/content/packages/utility.mdx
@@ -11,55 +11,54 @@ import CodeExample from '../../components/CodeExample.astro';
 
 The utility component provides a set of atomic classes that specialize in a single function.
 
-[![npm version](https://img.shields.io/npm/v/%40vrembem%2Futility.svg)](https://www.npmjs.com/package/%40vrembem%2Futility)
-
-[Documentation](https://vrembem.com/packages/utility)
-
-## Installation
-
 ```sh
 npm install @vrembem/utility
 ```
 
-### Styles
+<CodeExample lang="scss">
+  ```scss
+  @use "@vrembem/utility";
+  ```
+</CodeExample>
 
-```scss
-@use "@vrembem/utility";
-```
-
-### Markup
+## Basic usage
 
 Once loaded, the utility component provides a number of classes that can be used independently or to supplement other loaded components.
 
-```html
-<!-- Using utility classes independently -->
-<div class="padding background-shade border radius">
-  <p class="text-bold text-align-center">...</p>
-</div>
+<CodeExample lang="html">
+  ```html
+  <!-- Using utility classes independently -->
+  <div class="padding background-shade border radius">
+    <p class="text-bold text-align-center">...</p>
+  </div>
 
-<!-- Using utility classes with other components -->
-<div class="grid flex-justify-center">
-  <div class="grid__item span-auto">...</div>
-  <div class="grid__item span-auto">...</div>
-</div>
-```
+  <!-- Using utility classes with other components -->
+  <div class="grid flex-justify-center">
+    <div class="grid__item span-auto">...</div>
+    <div class="grid__item span-auto">...</div>
+  </div>
+  ```
+</CodeExample>
 
 Each utility has a corresponding `$output-[module]` and `$class-[module]` variable that determines whether or not the module is output and it's class name. Output variable inherits their default value from `$output`.
 
-```scss
-// Will disable the output of the color module
-@use "@vrembem/utility" with (
-  $output-color: false
-);
+<CodeExample lang="scss">
 
-// Will disable all modules, but enables the color module
-@use "@vrembem/utility" with (
-  $output: false,
-  $output-color: true
-);
-```
+  ```scss
+  // Will disable the output of the color module
+  @use "@vrembem/utility" with (
+    $output-color: false
+  );
 
-#### Global Variables
+  // Will disable all modules, but enables the color module
+  @use "@vrembem/utility" with (
+    $output: false,
+    $output-color: true
+  );
+  ```
+</CodeExample>
+
+## Customization
 
 Setting these variables will apply to all utility modules.
 
@@ -71,7 +70,7 @@ Setting these variables will apply to all utility modules.
 | `$gap`            | `core.$gap` &rarr; `1em`                       | Used as the default spacing unit for many utilities.                                                                          |
 | `$gap-map`        | [`core.$gap-map` Ref &darr;](#gap-map)         | Used to build gap variants for many utilities.                                                                                |
 
-#### `$breakpoints`
+### $breakpoints
 
 A map of breakpoints used by utilities that provide breakpoint specific variations such as the [`display`](#display) and [`span`](#span) utilities.
 
@@ -86,7 +85,7 @@ $breakpoints: (
 ) !default;
 ```
 
-#### `$gap-map`
+### $gap-map
 
 Used to build gap variants for [`flex-gap`](#flex-gap-key), [`flex-gap-x`](#flex-gap-x-key), [`flex-gap-y`](#flex-gap-y-key), [`gap-x`](#gap-x-key), [`gap-y`](#gap-y-key), [`margin`](#margin) and [`padding`](#padding) utilities.
 
@@ -102,30 +101,7 @@ $gap-map: (
 ) !default;
 ```
 
-## Modules
-
-The utility component consists of a number of modules with their own set of specific customizable class and output variables.
-
-- [`background`](#background)
-- [`border`](#border)
-- [`border-radius`](#border-radius)
-- [`elevate`](#elevate)
-- [`color`](#color)
-- [`display`](#display)
-- [`flex`](#flex)
-- [`flex-gap-[key]`](#flex-gap-key)
-- [`flex-gap-x-[key]`](#flex-gap-x-key)
-- [`flex-gap-y-[key]`](#flex-gap-y-key)
-- [`font`](#font)
-- [`gap-x-[key]`](#gap-x-key)
-- [`gap-y-[key]`](#gap-y-key)
-- [`margin`](#margin)
-- [`max-width`](#max-width)
-- [`padding`](#padding)
-- [`position`](#position)
-- [`text`](#text)
-
-### `background`
+## background
 
 Applies background color property. Most options include light, lighter, dark and darker variants.
 
@@ -211,7 +187,7 @@ Also available are utility classes for the `background-clip-[value]` property.
 
 > Checkout the [web documentation](https://vrembem.com/packages/utility/#background) for a complete list of available options.
 
-### `border`
+## border
 
 Applies border property with optional sides variants.
 
@@ -228,7 +204,7 @@ Applies border property with optional sides variants.
 | `$output-border` | `$output` &rarr; `true` | Toggles the output of this utility.                     |
 | `$class-border`  | `"border"`              | String to use for the class name of the border utility. |
 
-#### `border-none`
+### border-none
 
 Remove border styles with `border-none` utilities and optional side variants.
 
@@ -240,7 +216,7 @@ Remove border styles with `border-none` utilities and optional side variants.
 <div class="border-left-none"></div>
 ```
 
-#### `border-color`
+### border-color
 
 Add border color utilities with light, dark and darker variants. Also available is the `border-color-transparent` utility which sets the border-color property to transparent.
 
@@ -258,7 +234,7 @@ Add border color utilities with light, dark and darker variants. Also available 
 <div class="border border-color-invert-darker"></div>
 ```
 
-### `border-radius`
+## border-radius
 
 Applies border-radius styles with optional corner variants. The value used by the radius utility is pulled from the `core.$border-radius` variable.
 
@@ -284,7 +260,7 @@ Applies border-radius styles with optional corner variants. The value used by th
 | `$output-border-radius` | `$output` &rarr; `true` | Toggles the output of this utility.                            |
 | `$class-border-radius`  | `"radius"`              | String to use for the class name of the border-radius utility. |
 
-#### `radius-circle`
+### radius-circle
 
 Applies the maximum value to border-radius with optional corner variants. The value used by radius-circle utility is pulled from the `core.$border-radius-circle` variable.
 
@@ -305,7 +281,7 @@ Applies the maximum value to border-radius with optional corner variants. The va
 <div class="radius-circle-bottom-left"></div>
 ```
 
-#### `radius-square`
+### radius-square
 
 Removes border-radius by setting it's value to `0` with optional corner variants.
 
@@ -326,7 +302,7 @@ Removes border-radius by setting it's value to `0` with optional corner variants
 <div class="radius-square-bottom-left"></div>
 ```
 
-### `elevate`
+## elevate
 
 Applies different levels of elevation through box-shadow styles.
 
@@ -345,7 +321,7 @@ Applies different levels of elevation through box-shadow styles.
 | `$output-box-shadow` | `$output` &rarr; `true` | Toggles the output of this utility.                         |
 | `$class-box-shadow`  | `"elevate"`             | String to use for the class name of the box-shadow utility. |
 
-### `color`
+## color
 
 Applies text color property. Most options include light, lighter, dark and darker variants.
 
@@ -365,7 +341,7 @@ Applies text color property. Most options include light, lighter, dark and darke
 
 > Checkout the [web documentation](https://vrembem.com/packages/utility/#color) for a complete list of available options.
 
-### `display`
+## display
 
 Display utilities allow you to toggle the display property on an element with an optional breakpoint conditional.
 
@@ -407,7 +383,7 @@ Available properties are generated from the `$display-properties` variable map a
 | `$class-display`      | `"display"`                                  | String to use for the class name of the display utility.                     |
 | `$display-properties` | [`Sass Map` Ref &darr;](#display-properties) | A list of display properties to output along with their breakpoint variants. |
 
-#### `$display-properties`
+### $display-properties
 
 A list of display properties to output along with their breakpoint variants.
 
@@ -422,7 +398,7 @@ $display-properties: (
 ) !default;
 ```
 
-### `flex`
+## flex
 
 The flex utility is a great way to adjust individual flex properties on components that use flex layout. Flex utilities fall under two categories: 1) those that are appleid to a flexbox container and 2) those that are applied to flexbox children elements directly. These are some available flex property based utilities:
 
@@ -454,7 +430,7 @@ The flex utility is a great way to adjust individual flex properties on componen
 | `$flex-grow-count`   | `6`                     | Number of flex-grow utilities to output starting from 0.   |
 | `$flex-shrink-count` | `6`                     | Number of flex-shrink utilities to output starting from 0. |
 
-#### `flex-direction-[value]`
+### flex-direction-[value]
 
 Applies a flex direction property with the provided key value.
 
@@ -463,7 +439,7 @@ Applies a flex direction property with the provided key value.
 - `flex-direction-column`
 - `flex-direction-column-reverse`
 
-#### `flex-wrap`
+### flex-wrap
 
 Applies various flex-wrap property values.
 
@@ -472,7 +448,7 @@ Applies various flex-wrap property values.
 - `flex-wrap-reverse` - Applies the flex-wrap property with the value of `wrap-reverse`.
 
 
-#### `flex-justify-[value]`
+### flex-justify-[value]
 
 Applies the justify-content property with the provided key as the value.
 
@@ -483,7 +459,7 @@ Applies the justify-content property with the provided key as the value.
 - `flex-justify-around`
 - `flex-justify-evenly`
 
-#### `flex-align-[value]`
+### flex-align-[value]
 
 Applies the align-items property with the provided key as the value.
 
@@ -493,14 +469,14 @@ Applies the align-items property with the provided key as the value.
 - `flex-align-stretch`
 - `flex-align-baseline`
 
-#### `flex-items-[key]`
+### flex-items-[key]
 
 Gives all direct children the flex property to either share the container space equally (`equal`) or keep their content's width (`auto`).
 
 - `flex-items-equal` - Applies the flex property children elements with the value of `1 1 0` to share the container space equally.
 - `flex-items-auto` - Applies the flex property children elements with the value of `0 0 auto` to keep their content's width.
 
-### `flex-gap-[key]`
+## flex-gap-[key]
 
 The flex-gap module adds both horizontal and vertical spacing between an element's children. It also adds negative top and left margins to the element it's applied to which may require an anonymous `<div>` if additional margins are needed. Flex-gap keys and their values are generated from the [`$gap-map`](#gap-map) variable map.
 
@@ -525,7 +501,7 @@ The flex-gap module adds both horizontal and vertical spacing between an element
 | `$output-flex-gap` | `$output` &rarr; `true` | Toggles the output of this utility.                       |
 | `$class-flex-gap`  | `"flex-gap"`            | String to use for the class name of the flex-gap utility. |
 
-### `flex-gap-x-[key]`
+## flex-gap-x-[key]
 
 Adds flex-gap spacing horizontally between an element's children using margin-left. Flex-gap keys and their values are generated from the [`$gap-map`](#gap-map) variable map.
 
@@ -550,7 +526,7 @@ Adds flex-gap spacing horizontally between an element's children using margin-le
 | `$output-flex-gap-x` | `$output` &rarr; `true` | Toggles the output of this utility.                         |
 | `$class-flex-gap-x`  | `"flex-gap-x"`          | String to use for the class name of the flex-gap-x utility. |
 
-### `flex-gap-y-[key]`
+## flex-gap-y-[key]
 
 Adds flex-gap spacing vertically between an element's children using margin-top. Flex-gap keys and their values are generated from the [`$gap-map`](#gap-map) variable map.
 
@@ -575,7 +551,7 @@ Adds flex-gap spacing vertically between an element's children using margin-top.
 | `$output-flex-gap-y` | `$output` &rarr; `true` | Toggles the output of this utility.                         |
 | `$class-flex-gap-y`  | `"flex-gap-y"`          | String to use for the class name of the flex-gap-y utility. |
 
-### `font`
+## font
 
 A utility for adjusting various font styles.
 
@@ -605,7 +581,7 @@ A utility for adjusting various font styles.
 - `font-style-normal` - Sets the font-style property to normal.
 - `font-style-italic` - Sets the font-style property to italic.
 
-### `gap-x-[key]`
+## gap-x-[key]
 
 Adds gap spacing horizontally using margin-left and the `> * + *` selector. Gap-x keys and their values are generated from the [`$gap-map`](#gap-map) variable map.
 
@@ -630,7 +606,7 @@ Adds gap spacing horizontally using margin-left and the `> * + *` selector. Gap-
 | `$output-gap-x` | `$output` &rarr; `true` | Toggles the output of this utility.                    |
 | `$class-gap-x`  | `"gap-x"`               | String to use for the class name of the gap-x utility. |
 
-### `gap-y-[key]`
+## gap-y-[key]
 
 Adds gap spacing vertically using margin-top and the `> * + *` selector. Gap-y keys and their values are generated from the [`$gap-map`](#gap-map) variable map.
 
@@ -655,7 +631,7 @@ Adds gap spacing vertically using margin-top and the `> * + *` selector. Gap-y k
 | `$output-gap-y` | `$output` &rarr; `true` | Toggles the output of this utility.                    |
 | `$class-gap-y`  | `"gap-y"`               | String to use for the class name of the gap-y utility. |
 
-### `margin`
+## margin
 
 Add margin to an element using directional and size variations. Margin size and spacing values are generated from [`$gap-map`](#gap-map) variable map.
 
@@ -675,7 +651,7 @@ Add margin to an element using directional and size variations. Margin size and 
 | `$output-margin` | `$output` &rarr; `true` | Toggles the output of this utility.                     |
 | `$class-margin`  | `"margin"`              | String to use for the class name of the margin utility. |
 
-### `max-width`
+## max-width
 
 Set the max-width property on an element using values mapped from scale keys. Scale variations are built using the [`$max-width-scale`](#max-width-scale) variable map.
 
@@ -691,7 +667,7 @@ Set the max-width property on an element using values mapped from scale keys. Sc
 | `$max-width`        | `70rem`                                 | The default value used to set max-width.                   |
 | `$max-width-scale`  | [Sass map ref &darr;](#max-width-scale) | Map used to build max-width utility variants.              |
 
-#### `$max-width-scale`
+### $max-width-scale
 
 A scale map used for building max-width utility variations using the key as variant name.
 
@@ -707,7 +683,7 @@ $max-width-scale: (
 ) !default;
 ```
 
-### `padding`
+## Padding
 
 Add padding to an element using directional and size variations. Padding size and spacing values are generated from [`$gap-map`](#gap-map) variable map.
 
@@ -723,7 +699,7 @@ Add padding to an element using directional and size variations. Padding size an
 | `$output-padding` | `$output` &rarr; `true` | Toggles the output of this utility.                      |
 | `$class-padding`  | `"padding"`             | String to use for the class name of the padding utility. |
 
-### `position`
+## position
 
 A utility for setting the position CSS property.
 
@@ -738,7 +714,7 @@ A utility for setting the position CSS property.
 | `$output-position` | `$output` &rarr; `true` | Toggles the output of this utility.                       |
 | `$class-position`  | `"position"`            | String to use for the class name of the position utility. |
 
-### `text`
+## text
 
 A utility for adjusting various text styles.
 

--- a/docs/src/layouts/Page.astro
+++ b/docs/src/layouts/Page.astro
@@ -1,7 +1,6 @@
 ---
 import type { CollectionEntry } from "astro:content";
-import { getCollection } from "astro:content";
-import { packageOrder } from "../modules/packageOrder";
+import { getPackages } from "../modules/getPackages";
 import Base from "./Base.astro";
 import Navi from "../components/CollectionNavi.astro";
 import OnThisPage from "../components/OnThisPage.astro";
@@ -13,9 +12,7 @@ interface Props {
   frontmatter?: any;
 }
 
-const entries = await getCollection("packages");
-entries.sort(packageOrder);
-
+const entries = await getPackages();
 const { headings } = Astro.props;
 const { title, collection, filename } = Astro.props.frontmatter || Astro.props;
 

--- a/docs/src/layouts/Page.astro
+++ b/docs/src/layouts/Page.astro
@@ -1,6 +1,7 @@
 ---
 import type { CollectionEntry } from "astro:content";
 import { getCollection } from "astro:content";
+import { packageOrder } from "../modules/packageOrder";
 import Base from "./Base.astro";
 import Navi from "../components/CollectionNavi.astro";
 import OnThisPage from "../components/OnThisPage.astro";
@@ -13,6 +14,8 @@ interface Props {
 }
 
 const entries = await getCollection("packages");
+entries.sort(packageOrder);
+
 const { headings } = Astro.props;
 const { title, collection, filename } = Astro.props.frontmatter || Astro.props;
 
@@ -20,6 +23,7 @@ const layout = {
   hasDrawer: !!collection,
   hasAside: !!headings.filter((item) => item.depth === 2).length,
 };
+
 ---
 
 <Base {title} {layout}>

--- a/docs/src/modules/getPackages.js
+++ b/docs/src/modules/getPackages.js
@@ -1,0 +1,11 @@
+import { getCollection } from 'astro:content';
+
+function packageOrder(a, b) {
+  return a.data.state == 'settings' ? -1 : b.data.state == 'settings' ? 1 : (a.data.state == 'layers' ? -1 : b.data.state == 'layers' ? 1 : 0);
+}
+
+export async function getPackages() {
+  const entries = await getCollection('packages');
+  entries.sort(packageOrder);
+  return entries;
+}

--- a/docs/src/modules/packageOrder.js
+++ b/docs/src/modules/packageOrder.js
@@ -1,0 +1,3 @@
+export function packageOrder(a, b) {
+  return a.data.state == 'settings' ? -1 : b.data.state == 'settings' ? 1 : (a.data.state == 'layers' ? -1 : b.data.state == 'layers' ? 1 : 0);
+}

--- a/docs/src/modules/packageOrder.js
+++ b/docs/src/modules/packageOrder.js
@@ -1,3 +1,0 @@
-export function packageOrder(a, b) {
-  return a.data.state == 'settings' ? -1 : b.data.state == 'settings' ? 1 : (a.data.state == 'layers' ? -1 : b.data.state == 'layers' ? 1 : 0);
-}

--- a/docs/src/pages/packages/[slug].astro
+++ b/docs/src/pages/packages/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import type { CollectionEntry } from "astro:content";
 import { getCollection } from "astro:content";
+import { packageOrder } from "../../modules/packageOrder";
 import Base from "../../layouts/Base.astro";
 import Navi from "../../components/CollectionNavi.astro";
 import Pagi from "../../components/CollectionPagi.astro";
@@ -22,6 +23,8 @@ export async function getStaticPaths() {
 }
 
 const entries = await getCollection("packages");
+entries.sort(packageOrder);
+
 const { entry } = Astro.props;
 const { Content, headings } = await entry.render();
 
@@ -29,6 +32,7 @@ const layout = {
   hasDrawer: true,
   hasAside: true,
 };
+
 ---
 
 <Base title={entry.data.title} {layout}>

--- a/docs/src/pages/packages/[slug].astro
+++ b/docs/src/pages/packages/[slug].astro
@@ -1,7 +1,6 @@
 ---
 import type { CollectionEntry } from "astro:content";
-import { getCollection } from "astro:content";
-import { packageOrder } from "../../modules/packageOrder";
+import { getPackages } from "../../modules/getPackages";
 import Base from "../../layouts/Base.astro";
 import Navi from "../../components/CollectionNavi.astro";
 import Pagi from "../../components/CollectionPagi.astro";
@@ -15,16 +14,14 @@ interface Props {
 }
 
 export async function getStaticPaths() {
-  const packages = await getCollection("packages");
+  const packages = await getPackages();
   return packages.map((entry) => ({
     params: { slug: entry.slug },
     props: { entry },
   }));
 }
 
-const entries = await getCollection("packages");
-entries.sort(packageOrder);
-
+const entries = await getPackages();
 const { entry } = Astro.props;
 const { Content, headings } = await entry.render();
 

--- a/docs/src/styles/_layout-aside.scss
+++ b/docs/src/styles/_layout-aside.scss
@@ -64,7 +64,7 @@
     top: 0;
     width: var(--layout-aside-width);
     height: 100vh;
-    padding: calc(var(--layout-navibar-height) + 4rem) var(--layout-aside-padding);
+    padding: calc(var(--layout-navibar-height) + 4rem) var(--layout-aside-padding) calc(var(--layout-footer-height) + 8rem);
     overflow: hidden auto;
     scroll-behavior: smooth;
   }

--- a/docs/src/styles/_root.scss
+++ b/docs/src/styles/_root.scss
@@ -9,7 +9,8 @@ $bp-aside: 76rem;
   // Layout variables
   --layout-width: 74rem;
   --layout-padding: 1rem;
-  --layout-navibar-height: 4.5rem;
+  --layout-navibar-height: 5.25rem;
+  --layout-footer-height: 6rem;
   --layout-drawer-width: 14rem;
   --layout-drawer-padding: 1rem;
   --layout-aside-width: 14rem;


### PR DESCRIPTION
## What changed?

This PR introduces a way to better track the state of documentation pages by displaying status icons in the package navigation items. This update is temporary as I work through updating the documentation format and content of components, but it should help keep things organized. In addition to the status indicator icon, there are also some general improvements made to the documentation:

- Inline drawer navigation now scrolls to active item.
- Applied new documentation format to core, utility and base packages.
- Improved the order that package items are listed in drawer navication.
- Created module for fetching the package entries (`getPackages.js`).
- Added more padding for "On this page" menu to properly clear the footer.