### PR TITLE
Update the mixin names for outputting a theme's CSS variables

### DIFF
--- a/docs/src/content/packages/card.mdx
+++ b/docs/src/content/packages/card.mdx
@@ -184,7 +184,7 @@ Cards are primarily customized using CSS variables but can also be modified usin
     @include core.css("card-transition-timing-function", var.$transition-timing-function);
   }
 
-  @include theme.output-themes("card");
+  @include theme.output("card");
   ```
 </DocBlock>
 

--- a/docs/src/content/packages/checkbox.mdx
+++ b/docs/src/content/packages/checkbox.mdx
@@ -211,7 +211,7 @@ Checkboxes are primarily customized using CSS variables but can also be modified
     @include core.css("checkbox-transition-timing-function", var.$transition-timing-function);
   }
 
-  @include theme.output-themes("checkbox");
+  @include theme.output("checkbox");
   ```
 </DocBlock>
 

--- a/docs/src/content/packages/dialog.mdx
+++ b/docs/src/content/packages/dialog.mdx
@@ -114,7 +114,7 @@ Dialogs are primarily customized using CSS variables but can also be modified us
     @include core.css("dialog-title-font-weight", var.$title-font-weight);
   }
 
-  @include theme.output-themes("dialog");
+  @include theme.output("dialog");
   ```
 </DocBlock>
 

--- a/docs/src/content/packages/radio.mdx
+++ b/docs/src/content/packages/radio.mdx
@@ -217,7 +217,7 @@ Radios are primarily customized using CSS variables but can also be modified usi
     @include core.css("radio-transition-timing-function", var.$transition-timing-function);
   }
 
-  @include theme.output-themes("radio");
+  @include theme.output("radio");
   ```
 </DocBlock>
 

--- a/docs/src/content/packages/switch.mdx
+++ b/docs/src/content/packages/switch.mdx
@@ -185,7 +185,7 @@ Switches are primarily customized using CSS variables but can also be modified u
     @include core.css("switch-transition-timing-function", var.$transition-timing-function);
   }
 
-  @include theme.output-themes("switch");
+  @include theme.output("switch");
   ```
 </DocBlock>
 

--- a/docs/src/pages/packages/index.mdx
+++ b/docs/src/pages/packages/index.mdx
@@ -74,7 +74,7 @@ Packages and their use of the theme module will impact the flexibility of a comp
   <span class="test-2 vb-theme-dark">vb-theme-dark</span>
 </div>
 
-3. If a package has its own custom CSS vars but uses the theme module's `theme.set` to set and `theme.output-themes` to output theme variables, it will have the ability to use theme classes directly.
+3. If a package has its own custom CSS vars but uses the theme module's `theme.set` to set and `theme.output` to output theme variables, it will have the ability to use theme classes directly.
 
 <div class="level">
   <span class="test-3">Default</span>

--- a/docs/src/styles/_test.scss
+++ b/docs/src/styles/_test.scss
@@ -53,7 +53,7 @@ $theme-dark: (
 
 @include theme.set("light", "test-3", $theme-light);
 @include theme.set("dark", "test-3", $theme-dark);
-@include theme.output-themes("test-3");
+@include theme.output("test-3");
 
 .test-3 {
   border-color: var(--vb-test-3-border-color);

--- a/packages/card/src/_root.scss
+++ b/packages/card/src/_root.scss
@@ -24,4 +24,4 @@
   @include core.css("card-transition-timing-function", var.$transition-timing-function);
 }
 
-@include theme.output-themes("card");
+@include theme.output("card");

--- a/packages/checkbox/src/_root.scss
+++ b/packages/checkbox/src/_root.scss
@@ -22,4 +22,4 @@
   @include core.css("checkbox-transition-timing-function", var.$transition-timing-function);
 }
 
-@include theme.output-themes("checkbox");
+@include theme.output("checkbox");

--- a/packages/core/src/scss/_theme.scss
+++ b/packages/core/src/scss/_theme.scss
@@ -179,15 +179,15 @@ $themes: (
 
 /// Output all the custom properties and values of a theme or a component theme.
 /// @example - Output the custom properties of the default theme.
-///   @include theme.output();
+///   @include theme.output-theme();
 /// @example - Output the custom properties of the dark theme.
-///   @include theme.output("dark");
+///   @include theme.output-theme("dark");
 /// @example - Output the custom properties of the light theme for the button component.
-///   @include theme.output("light", "button");
+///   @include theme.output-theme("light", "button");
 /// @output Custom properties with their associated values of a theme.
 /// @param {String} $theme [$default] - The theme name to output.
 /// @param {String} $component [null] - The name of component themes to output.
-@mixin output($theme: $default, $component: null) {
+@mixin output-theme($theme: $default, $component: null) {
   // Check if the key exists on the provided $themes map.
   @if map.has-key($themes, $theme) {
 
@@ -237,30 +237,30 @@ $themes: (
 /// $root-selector is used to wrap the $default. Themes named "light" or
 /// "dark" are also output in the `prefers-color-scheme` media query.
 /// @example
-///   @include theme.output-themes();
+///   @include theme.output();
 /// @example - Output the custom properties of the notice component.
-///   @include theme.output-themes("notice");
+///   @include theme.output("notice");
 /// @output
 ///   Custom properties with their associated values of a theme wrapped with
 ///   their associated theme classes.
 /// @param {String} $component [null] - The name of component themes to output.
 /// @require {Mixin} output - Used internally to output individual themes.
-@mixin output-themes($component: null) {
+@mixin output($component: null) {
   // Output the default theme in the root selector.
   #{$root-selector} {
-    @include output($default, $component);
+    @include output-theme($default, $component);
   
     // If the default them is not light mode, output the prefers light media query.
     @if $default != 'light' {
       @media (prefers-color-scheme: light) {
-        @include output("light", $component);
+        @include output-theme("light", $component);
       }
     }
     
     // If the default them is not dark mode, output the prefers dark media query.
     @if $default != 'dark' {
       @media (prefers-color-scheme: dark) {
-        @include output("dark", $component);
+        @include output-theme("dark", $component);
       }
     }
   }
@@ -268,7 +268,7 @@ $themes: (
   // Run the output function on all 
   @each $key, $value in $themes {
     .#{$_t}#{$key} {
-      @include output($key, $component);
+      @include output-theme($key, $component);
     }
   }
 }

--- a/packages/core/src/scss/root/theme.scss
+++ b/packages/core/src/scss/root/theme.scss
@@ -1,3 +1,3 @@
 @use "../theme";
 
-@include theme.output-themes();
+@include theme.output();

--- a/packages/dialog/src/_root.scss
+++ b/packages/dialog/src/_root.scss
@@ -16,4 +16,4 @@
   @include core.css("dialog-title-font-weight", var.$title-font-weight);
 }
 
-@include theme.output-themes("dialog");
+@include theme.output("dialog");

--- a/packages/notice/src/_root.scss
+++ b/packages/notice/src/_root.scss
@@ -1,3 +1,3 @@
 @use "@vrembem/core/theme";
 
-@include theme.output-themes("notice");
+@include theme.output("notice");

--- a/packages/radio/src/_root.scss
+++ b/packages/radio/src/_root.scss
@@ -20,4 +20,4 @@
   @include core.css("radio-transition-timing-function", var.$transition-timing-function);
 }
 
-@include theme.output-themes("radio");
+@include theme.output("radio");

--- a/packages/switch/src/_root.scss
+++ b/packages/switch/src/_root.scss
@@ -20,4 +20,4 @@
   @include core.css("switch-transition-timing-function", var.$transition-timing-function);
 }
 
-@include theme.output-themes("switch");
+@include theme.output("switch");


### PR DESCRIPTION
## What changed?

This PR renames two mixins within the `theme` module. The reason for this change is to keep the theme module as concise as possible. Because the formerly `theme.output` mixin was only being used internally, it was given the longer name while `theme.output-themes` was renamed `theme.output`.

- `theme.output` > `output-theme`
- `theme.output-themes` > `theme.output`

Fixes: #1829