### PR TITLE
Fix error on Get Started page by adding drawer element conditional check

### DIFF
--- a/docs/src/components/LayoutDrawer.astro
+++ b/docs/src/components/LayoutDrawer.astro
@@ -10,13 +10,16 @@
 
 <script>
   import { drawer } from "../modules/useDrawer";
-  const drawerItem = await drawer.register(document.getElementById("layout-drawer"));
-  if (drawerItem.mode == "inline") {
-    const active = drawerItem.dialog.querySelector(".is-active");
-    if (active) {
-      const space = window.innerHeight - active.offsetTop;
-      if (space < 80) {
-        active.scrollIntoView({ behavior: "instant", block: "center" });
+  const drawerElement = document.getElementById("layout-drawer");
+  if (drawerElement) {
+    const drawerItem = await drawer.register(drawerElement);
+    if (drawerItem.mode == "inline") {
+      const active = drawerItem.dialog.querySelector(".is-active");
+      if (active) {
+        const space = window.innerHeight - active.offsetTop;
+        if (space < 80) {
+          active.scrollIntoView({ behavior: "instant", block: "center" });
+        }
       }
     }
   }


### PR DESCRIPTION
## What changed?

This PR fixes the get started page's error by adding a drawer element conditional check. I decided the error handling on the drawer component itself was sufficient since you shouldn't be trying to register an element that doesn't exist (passing `null`).

Fixes: #1837