### PR TITLE
Add skip to main content link in navibar

### DIFF
--- a/docs/src/components/Navibar.astro
+++ b/docs/src/components/Navibar.astro
@@ -15,6 +15,9 @@ const { classes = "" } = Astro.props;
 <header class={`navibar${classes ? " " + classes : ""}`}>
   <div class="navibar__container">
     <div class="navibar__title">
+      <a class="navibar__skip button button_color_primary" href="#main-content">
+        Skip to main content
+      </a>
       <a href="/" class="brand">
         <LogoIcon width={24} height={24} classes="brand__icon" />
         <strong class="brand__name">Vrembem</strong>

--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -32,7 +32,7 @@ const { title, layout = {} } = Astro.props;
         </div>
       )
     }
-    <div class="layout__main">
+    <div id="main-content" class="layout__main" tabindex="-1">
       <div class="layout__grid">
         {
           layout.hasAside && (

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -10,7 +10,7 @@ import Icon from "../components/Icon.astro";
 <Root bodyClass="background-darker">
   <Navibar classes="fold-shadow" />
   <div class="navibar-spacer"></div>
-  <div class="section section_size_xl fold-shadow-top type">
+  <div id="main-content" class="section section_size_xl fold-shadow-top type" tabindex="-1">
     <div class="section__container text-align-center">
       <h1 class="foreground">
         <Logo />

--- a/docs/src/styles/_navibar.scss
+++ b/docs/src/styles/_navibar.scss
@@ -41,14 +41,14 @@
 
 .navibar__skip {
   position: absolute;
-  top: -100%;
-  opacity: 0;
-  margin-right: 1em;
-  width: calc(100% - 1em);
   z-index: 100;
+  top: -100%;
+  width: calc(100% - 1em);
+  margin-right: 1em;
   transition-property: top, opacity;
   transition-duration: core.$transition-duration;
   transition-timing-function: core.$transition-timing-function;
+  opacity: 0;
 
   &:focus {
     top: calc(calc(var(--layout-navibar-height) - var(--vb-button-size)) / 2);

--- a/docs/src/styles/_navibar.scss
+++ b/docs/src/styles/_navibar.scss
@@ -1,3 +1,4 @@
+@use "@vrembem/core";
 @use "@vrembem/core/theme";
 @use "./root";
 
@@ -34,7 +35,25 @@
 }
 
 .navibar__title {
+  position: relative;
   width: var(--layout-drawer-width);
+}
+
+.navibar__skip {
+  position: absolute;
+  top: -100%;
+  opacity: 0;
+  margin-right: 1em;
+  width: calc(100% - 1em);
+  z-index: 100;
+  transition-property: top, opacity;
+  transition-duration: core.$transition-duration;
+  transition-timing-function: core.$transition-timing-function;
+
+  &:focus {
+    top: calc(calc(var(--layout-navibar-height) - var(--vb-button-size)) / 2);
+    opacity: 1;
+  }
 }
 
 .navibar__menu {


### PR DESCRIPTION
## What changed?

This PR adds a "Skip to main content" button to the navibar so that keyboard users can skip the main navigation and package menu more easily.

Fixes: #1830