### PR TITLE
Add light and dark themes to default button styles

### DIFF
--- a/packages/button/src/_root.scss
+++ b/packages/button/src/_root.scss
@@ -31,3 +31,5 @@
   @include core.css("button-loading-animation-duration", var.$loading-animation-duration);
   @include core.css("button-loading-animation-timing-function", var.$loading-animation-timing-function);
 }
+
+@include theme.output("button");

--- a/packages/button/src/_variables.scss
+++ b/packages/button/src/_variables.scss
@@ -6,19 +6,19 @@ $breakpoints: core.$breakpoints !default;
 $size: core.$form-control-size !default;
 $padding: calc(#{list.nth(core.$padding, 1)} - 1px) list.nth(core.$padding, 2) !default;
 $gap: 0.5rem !default;
-$background: transparent !default;
-$background-hover: transparent !default;
-$background-active: transparent !default;
-$foreground: theme.get("foreground") !default;
-$foreground-hover: theme.get("foreground") !default;
-$foreground-active: theme.get("foreground") !default;
-$border-color: theme.get("border-color-dark") !default;
-$border-color-hover: theme.get("border-color-darker") !default;
-$border-color-active: theme.get("border-color-darker") !default;
+$background: null !default;
+$background-hover: null !default;
+$background-active: null !default;
+$foreground: null !default;
+$foreground-hover: null !default;
+$foreground-active: null !default;
+$border-color: null !default;
+$border-color-hover: null !default;
+$border-color-active: null !default;
 $border-width: 1px !default;
 $border-radius: core.$border-radius !default;
-$box-shadow: 0 0 0 0 rgb(0 0 0 / 0%) !default;
-$box-shadow-focus: 0 0 0 0.2rem rgb(0 0 0 / 15%) !default;
+$box-shadow: null !default;
+$box-shadow-focus: null !default;
 $font-size: 1em !default;
 $font-weight: inherit !default;
 $line-height: 1.6 !default;
@@ -54,3 +54,35 @@ $size-lg: core.$form-control-size-lg !default;
 $size-lg-padding: calc(#{list.nth(core.$padding-lg, 1)} - 1px) list.nth(core.$padding-lg, 2) !default;
 $size-lg-font-size: core.$font-size-lg !default;
 $size-lg-line-height: core.$line-height-lg !default;
+
+// Theme maps
+$theme-light: (
+  "background": transparent,
+  "background-hover": transparent,
+  "background-focus": transparent,
+  "foreground": theme.get("foreground"),
+  "foreground-hover": theme.get("foreground"),
+  "foreground-focus": theme.get("foreground"),
+  "border-color": theme.get("border-color-dark"),
+  "border-color-hover": theme.get("border-color-darker"),
+  "border-color-focus": theme.get("border-color-darker"),
+  "box-shadow": 0 0 0 0 rgb(0 0 0 / 0%),
+  "box-shadow-focus": 0 0 0 0.2rem rgb(0 0 0 / 15%)
+) !default;
+
+$theme-dark: (
+  "background": transparent,
+  "background-hover": transparent,
+  "background-focus": transparent,
+  "foreground": theme.get("foreground"),
+  "foreground-hover": theme.get("foreground"),
+  "foreground-focus": theme.get("foreground"),
+  "border-color": theme.get("border-color-dark"),
+  "border-color-hover": theme.get("border-color-darker"),
+  "border-color-focus": theme.get("border-color-darker"),
+  "box-shadow": 0 0 0 0 rgb(255 255 255 / 0%),
+  "box-shadow-focus": 0 0 0 0.2rem rgb(255 255 255 / 15%)
+) !default;
+
+@include theme.set("light", "button", $theme-light);
+@include theme.set("dark", "button", $theme-dark);


### PR DESCRIPTION
## What changed?

This PR introduces light and dark themes using the `theme` module so that the default button styles correctly update when using theme classes.

Fixes: #1828