### PR TITLE
Add sr-only class to base module

### DIFF
--- a/docs/src/components/CollectionNavi.astro
+++ b/docs/src/components/CollectionNavi.astro
@@ -19,12 +19,16 @@ const cp = currentPage(new URL(Astro.request.url).pathname, {
 ---
 
 <nav>
-  <h2 class="padding padding-y-sm">
-    <a class="header-link" href={`/${collection}/`}>
-      {title}
-    </a>
-  </h2>
+  <h2 class="sr-only">{title}</h2>
   <ul class={`menu${menuClass ? " " + menuClass : ""}`}>
+    <li class="menu__item">
+      <a
+        class={cp.classes(`/${collection}`)} 
+        href={`/${collection}`}
+      >
+        <strong>{title}</strong>
+      </a>
+    </li>
     {
       entries.map((entry) => (
         <li class="menu__item">

--- a/docs/src/styles/_header-anchor.scss
+++ b/docs/src/styles/_header-anchor.scss
@@ -28,7 +28,3 @@
     }
   }
 }
-
-.header-link:hover {
-  color: base.$link-color-hover;
-}

--- a/packages/base/index.scss
+++ b/packages/base/index.scss
@@ -11,4 +11,5 @@
 @forward "./src/pre";
 @forward "./src/scroll-box";
 @forward "./src/separator";
+@forward "./src/sr-only";
 @forward "./src/type";

--- a/packages/base/src/_mixins.scss
+++ b/packages/base/src/_mixins.scss
@@ -204,6 +204,20 @@
   border-top: $border;
 }
 
+// Screen reader only content
+// ---
+
+@mixin sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+}
+
 // Type
 // ---
 

--- a/packages/base/src/_sr-only.scss
+++ b/packages/base/src/_sr-only.scss
@@ -1,0 +1,8 @@
+@use "./variables" as var;
+@use "./mixins" as mix;
+
+@if (var.$output-sr-only) {
+  .#{var.$prefix-block}#{var.$class-sr-only} {
+    @include mix.sr-only();
+  }
+}

--- a/packages/base/src/_variables.scss
+++ b/packages/base/src/_variables.scss
@@ -24,6 +24,7 @@ $output-list: $output !default;
 $output-pre: $output !default;
 $output-scroll-box: $output !default;
 $output-separator: $output !default;
+$output-sr-only: $output !default;
 $output-type: $output !default;
 
 // Base component classes
@@ -37,6 +38,7 @@ $class-list: "list" !default;
 $class-pre: "pre" !default;
 $class-scroll-box: "scroll-box" !default;
 $class-separator: "sep" !default;
+$class-sr-only: "sr-only" !default;
 $class-type: "type" !default;
 
 // Normalize


### PR DESCRIPTION
## What changed?

This PR adds the new `sr-only` class intended to be used for content that is meant for screen-readers only. This PR also applies the new `sr-only` class to the packages drawer title since we now also include the packages link in the menu itself.