### PR TITLE
Migrate drawer, modal and popover documentation to new format

### DIFF
--- a/docs/src/components/CollectionNavi.astro
+++ b/docs/src/components/CollectionNavi.astro
@@ -20,7 +20,7 @@ const cp = currentPage(new URL(Astro.request.url).pathname, {
 
 <nav>
   <h2 class="sr-only">{title}</h2>
-  <ul class={`menu${menuClass ? " " + menuClass : ""}`}>
+  <ul class={`menu menu_collection ${menuClass}`.trim()}>
     <li class="menu__item">
       <a
         class={cp.classes(`/${collection}`)} 

--- a/docs/src/components/DocBlock.astro
+++ b/docs/src/components/DocBlock.astro
@@ -83,7 +83,9 @@ const isFile = (type === "file");
             }
           </div>
           <hr class="sep" />
-          <slot />
+          <div class="type">
+            <slot />
+          </div>
         </div>
       )
     }

--- a/docs/src/components/Footer.astro
+++ b/docs/src/components/Footer.astro
@@ -9,7 +9,7 @@ const { classes = "" } = Astro.props;
 
 ---
 
-<footer class={`footer${classes ? " " + classes : ""}`}>
+<footer class={`footer ${classes}`.trim()}>
   <div class="grid grid_stack_xs">
     <div class="grid__item">
       <p class="foreground-lighter flex-grow-1">

--- a/docs/src/components/Navi.astro
+++ b/docs/src/components/Navi.astro
@@ -5,15 +5,11 @@ import ThemeSwitcherMenu from "../components/ThemeSwitcherMenu.astro";
 import Icon from "./Icon.astro";
 
 interface Props {
-  classes?: string;
+  menuClass?: string;
   inline?: boolean;
 }
 
-const { classes = "", inline = false } = Astro.props;
-
-let menuClasses = "menu";
-menuClasses += inline ? " menu_inline" : "";
-menuClasses += classes ? " " + classes : "";
+const { menuClass, inline = false } = Astro.props;
 
 const cp = currentPage(new URL(Astro.request.url).pathname, {
   classBase: "menu__action",
@@ -23,7 +19,7 @@ const cp = currentPage(new URL(Astro.request.url).pathname, {
 
 ---
 
-<ul class={menuClasses}>
+<ul class={`menu ${inline ? "menu_inline" : ""} ${menuClass}`.trim()}>
   <li class="menu__item">
     <a class={cp.classes("/getting-started")} href="/getting-started"
       >Get Started</a

--- a/docs/src/components/Navibar.astro
+++ b/docs/src/components/Navibar.astro
@@ -12,7 +12,7 @@ const { classes = "" } = Astro.props;
 
 ---
 
-<header class={`navibar${classes ? " " + classes : ""}`}>
+<header class={`navibar ${classes}`.trim()}>
   <div class="navibar__container">
     <div class="navibar__title">
       <a class="navibar__skip button button_color_primary" href="#main-content">
@@ -25,7 +25,7 @@ const { classes = "" } = Astro.props;
       </a>
     </div>
     <div class="navibar__menu">
-      <Navi classes="display-none display-flex-md" inline={true} />
+      <Navi menuClass="display-none display-flex-md" inline={true} />
       <button
         data-modal-open="modal-navi"
         class="button button_icon display-block display-none-md"

--- a/docs/src/components/OnThisPage.astro
+++ b/docs/src/components/OnThisPage.astro
@@ -4,7 +4,9 @@ import OnThisPageList from "./OnThisPageList.astro";
 const { headings, menuClass } = Astro.props;
 
 // Filter the headings to only display the ones we want.
-const filteredHeadings = build(headings.filter((item) => item.depth === 2));
+const filteredHeadings = build(headings.filter((item) => {
+  return item.depth === 2 || item.depth === 3
+}));
 
 function build(headings) {
   const otp = [];
@@ -27,7 +29,7 @@ function build(headings) {
 
 <nav>
   <h2 class="padding padding-y-sm">On this page</h2>
-  <ul class={`menu menu_otp${menuClass ? " " + menuClass : ""}`}>
+  <ul class={`menu menu_otp ${menuClass}`.trim()}>
     {filteredHeadings.map((item) => <OnThisPageList {item} />)}
     <li class="menu__sep slide-up scroll-spy"></li>
     <li class="menu__item slide-up scroll-spy">
@@ -48,11 +50,3 @@ function build(headings) {
     selectorAnchors: ".menu_otp a",
   }).mount();
 </script>
-
-<style is:global>
-  .menu_otp .menu__action {
-    display: block;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-</style>

--- a/docs/src/components/OnThisPage.astro
+++ b/docs/src/components/OnThisPage.astro
@@ -28,8 +28,11 @@ function build(headings) {
 ---
 
 <nav>
-  <h2 class="padding padding-y-sm">On this page</h2>
+  <h2 class="sr-only">On this page</h2>
   <ul class={`menu menu_otp ${menuClass}`.trim()}>
+    <li>
+      <a href="#main" class="menu__action"><strong>On this page</strong></a>
+    </li>
     {filteredHeadings.map((item) => <OnThisPageList {item} />)}
     <li class="menu__sep slide-up scroll-spy"></li>
     <li class="menu__item slide-up scroll-spy">

--- a/docs/src/content/packages/checkbox.mdx
+++ b/docs/src/content/packages/checkbox.mdx
@@ -81,7 +81,7 @@ Checkboxes are composed using a set of `<span>` elements alongside the native `<
 Indeterminate checkboxes need to be set in JavaScript though styling is provided by Vrembem for the indeterminate states (see example above). Review [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/:indeterminate) for more details.
 
 
-### Checkboxes with labels
+### Checkbox with labels
 
 For checkboxes with labels, wrap the checkbox component along with the text label using the `<label>` element.
 

--- a/docs/src/content/packages/drawer.mdx
+++ b/docs/src/content/packages/drawer.mdx
@@ -61,7 +61,7 @@ Drawers are composed using classes and data attributes for their triggers. The b
   <div class="drawer-frame">
 
     <!-- The drawer element -->
-    <aside id="drawer-id" class="drawer">
+    <aside id="[unique-id]" class="drawer">
       <div class="drawer__dialog">
         ...
       </div>
@@ -83,9 +83,9 @@ Drawer triggers are defined using three data attributes:
 
 <CodeExample lang="html">
   ```html
-  <button data-drawer-open="drawer-id">...</button>
-  <button data-drawer-close="drawer-id">...</button>
-  <button data-drawer-toggle="drawer-id">...</button>
+  <button data-drawer-open="[unique-id]">...</button>
+  <button data-drawer-close="[unique-id]">...</button>
+  <button data-drawer-toggle="[unique-id]">...</button>
   ```
 </CodeExample>
 
@@ -118,7 +118,7 @@ The dialog element of a drawer is defined using the `drawer__dialog` class. Alon
     </div>
   </Fragment>
   ```html
-  <aside id="drawer-id" class="drawer">
+  <aside id="[unique-id]" class="drawer">
     <div class="drawer__dialog dialog" role="dialog" aria-labelledby="dialog-title" aria-describedby="dialog-description">
       <div class="dialog__header">
         <h2 id="dialog-title">...</h2>
@@ -152,19 +152,13 @@ There are multiple ways a modal drawer can be created. The simplest being applyi
         </div>
       </aside>
       <div class="drawer-main padding">
-        <ul class="list">
-          <li>
-            <button class="link" data-drawer-toggle="drawer-3">
-              Toggle
-            </button>
-          </li>
-        </ul>
+        <button class="link" data-drawer-toggle="drawer-3">Toggle</button>
       </div>
     </div>
   </Fragment>
   <Fragment slot="tab-html">
     ```html
-    <aside id="drawer-id" class="drawer drawer_modal">
+    <aside id="[unique-id]" class="drawer drawer_modal">
       ...
     </aside>
     ```
@@ -218,12 +212,12 @@ In cases where you'd like a drawer to switch modes based on a specific viewport 
   </Fragment>
   ```html
   <!-- Switches to modal below 1200px viewports -->
-  <aside id="drawer-id" class="drawer" data-drawer-breakpoint="1200px">
+  <aside id="[unique-id]" class="drawer" data-drawer-breakpoint="1200px">
     ...
   </aside>
 
   <!-- Switches to modal below "md" breakpoint viewports -->
-  <aside id="drawer-id" class="drawer" data-drawer-breakpoint="md">
+  <aside id="[unique-id]" class="drawer" data-drawer-breakpoint="md">
     ...
   </aside>
   ```
@@ -298,13 +292,13 @@ Drawer dialogs are given focus when opened as long as the `setTabindex` option i
   ```html
   <div class="drawer-frame">
     <!-- Focuses the drawer dialog on open -->
-    <aside id="drawer-id" class="drawer">
+    <aside id="[unique-id]" class="drawer">
       <div class="drawer__dialog" tabindex="-1">
         ...
       </div>
     </aside>
     <!-- Focuses an inner element on open -->
-    <aside id="drawer-id" class="drawer">
+    <aside id="[unique-id]" class="drawer">
       <div class="drawer__dialog">
         <input data-focus type="text" />
       </div>
@@ -312,7 +306,7 @@ Drawer dialogs are given focus when opened as long as the `setTabindex` option i
     
     <div class="drawer-main">
       <!-- Return focus to toggle on close -->
-      <button data-drawer-toggle="drawer-id">...</button>
+      <button data-drawer-toggle="[unique-id]">...</button>
     </div>
   </div>
   ```
@@ -334,8 +328,6 @@ Drawers while in their modal state follow a set of patterns expected from other 
 4. When a modal drawer is closed, focus is returned to the initial trigger element that activated the dialog.
 
 To take full advantage of modal drawer's accessibility features, it's recommended to set the `selectorInert` option to all elements that are outside the modal (most likely the `drawer-main` element). All elements that match the `selectorInert` selector will be given the `inert` attribute as well as `aria-hidden="true"` when a modal is opened.
-
-> Inert is not currently widely supported by all browsers. Consider using a polyfill such as [wicg-inert](https://github.com/WICG/inert) or Google's [inert-polyfill](https://github.com/GoogleChrome/inert-polyfill).
 
 **Example**
 
@@ -369,18 +361,12 @@ Applies modal drawer styles to a drawer. This modifier should be applied before 
         </div>
       </aside>
       <div class="drawer-main padding">
-        <ul class="list">
-          <li>
-            <button class="link" data-drawer-toggle="drawer-8">
-              Toggle
-            </button>
-          </li>
-        </ul>
+        <button class="link" data-drawer-toggle="drawer-8">Toggle</button>
       </div>
      </div>
   </Fragment>
   ```html
-  <aside id="drawer-id" class="drawer drawer_modal">
+  <aside id="[unique-id]" class="drawer drawer_modal">
     ...
   </aside>
   ```
@@ -402,13 +388,7 @@ Drawers slide in from the left by default. To create a right side drawer, use th
         </div>
       </aside>
       <div class="drawer-main padding">
-        <ul class="list">
-          <li>
-            <button class="link" data-drawer-toggle="drawer-9">
-              Toggle
-            </button>
-          </li>
-        </ul>
+        <button class="link" data-drawer-toggle="drawer-9">Toggle</button>
       </div>
     </div>
   </Fragment>
@@ -522,7 +502,7 @@ Drawers are primarily customized using CSS variables but can also be modified us
 
 ## JavaScript usage
 
-After the drawer component has been instantiated the drawer object is returned with a robust API to help manage all the drawers on your page.
+After the drawer component has been instantiated the drawer object is returned with a robust API to help manage all drawer components on your page.
 
 <DocBlock name="drawer.collection" type="property" returns="array" src="core/src/js/Collection.js" line="3">
   Returns an array where all drawer objects are stored when registered. Each drawer object contains the following properties:
@@ -550,7 +530,7 @@ After the drawer component has been instantiated the drawer object is returned w
 </DocBlock>
 
 <DocBlock name="drawer.activeModal" type="property" returns="Object || undefined" src="drawer/src/js/index.js" line="29">
-  Returns the currently active modal drawer. Returns `undefined` if there is no modal drawer open.
+  Returns the currently active modal drawer. Returns `undefined` if there are no modal drawer open.
 </DocBlock>
 
 <DocBlock name="drawer.init" type="method" returns="Object" src="drawer/src/js/index.js" line="35" args={[
@@ -665,9 +645,9 @@ After the drawer component has been instantiated the drawer object is returned w
   ["value", "String || Object", "The value to search for within the collection."],
   ["key", "String (optional)", "The property key to search the value against (defaults to 'id')."]
 ]}>
-   Used to retrieve a registered drawer object from the collection. The value should match the key type to search by: e.g. to search by drawer elements, pass the drawer html node with a key of `'el'`. Defaults to `'id'`.
+  Used to retrieve a registered drawer entry from the collection. The value should match the key type to search by: e.g. to search by drawer elements, pass the drawer html node with a key of `'el'`. Defaults to `'id'`.
 
-   Returns the first element in the collection that matches the provided query and key. Otherwise, undefined is returned.
+  Returns the first element in the collection that matches the provided query and key. Otherwise, undefined is returned.
 
   <Fragment slot="example">
     ```js
@@ -682,7 +662,7 @@ After the drawer component has been instantiated the drawer object is returned w
   ["transition", "Boolean (optional)", "Whether or not to animate the transition."],
   ["focus", "Boolean (optional)", "Whether or not to handle focus management."]
 ]}>
-   Opens a drawer using the provided ID. Returns the drawer object that was opened.
+  Opens a drawer using the provided ID. Returns the drawer object that was opened.
 
   <Fragment slot="example">
     ```js
@@ -698,7 +678,7 @@ After the drawer component has been instantiated the drawer object is returned w
   ["transition", "Boolean (optional)", "Whether or not to animate the transition."],
   ["focus", "Boolean (optional)", "Whether or not to handle focus management."]
 ]}>
-   Closes a drawer using the provided ID. Returns the drawer object that was closed.
+  Closes a drawer using the provided ID. Returns the drawer object that was closed.
 
   <Fragment slot="example">
     ```js
@@ -725,7 +705,7 @@ After the drawer component has been instantiated the drawer object is returned w
 
 ### Custom Events
 
-The drawer component also exposes some custom events for hooking into the drawer lifecycle. All drawer events are fired on the root drawer element (i.e. at the `<aside id="drawer-id" class="drawer">`).
+The drawer component also exposes some custom events for hooking into the drawer lifecycle. All drawer events are fired on the root drawer element (i.e. at the `<aside id="[unique-id]" class="drawer">`).
 
 - `drawer:opened` Emits when a drawer has opened.
 - `drawer:closed` Emits when a drawer has closed.

--- a/docs/src/content/packages/drawer.mdx
+++ b/docs/src/content/packages/drawer.mdx
@@ -2,57 +2,78 @@
 title: Drawer
 description: "A container component that slides in from the left or right. Typically containing menus, search or other content."
 package: "@vrembem/drawer"
+state: "circle"
 ---
+
+import CodeExample from "../../components/CodeExample.astro";
+import DocBlock from "../../components/DocBlock.astro";
 
 # Drawer
 
 A container component that slides in from the left or right. Typically containing menus, search or other content.
 
-[![npm version](https://img.shields.io/npm/v/%40vrembem%2Fdrawer.svg)](https://www.npmjs.com/package/%40vrembem%2Fdrawer)
-
-[Documentation](https://vrembem.com/packages/drawer)
-
-## Installation
-
 ```sh
 npm install @vrembem/drawer
 ```
 
-### Styles
+<CodeExample lang="scss">
+  ```scss
+  @use "@vrembem/drawer";
+  ```
+</CodeExample>
 
-```scss
-@use "@vrembem/drawer";
-```
+<CodeExample lang="js">
+  ```js
+  import Drawer from "@vrembem/drawer";
+  const drawer = new Drawer({ autoInit: true });
+  ```
+</CodeExample>
 
-### JavaScript
-
-```js
-import Drawer from '@vrembem/drawer';
-const drawer = new Drawer({ autoInit: true });
-```
-
-### Markup
+## Basic usage
 
 Drawers are composed using classes and data attributes for their triggers. The basic structure of a drawer is an element with an `id` and `drawer` class containing a child element with the `drawer__dialog` class. There are two required structure elements for drawers to work correctly:
 
 - `drawer-frame`: Applied to the parent element wrapping all drawers and the main content.
 - `drawer-main`: Applied to the element containing the main content. This should be the last child of the `drawer-frame` element.
 
-```html
-<div class="drawer-frame">
+<CodeExample lang="html" flush={true}>
+  <Fragment slot="output">
+    <div class="drawer-frame">
+      <aside id="drawer-1" class="drawer">
+        <div class="drawer__dialog padding">
+          <div class="flex flex-justify-between">
+            <span>Drawer example</span>
+            <button class="link" data-drawer-close>Close</button>
+          </div>
+        </div>
+      </aside>
+      <div class="drawer-main padding">
+        <ul class="list">
+          <li><button class="link" data-drawer-open="drawer-1">Open</button></li>
+          <li><button class="link" data-drawer-close="drawer-1">Close</button></li>
+          <li><button class="link" data-drawer-toggle="drawer-1">Toggle</button></li>
+        </ul>
+      </div>
+    </div>
+  </Fragment>
+  ```html
+  <!-- The drawer and content wrapper -->
+  <div class="drawer-frame">
 
-  <aside id="drawer-id" class="drawer">
-    <div class="drawer__dialog">
+    <!-- The drawer element -->
+    <aside id="drawer-id" class="drawer">
+      <div class="drawer__dialog">
+        ...
+      </div>
+    </aside>
+
+    <!-- The main content container -->
+    <div class="drawer-main">
       ...
     </div>
-  </aside>
-
-  <div class="drawer-main">
-    ...
   </div>
-
-</div>
-```
+  ```
+</CodeExample>
 
 Drawer triggers are defined using three data attributes:
 
@@ -60,81 +81,172 @@ Drawer triggers are defined using three data attributes:
 - `data-drawer-close`: Closes a drawer. Will close the parent drawer if left value-less. Can also take an id of a drawer to close.
 - `data-drawer-toggle`: Toggles a drawer opened or closed. Takes the id of the drawer it's meant to toggle.
 
-```html
-<button data-drawer-open="drawer-id">...</button>
-<button data-drawer-close="drawer-id">...</button>
-<button data-drawer-toggle="drawer-id">...</button>
-```
+<CodeExample lang="html">
+  ```html
+  <button data-drawer-open="drawer-id">...</button>
+  <button data-drawer-close="drawer-id">...</button>
+  <button data-drawer-toggle="drawer-id">...</button>
+  ```
+</CodeExample>
 
-The dialog element of a drawer is defined using the `drawer__dialog` class. Along with a role attribute (e.g. `role="dialog"`), authors should provide drawer dialogs with [`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) and [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) attributes if applicable to further improve accessibility. The `aria-modal` attribute is applied automatically based on if the drawer is currently in `'modal'` mode.
+The dialog element of a drawer is defined using the `drawer__dialog` class. Along with a role attribute (e.g. `role="dialog"`), authors should provide drawer dialogs with [`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) and [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) attributes if applicable to further improve accessibility. The `aria-modal` attribute is applied automatically based on if the drawer is currently in modal mode.
 
-```html
-<aside id="drawer-id" class="drawer">
-  <div class="drawer__dialog dialog" role="dialog" aria-labelledby="dialog-title" aria-describedby="dialog-description">
-    <div class="dialog__header">
-      <h2 id="dialog-title">...</h2>
+<CodeExample lang="html" flush={true}>
+  <Fragment slot="output">
+    <div class="drawer-frame" style="min-height: 16rem;">
+      <aside id="drawer-2" class="drawer">
+        <div class="drawer__dialog dialog" role="dialog" aria-labelledby="dialog-title" aria-describedby="dialog-description">
+          <div class="dialog__header flex-justify-between">
+            <h2 id="dialog-title">Drawer title</h2>
+            <button class="link" data-drawer-close>Close</button>
+          </div>
+          <div class="dialog__body">
+            <p id="dialog-description">This is a drawer example using the dialog component.</p>
+          </div>
+          <div class="dialog__footer">
+            Drawer footer.
+          </div>
+        </div>
+      </aside>
+      <div class="drawer-main padding">
+        <ul class="list">
+          <li><button class="link" data-drawer-open="drawer-2">Open</button></li>
+          <li><button class="link" data-drawer-close="drawer-2">Close</button></li>
+          <li><button class="link" data-drawer-toggle="drawer-2">Toggle</button></li>
+        </ul>
+      </div>
     </div>
-    <div class="dialog__body">
-      <p id="dialog-description">...</p>
+  </Fragment>
+  ```html
+  <aside id="drawer-id" class="drawer">
+    <div class="drawer__dialog dialog" role="dialog" aria-labelledby="dialog-title" aria-describedby="dialog-description">
+      <div class="dialog__header">
+        <h2 id="dialog-title">...</h2>
+      </div>
+      <div class="dialog__body">
+        <p id="dialog-description">...</p>
+      </div>
+      <div class="dialog__footer">
+        ...
+      </div>
     </div>
-    <div class="dialog__footer">
+  </aside>
+  ```
+</CodeExample>
+
+> The [dialog component](/packages/dialog) is a great fit for composing a drawer's dialog.
+
+### Modal drawers
+
+There are multiple ways a modal drawer can be created. The simplest being applying the [`drawer_modal`](#drawer_modal) modifier class to the `drawer` element before its been registered. To change a drawer's mode after its been registered, change the `mode` property of the drawer entry from `'inline'` to `'modal'` (or vice versa) in JavaScript.
+
+<CodeExample tabs={true} flush={true}>
+  <Fragment slot="output">
+    <div class="drawer-frame" style="min-height: 8rem;">
+      <aside id="drawer-3" class="drawer drawer_modal" data-drawer-config="{ 'selectorInert': null, 'selectorOverflow': null }">
+        <div class="drawer__dialog padding">
+          <div class="flex flex-justify-between">
+            <span>Modal drawer</span>
+            <button class="link" data-drawer-close>Close</button>
+          </div>
+        </div>
+      </aside>
+      <div class="drawer-main padding">
+        <ul class="list">
+          <li>
+            <button class="link" data-drawer-toggle="drawer-3">
+              Toggle
+            </button>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </Fragment>
+  <Fragment slot="tab-html">
+    ```html
+    <aside id="drawer-id" class="drawer drawer_modal">
       ...
-    </div>
-  </div>
-</aside>
-```
+    </aside>
+    ```
+  </Fragment>
+  <Fragment slot="tab-js">
+    ```js
+    // Set a drawer to "modal" mode.
+    drawer.get("drawer-id").mode = "modal";
 
-> The [dialog component](https://github.com/sebnitu/vrembem/tree/main/packages/dialog) is a great fit for composing a drawer's dialog.
-
-#### Modal Drawers
-
-To create a modal drawer, apply the `drawer_modal` modifier.
-
-```html
-<aside id="drawer-id" class="drawer drawer_modal">
-  ...
-</aside>
-```
-
-You can also switch a drawer from `'inline'` to `'modal'` by changing the collection API `mode` property:
-
-```js
-// Get the drawer object from the collection.
-const entry = drawer.get('drawer-id');
-
-// Set it's mode to either 'modal' or 'inline'.
-entry.mode = 'modal';
-```
+    // Set a drawer to "Inline" mode.
+    drawer.get("drawer-id").mode = "inline";
+    ```
+  </Fragment>
+</CodeExample>
 
 In cases where you'd like a drawer to switch modes based on a specific viewport width, use the `data-drawer-breakpoint` data attribute with either a width value or a breakpoint key.
 
-```html
-<!-- Switches to modal below 1200px viewports -->
-<aside id="drawer-id" class="drawer" data-drawer-breakpoint="1200px">
-  ...
-</aside>
+<CodeExample lang="html" flush={true}>
+  <Fragment slot="output">
+    <div class="drawer-frame">
+      <aside id="drawer-4" class="drawer" data-drawer-breakpoint="1200px" data-drawer-config="{ 'selectorInert': null, 'selectorOverflow': null }">
+        <div class="drawer__dialog padding gap-y">
+          <div class="flex flex-justify-between">
+            <span>Drawer example</span>
+            <button class="link" data-drawer-close>Close</button>
+          </div>
+          <code>data-drawer-breakpoint="1200px"</code>
+        </div>
+      </aside>
+      <aside id="drawer-5" class="drawer" data-drawer-breakpoint="md" data-drawer-config="{ 'selectorInert': null, 'selectorOverflow': null }">
+        <div class="drawer__dialog padding gap-y">
+          <div class="flex flex-justify-between">
+            <span>Drawer example</span>
+            <button class="link" data-drawer-close>Close</button>
+          </div>
+          <code>data-drawer-breakpoint="md"</code>
+        </div>
+      </aside>
+      <div class="drawer-main padding gap-y">
+        <p>Current viewport width: <code class="vp-width">...</code></p>
+        <ul class="list">
+          <li>
+            <button class="link" data-drawer-toggle="drawer-4">Toggle</button> - Switches to modal below `1200px` viewports.
+          </li>
+          <li>
+            <button class="link" data-drawer-toggle="drawer-5">Toggle</button> - Switches to modal below `"md"` breakpoint viewports.
+          </li>
+        </ul>
+      </div>
+    </div>
+  </Fragment>
+  ```html
+  <!-- Switches to modal below 1200px viewports -->
+  <aside id="drawer-id" class="drawer" data-drawer-breakpoint="1200px">
+    ...
+  </aside>
 
-<!-- Switches to modal below "md" breakpoint viewports -->
-<aside id="drawer-id" class="drawer" data-drawer-breakpoint="md">
-  ...
-</aside>
-```
+  <!-- Switches to modal below "md" breakpoint viewports -->
+  <aside id="drawer-id" class="drawer" data-drawer-breakpoint="md">
+    ...
+  </aside>
+  ```
+</CodeExample>
 
 A custom breakpoints object can be passed in using the `breakpoints` option. Otherwise, breakpoints are resolved by looking up a CSS variable using the passed key (e.g: `--vb-breakpoint-[key]`).
 
+<CodeExample lang="js">
 ```js
 const drawer = new Drawer({
   breakpoints: {
-    xs: '480px',
-    sm: '620px',
-    md: '760px',
-    lg: '990px',
-    xl: '1380px'
+    xs: "480px",
+    sm: "620px",
+    md: "760px",
+    lg: "990px",
+    xl: "1380px"
   }
 });
 ```
+</CodeExample>
 
-```scss
+<CodeExample lang="css">
+```css
 :root {
   --vb-breakpoint-xs: 480px;
   --vb-breakpoint-sm: 620px;
@@ -143,44 +255,76 @@ const drawer = new Drawer({
   --vb-breakpoint-xl: 1380px;
 }
 ```
+</CodeExample>
 
 While a modal drawer is active, the contents obscured by the modal are made inaccessible to all users via a focus trap. This means that the `TAB` key, and a screen reader’s virtual cursor (arrow keys) should not be allowed to leave the drawer dialog and traverse the content outside of the dialog. This does not apply to inline drawers.
 
-#### Focus Management
+### Focus management
 
 Drawer dialogs are given focus when opened as long as the `setTabindex` option is set to `true` or if the drawer dialog has `tabindex="-1"` set manually. If focus on a specific element inside a drawer is preferred, give that element the `data-focus` attribute. Focus is returned to the element that initially triggered the drawer once closed.
 
-```html
-<div class="drawer-frame">
-  <!-- Focuses the drawer dialog on open -->
-  <aside id="drawer-id" class="drawer">
-    <div class="drawer__dialog" tabindex="-1">
-      ...
+<CodeExample lang="html" flush={true}>
+  <Fragment slot="output">
+    <div class="drawer-frame" style="min-height: 8rem;">
+      <aside id="drawer-6" class="drawer">
+        <div class="drawer__dialog padding" tabindex="-1">
+          <div class="flex flex-justify-between">
+            <span>Drawer example</span>
+            <button class="link" data-drawer-close>Close</button>
+          </div>
+        </div>
+      </aside>
+      <aside id="drawer-7" class="drawer">
+        <div class="drawer__dialog padding gap-y">
+          <div class="flex flex-justify-between">
+            <span>Drawer example</span>
+            <button class="link" data-drawer-close>Close</button>
+          </div>
+          <input class="input" data-focus type="text" />
+        </div>
+      </aside>
+      <div class="drawer-main padding">
+        <ul class="list">
+          <li>
+            <button class="link" data-drawer-toggle="drawer-6">Toggle</button> - Sets focus to the drawer dialog when opened.
+          </li>
+          <li>
+            <button class="link" data-drawer-toggle="drawer-7">Toggle</button> - Sets focus to the `data-focus` element when opened.
+          </li>
+        </ul>
+      </div>
     </div>
-  </aside>
-
-  <!-- Focuses an inner element on open -->
-  <aside id="drawer-id" class="drawer">
-    <div class="drawer__dialog">
-      <input data-focus type="text">
-      ...
+  </Fragment>
+  ```html
+  <div class="drawer-frame">
+    <!-- Focuses the drawer dialog on open -->
+    <aside id="drawer-id" class="drawer">
+      <div class="drawer__dialog" tabindex="-1">
+        ...
+      </div>
+    </aside>
+    <!-- Focuses an inner element on open -->
+    <aside id="drawer-id" class="drawer">
+      <div class="drawer__dialog">
+        <input data-focus type="text" />
+      </div>
+    </aside>
+    
+    <div class="drawer-main">
+      <!-- Return focus to toggle on close -->
+      <button data-drawer-toggle="drawer-id">...</button>
     </div>
-  </aside>
-  
-  <div class="drawer-main">
-    <!-- Return focus to toggle on close -->
-    <button data-drawer-toggle="drawer-id">...</button>
   </div>
-</div>
-```
+  ```
+</CodeExample>
 
 > To change the selector used in finding the preferred focus element, pass your own selector via the `selectorFocus` option (defaults to `'[data-focus]'`).
 
-#### Drawer State
+### Drawer state
 
 The state of all drawers are saved to local storage and applied persistently under the `VB:DrawerState` local storage key. Set `store: false` to disable the local storage feature. Use `storeKey: "CUSTOM-KEY"` to change the key that local store is saved under.
 
-## Behavior and Accessibility
+### Behavior and accessibility
 
 Drawers while in their modal state follow a set of patterns expected from other modals on the web. Here's what to expect:
 
@@ -193,331 +337,396 @@ To take full advantage of modal drawer's accessibility features, it's recommende
 
 > Inert is not currently widely supported by all browsers. Consider using a polyfill such as [wicg-inert](https://github.com/WICG/inert) or Google's [inert-polyfill](https://github.com/GoogleChrome/inert-polyfill).
 
-### Example
+**Example**
 
 Here's an example where we want the `drawer-main` content area to be inaccessible while drawer modals are open. We also want to disable other scrollable elements using the `selectorOverflow` option.
 
-```js
-const drawer = new Drawer({
-  selectorInert: '.drawer-main',
-  selectorOverflow: 'body, .drawer-main'
-});
+<CodeExample lang="js">
 
-await drawer.init();
-```
+   ```js
+   const drawer = new Drawer({
+     selectorInert: ".drawer-main",
+     selectorOverflow: "body, .drawer-main"
+   });
 
-## Modifiers
+   await drawer.init();
+   ```
+</CodeExample>
 
-### `drawer_modal`
+## drawer_modal
 
-Applies modal drawer styles to a drawer. To convert a drawer to its modal state after its been registered, set the collection API `mode` property to `'modal'`. Only one modal can be open at a time.
+Applies modal drawer styles to a drawer. This modifier should be applied before the drawer has been registered to properly setup the modal drawer. For more details on modal drawers and how to create them dynamically, please see the [modal drawer](#modal-drawers) documentation.
 
-```html
-<aside id="drawer-id" class="drawer drawer_modal">
-  ...
-</aside>
-```
+<CodeExample lang="html" flush={true}>
+  <Fragment slot="output">
+    <div class="drawer-frame" style="min-height: 8rem;">
+      <aside id="drawer-8" class="drawer drawer_modal" data-drawer-config="{ 'selectorInert': null, 'selectorOverflow': null }">
+        <div class="drawer__dialog padding">
+          <div class="flex flex-justify-between">
+            <span>Drawer example</span>
+            <button class="link" data-drawer-close>Close</button>
+          </div>
+        </div>
+      </aside>
+      <div class="drawer-main padding">
+        <ul class="list">
+          <li>
+            <button class="link" data-drawer-toggle="drawer-8">
+              Toggle
+            </button>
+          </li>
+        </ul>
+      </div>
+     </div>
+  </Fragment>
+  ```html
+  <aside id="drawer-id" class="drawer drawer_modal">
+    ...
+  </aside>
+  ```
+</CodeExample>
 
-### `drawer_switch`
+## drawer_switch
 
 Drawers slide in from the left by default. To create a right side drawer, use the `drawer_switch` modifier.
 
-```html
-<aside id="drawer-right" class="drawer drawer_switch">
-  ...
-</aside>
-```
+<CodeExample lang="html" flush={true}>
+  <Fragment slot="output">
+    <div class="drawer-frame" style="min-height: 8rem;">
+      <aside id="drawer-9" class="drawer drawer_switch">
+        <div class="drawer__dialog padding">
+          <div class="flex flex-justify-between">
+            <span>Drawer example</span>
+            <button class="link" data-drawer-close>Close</button>
+          </div>
+        </div>
+      </aside>
+      <div class="drawer-main padding">
+        <ul class="list">
+          <li>
+            <button class="link" data-drawer-toggle="drawer-9">
+              Toggle
+            </button>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </Fragment>
+  ```html
+  <aside id="drawer-right" class="drawer drawer_switch">
+    ...
+  </aside>
+  ```
+</CodeExample>
 
 ## Customization
 
-### Sass Variables
+Drawers are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable via the `core` module.
 
-| Variable                         | Default                            | Description                                                                                          |
-| -------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `$prefix-block`                  | `null`                             | String to prefix blocks with.                                                                        |
-| `$prefix-element`                | `"__"`                             | String to prefix elements with.                                                                      |
-| `$prefix-modifier`               | `"_"`                              | String to prefix modifiers with.                                                                     |
-| `$prefix-modifier-value`         | `"_"`                              | String to prefix modifier values with.                                                               |
-| `$class-frame`                   | `$prefix-block'drawer-frame'`      | Class name to use for the `drawer-frame` element.                                                    |
-| `$class-main`                    | `$prefix-block'drawer-main'`       | Class name to use for the `drawer-main` element.                                                     |
-| `$width`                         | `18em`                             | The width of drawers.                                                                                |
-| `$max-width`                     | `100%`                             | The max-width of drawers.                                                                            |
-| `$border`                        | `null`                             | Border applied to drawer items with position modifiers. Shown on side of drawers facing drawer main. |
-| `$sep-border`                    | `null`                             | Border color applied to dialog elements within drawers.                                              |
-| `$background`                    | `core.$shade`                      | Background color applied to drawer items.                                                            |
-| `$box-shadow`                    | `none`                             | Box shadow applied to drawer items.                                                                  |
-| `$transition-duration`           | `core.$transition-duration`        | Duration of drawer transition.                                                                       |
-| `$transition-timing-function`    | `core.$transition-timing-function` | Timing function used for drawer transitions.                                                         |
-| `$frame-height`                  | `100vh`                            | Height given to the `drawer-frame` element.                                                          |
-| `$modal-z-index`                 | `900`                              | Modal z-index to help control the stack order. Should be highest priority as modal.                  |
-| `$modal-width`                   | `$width`                           | The width of modal drawers.                                                                          |
-| `$modal-max-width`               | `80%`                              | The max-width of modal drawers.                                                                      |
-| `$modal-sep-border`              | `null`                             | Border color applied to dialog elements within modal drawers.                                        |
-| `$modal-background`              | `white`                            | Background color applied to modal drawer items.                                                      |
-| `$modal-box-shadow`              | `core.$box-shadow-5`               | Box shadow applied to modal drawer items.                                                            |
-| `$modal-screen-background`       | `core.$night`                      | Background color of modal screen.                                                                    |
-| `$modal-screen-background-alpha` | `0.8`                              | The alpha channel for the modal screen.                                                              |
+<DocBlock name="CSS Variables" type="file" src="drawer/src/scss/_root.scss">
 
-### JavaScript Options
+  ```scss
+  @use "./variables" as var;
 
-| Key                 | Default               | Description                                                                                          |
-| ------------------- | --------------------- | ---------------------------------------------------------------------------------------------------- |
-| `autoInit`          | `false`               | Automatically initializes the instance.                                                              |
-| `dataOpen`          | `'drawer-open'`       | Data attribute for a drawer open trigger.                                                            |
-| `dataClose`         | `'drawer-close'`      | Data attribute for a drawer close trigger.                                                           |
-| `dataToggle`        | `'drawer-toggle'`     | Data attribute for a drawer toggle trigger.                                                          |
-| `dataBreakpoint`    | `'drawer-breakpoint'` | Data attribute for setting a drawer's breakpoint.                                                    |
-| `dataBreakpoint`    | `'drawer-config'`     | Data attribute to find drawer specific configuration settings. Value should be a JSON object.        |
-| `selectorDrawer`    | `'.drawer'`           | Selector for dialog element.                                                                         |
-| `selectorDialog`    | `'.drawer__dialog'`   | Selector for drawer dialog element.                                                                  |
-| `selectorFocus`     | `'[data-focus]'`      | Focus preference selector for when drawers are initially opened.                                     |
-| `selectorInert`     | `null`                | Applies `inert` and `aria-hidden` attributes to all matching elements when a modal drawer is opened. |
-| `selectorOverflow`  | `'body'`              | Applies `overflow:hidden` styles on all matching elements when a modal drawer is opened.             |
-| `stateOpen`         | `'is-opened'`         | Class used for open state.                                                                           |
-| `stateOpening`      | `'is-opening'`        | Class used for transitioning to open state.                                                          |
-| `stateClosing`      | `'is-closing'`        | Class used for transitioning to closed state.                                                        |
-| `stateClosed`       | `'is-closed'`         | Class used for closed state.                                                                         |
-| `classModal`        | `'drawer_modal'`      | Class used for toggling the drawer modal state.                                                      |
-| `breakpoints`       | `null`                | An object with key/value pairs defining a breakpoint set.                                            |
-| `customEventPrefix` | `'drawer:'`           | Prefix to be used on custom events.                                                                  |
-| `eventListeners`    | `true`                | Whether or not to set the document event listeners on init.                                          |
-| `store`             | `true`                | Toggles the local store feature.                                                                     |
-| `storeKey`          | `'VB:DrawerState'`    | Defines the localStorage key where drawer states are saved.                                          |
-| `setTabindex`       | `true`                | Whether or not to set `tabindex="-1"` on all drawer dialog elements on init.                         |
-| `transition`        | `true`                | Toggle the transition animation of drawers.                                                          |
+  $_v: var.$prefix-variable;
 
-## Events
+  :root {
+    --#{$_v}drawer-transition-duration: #{var.$transition-duration};
+    --#{$_v}drawer-transition-timing-function: #{var.$transition-timing-function};
+  }
+  ```
+</DocBlock>
+
+<DocBlock name="SCSS Variables" type="file" src="drawer/src/scss/_variables.scss">
+
+  ```scss
+  @use "@vrembem/core";
+  @use "@vrembem/core/palette";
+  @use "@vrembem/core/theme";
+
+  $prefix-variable: core.$prefix-variable !default;
+  $prefix-block: core.$prefix-block !default;
+  $prefix-element: core.$prefix-element !default;
+  $prefix-modifier: core.$prefix-modifier !default;
+  $prefix-modifier-value: core.$prefix-modifier-value !default;
+
+  $_v: $prefix-variable;
+
+  $class-frame: "#{$prefix-block}drawer-frame" !default;
+  $class-main: "#{$prefix-block}drawer-main" !default;
+
+  $width: 18em !default;
+  $max-width: 100% !default;
+  $border: null !default;
+  $sep-border: null !default;
+  $background: theme.get("background-darker") !default;
+  $shadow: none !default;
+  $transition-duration: var(--#{$_v}transition-duration, #{core.transition-duration}) !default;
+  $transition-timing-function: var(--#{$_v}transition-timing-function, #{core.$transition-timing-function}) !default;
+
+  $frame-height: 100vh !default;
+
+  $modal-z-index: 900 !default;
+  $modal-width: $width !default;
+  $modal-max-width: 80% !default;
+  $modal-sep-border: null !default;
+  $modal-background: white !default;
+  $modal-shadow: core.$shadow-5 !default;
+  $modal-screen-background: palette.get("neutral", 10) !default;
+  $modal-screen-opacity: 0.8 !default;
+  ```
+</DocBlock>
+
+<DocBlock name="JS Config" type="file" src="drawer/src/js/defaults.js">
+
+  ```js
+  export default {
+    autoInit: false,
+
+    // Data attributes
+    dataOpen: "drawer-open",
+    dataClose: "drawer-close",
+    dataToggle: "drawer-toggle",
+    dataBreakpoint: "drawer-breakpoint",
+    dataConfig: "drawer-config",
+
+    // Selectors
+    selectorDrawer: ".drawer",
+    selectorDialog: ".drawer__dialog",
+    selectorScreen: ".drawer",
+    selectorFocus: "[data-focus]",
+    selectorInert: null,
+    selectorOverflow: "body",
+
+    // State classes
+    stateOpened: "is-opened",
+    stateOpening: "is-opening",
+    stateClosing: "is-closing",
+    stateClosed: "is-closed",
+
+    // Classes
+    classModal: "drawer_modal",
+
+    // Feature toggles
+    breakpoints: null,
+    customEventPrefix: "drawer:",
+    eventListeners: true,
+    store: true,
+    storeKey: "VB:DrawerState",
+    setTabindex: true,
+    transition: true,
+    transitionDuration: "--vb-drawer-transition-duration"
+  };
+  ```
+</DocBlock>
+
+## JavaScript usage
+
+After the drawer component has been instantiated the drawer object is returned with a robust API to help manage all the drawers on your page.
+
+<DocBlock name="drawer.collection" type="property" returns="array" src="core/src/js/Collection.js" line="3">
+  Returns an array where all drawer objects are stored when registered. Each drawer object contains the following properties:
+
+  ```scss
+  {
+    id: String, // The unique ID of the drawer.
+    state: String, // The current state of the drawer ('closing', 'closed', 'opening' or 'opened').
+    el: HTMLElement, // The drawer HTML element.
+    dialog: HTMLElement // The drawer dialog HTML element.
+    trigger: HTMLElement // The trigger element that opened the drawer.
+    settings: Object // The drawer specific settings.
+    breakpoint: String // Returns the set breakpoint of the drawer. If no breakpoint is set, returns 'null'.
+    mode: String // The current mode of the drawer. Either 'inline' or 'modal'.
+    open: Function // Method to open this drawer.
+    close: Function // Method to close this drawer.
+    toggle: Function // Method to toggle this drawer opened and closed.
+    deregister: Function // Method to deregister this drawer.
+    mountBreakpoint: Function // Method to mount the breakpoint feature.
+    unmountBreakpoint: Function // Method to unmount the breakpoint feature.
+    handleBreakpoint: Function // The function that runs whenever the breakpoint media match property is changed. Receives the event parameter.
+    getSetting: Function // Method that returns either a drawer specific setting or global drawer setting.
+  }
+  ```
+</DocBlock>
+
+<DocBlock name="drawer.activeModal" type="property" returns="Object || undefined" src="drawer/src/js/index.js" line="29">
+  Returns the currently active modal drawer. Returns `undefined` if there is no modal drawer open.
+</DocBlock>
+
+<DocBlock name="drawer.init" type="method" returns="Object" src="drawer/src/js/index.js" line="35" args={[
+  ["options", "Object (optional)", "An options object for passing custom settings."]
+]}>
+  Initializes the drawer instance. During initialization, the following processes are run:
+
+  - Register each drawer in the collection by running `registerCollection()`.
+  - Sets up global event listeners by running `initEventListeners()`.
+
+  <Fragment slot="example">
+    ```js
+    const drawer = new Drawer();
+    await drawer.init();
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="drawer.destroy" type="method" returns="Object" src="drawer/src/js/index.js" line="53">
+  Destroys and cleans up the drawer initialization. During cleanup, the following processes are run:
+
+  - Deregister the drawer collection by running `deregisterCollection()`.
+  - Removes global event listeners by running `destroyEventListeners()`.
+
+  <Fragment slot="example">
+    ```js
+    const drawer = new Drawer();
+    await drawer.init();
+    // ...
+    await drawer.destroy();
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="drawer.initEventListeners" type="method" returns="Object" src="drawer/src/js/index.js" line="65">
+  Set document event listeners.
+
+  <Fragment slot="example">
+    ```js
+    const drawer = new Drawer({ eventListeners: false });
+    await drawer.init();
+    drawer.initEventListeners();
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="drawer.destroyEventListeners" type="method" returns="Object" src="drawer/src/js/index.js" line="70">
+  Remove document event listeners.
+
+  <Fragment slot="example">
+    ```js
+    const drawer = new Drawer();
+    await drawer.init();
+    // ...
+    drawer.destroyEventListeners();
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="drawer.register" type="method" returns="Object" src="drawer/src/js/register.js" args={[
+  ["query", "String || Object", "A drawer ID or an HTML element of either the drawer or its trigger."]
+]}>
+  Registers a drawer into the collection. This also sets the initial state, mode, mounts any media match breakpoints and applies missing accessibility attributes. Returns the drawer object that got stored in the collection.
+
+  <Fragment slot="example">
+    ```js
+    const result = await drawer.register("drawer-id");
+    // => Object { id: "drawer-id", ... }
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="drawer.deregister" type="method" returns="Array" src="drawer/src/js/deregister.js" args={[
+  ["query", "String || Object", "A drawer ID or an HTML element of either the drawer or its trigger."]
+]}>
+  Deregister the drawer from the collection. This closes the drawer if it's opened, removes any active media match breakpoints and removes the entry from the collection. Returns the newly modified collection array.
+
+  <Fragment slot="example">
+    ```js
+    const result = await drawer.deregister("drawer-id");
+    // => Array [{}, {}, ...]
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="drawer.registerCollection" type="method" returns="Array" src="core/src/js/Collection.js" line="26" args={[
+  ["items", "Array", "An array of drawers or drawer IDs to register."]
+]}>
+  Registers array of drawers to the collection. All drawers in array are run through the `register()` method. Returns the collection array.
+
+  <Fragment slot="example">
+    ```js
+    const drawers = document.querySelectorAll(".drawer");
+    const result = await drawer.registerCollection(drawers);
+    // => Array [{}, {}, ...]
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="drawer.deregisterCollection" type="method" returns="Array" src="core/src/js/Collection.js" line="33">
+  Deregister all drawers in the collections array. All drawers in collection are run through the `deregister()` method. Returns the empty collection array.
+
+  <Fragment slot="example">
+    ```js
+    const result = await drawer.deregisterCollection();
+    // => Array []
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="drawer.get" type="method" returns="Object || undefined" src="core/src/js/Collection.js" line="40" args={[
+  ["value", "String || Object", "The value to search for within the collection."],
+  ["key", "String (optional)", "The property key to search the value against (defaults to 'id')."]
+]}>
+   Used to retrieve a registered drawer object from the collection. The value should match the key type to search by: e.g. to search by drawer elements, pass the drawer html node with a key of `'el'`. Defaults to `'id'`.
+
+   Returns the first element in the collection that matches the provided query and key. Otherwise, undefined is returned.
+
+  <Fragment slot="example">
+    ```js
+    const entry = drawer.get("drawer-id");
+    // => Object { id: "drawer-id", ... }
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="drawer.open" type="method" returns="Object" src="drawer/src/js/open.js" args={[
+  ["id", "String", "The ID of the drawer to open."],
+  ["transition", "Boolean (optional)", "Whether or not to animate the transition."],
+  ["focus", "Boolean (optional)", "Whether or not to handle focus management."]
+]}>
+   Opens a drawer using the provided ID. Returns the drawer object that was opened.
+
+  <Fragment slot="example">
+    ```js
+    const entry = await drawer.open("drawer-key");
+    // => Object { id: "drawer-id", ... }
+    ```
+  </Fragment>
+</DocBlock>
+
+
+<DocBlock name="drawer.close" type="method" returns="Object" src="drawer/src/js/close.js" args={[
+  ["id", "String", "The ID of the drawer to close."],
+  ["transition", "Boolean (optional)", "Whether or not to animate the transition."],
+  ["focus", "Boolean (optional)", "Whether or not to handle focus management."]
+]}>
+   Closes a drawer using the provided ID. Returns the drawer object that was closed.
+
+  <Fragment slot="example">
+    ```js
+    const entry = await drawer.close();
+    // => Object { id: "drawer-id", ... }
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="drawer.toggle" type="method" returns="Object" src="drawer/src/js/toggle.js" args={[
+  ["id", "String", "The ID of the drawer to toggle."],
+  ["transition", "Boolean (optional)", "Whether or not to animate the transition."],
+  ["focus", "Boolean (optional)", "Whether or not to handle focus management."]
+]}>
+  Toggles a drawer opened or closed using the provided ID. Returns the drawer object that was toggled.
+
+  <Fragment slot="example">
+    ```js
+    const entry = await drawer.toggle();
+    // => Object { id: "drawer-id", ... }
+    ```
+  </Fragment>
+</DocBlock>
+
+### Custom Events
+
+The drawer component also exposes some custom events for hooking into the drawer lifecycle. All drawer events are fired on the root drawer element (i.e. at the `<aside id="drawer-id" class="drawer">`).
 
 - `drawer:opened` Emits when a drawer has opened.
 - `drawer:closed` Emits when a drawer has closed.
 - `drawer:switchMode` Emits when a drawer's mode changes.
-
-## API
-
-### `drawer.collection`
-
-Returns an array where all drawer objects are stored when registered. Each drawer object contains the following properties:
-
-```js
-{
-  id: String, // The unique ID of the drawer.
-  state: String, // The current state of the drawer ('closing', 'closed', 'opening' or 'opened').
-  el: HTMLElement, // The drawer HTML element.
-  dialog: HTMLElement // The drawer dialog HTML element.
-  trigger: HTMLElement // The trigger element that opened the drawer.
-  settings: Object // The drawer specific settings.
-  breakpoint: String // Returns the set breakpoint of the drawer. If no breakpoint is set, returns 'null'.
-  mode: String // The current mode of the drawer. Either 'inline' or 'modal'.
-  open: Function // Method to open this drawer.
-  close: Function // Method to close this drawer.
-  toggle: Function // Method to toggle this drawer opened and closed.
-  deregister: Function // Method to deregister this drawer.
-  mountBreakpoint: Function // Method to mount the breakpoint feature.
-  unmountBreakpoint: Function // Method to unmount the breakpoint feature.
-  handleBreakpoint: Function // The function that runs whenever the breakpoint media match property is changed. Receives the event parameter.
-  getSetting: Function // Method that returns either a drawer specific setting or global drawer setting.
-}
-```
-
-**Returns**
-
-- `Array` An array of collection entries.
-
-### `drawer.activeModal`
-
-Returns the currently active modal drawer. Returns `undefined` if there is no modal drawer open.
-
-**Returns**
-
-- `Object || undefined` Collection entry.
-
-### `drawer.init(options)`
-
-Initializes the drawer instance. During initialization, the following processes are run:
-
-- Register each drawer in the collection by running `registerCollection()`.
-- Sets up global event listeners by running `initEventListeners()`.
-
-**Parameters**
-
-- `options [Object] (optional)` An options object for passing custom settings.
-
-```js
-const drawer = new Drawer();
-await drawer.init();
-```
-
-### `drawer.destroy()`
-
-Destroys and cleans up the drawer initialization. During cleanup, the following processes are run:
-
-- Deregister the drawer collection by running `deregisterCollection()`.
-- Removes global event listeners by running `destroyEventListeners()`.
-
-```js
-const drawer = new Drawer();
-await drawer.init();
-// ...
-await drawer.destroy();
-```
-
-### `drawer.initEventListeners()`
-
-Set document event listeners.
-
-```js
-const drawer = new Drawer({ eventListeners: false });
-await drawer.init();
-drawer.initEventListeners();
-```
-
-### `drawer.destroyEventListeners()`
-
-Remove document event listeners.
-
-```js
-const drawer = new Drawer();
-await drawer.init();
-// ...
-drawer.destroyEventListeners();
-```
-
-### `drawer.register(query)`
-
-Registers a drawer into the collection. This also sets the initial state, mode, mounts any media match breakpoints and applies missing accessibility attributes.
-
-**Parameters**
-
-- `query [String || Object]` A drawer ID or an HTML element of either the drawer or its trigger.
-
-**Returns**
-
-- `Object` The drawer object that got stored in the collection.
-
-```js
-const result = await drawer.register('drawer-id');
-// => Object { id: 'drawer-id', ... }
-```
-
-### `drawer.deregister(query)`
-
-Deregister the drawer from the collection. This closes the drawer if it's opened, removes any active media match breakpoints and removes the entry from the collection.
-
-**Parameters**
-
-- `query [String || Object]` A drawer ID or an HTML element of either the drawer or its trigger.
-
-**Returns**
-
-- `Array` Returns the newly modified collection array.
-
-```js
-const result = await drawer.deregister('drawer-id');
-// => Array [{}, {}, ...]
-```
-
-### `drawer.registerCollection(items)`
-
-Registers array of drawers to the collection. All drawers in array are run through the `register()` method.
-
-**Parameters**
-
-- `items [Array]` An array of drawers or drawer IDs to register.
-
-**Returns**
-
-- `Array` Returns the collection array.
-
-```js
-const drawers = document.querySelectorAll('.drawer');
-const result = await drawer.registerCollection(drawers);
-// => Array [{}, {}, ...]
-```
-
-### `drawer.deregisterCollection()`
-
-Deregister all drawers in the collections array. All drawers in collection are run through the `deregister()` method.
-
-**Returns**
-
-- `Array` Returns the empty collection array.
-
-```js
-const result = await drawer.registerCollection();
-// => Array []
-```
-
-### `drawer.get(value, key)`
-
-Used to retrieve a registered drawer object from the collection. The value should match the key type to search by: e.g. to search by drawer elements, pass the drawer html node with a key of `'el'`. Defaults to `'id'`.
-
-**Parameters**
-
-- `value [String || Object]` The value to search for within the collection.
-- `key [String] (optional) (default 'id')` The property key to search the value against.
-
-**Returns**
-
-- `Object || undefined` The first element in the collection that matches the provided query and key. Otherwise, undefined is returned.
-
-```js
-const entry = drawer.get('drawer-id');
-// => Object { id: 'drawer-id', ... }
-```
-
-### `drawer.open(id, transition, focus)`
-
-Opens a drawer using the provided ID.
-
-**Parameters**
-
-- `id [String]` The ID of the drawer to open.
-- `transition [Boolean] (optional)` Whether or not to animate the transition.
-- `focus [Boolean] (optional)` Whether or not to handle focus management.
-
-**Returns**
-
-- `Object` The drawer object that was opened.
-
-```js
-const entry = await drawer.open('drawer-key');
-// => Object { id: 'drawer-id', ... }
-```
-
-### `drawer.close(id, transition, focus)`
-
-Closes a drawer using the provided ID.
-
-**Parameters**
-
-- `id [String] (optional)` The ID of the drawer to close.
-- `transition [Boolean] (optional)` Whether or not to animate the transition.
-- `focus [Boolean] (optional)` Whether or not to handle focus management.
-
-**Returns**
-
-- `Object` The drawer object that was closed.
-
-```js
-const entry = await drawer.close();
-// => Object { id: 'drawer-id', ... }
-```
-
-### `drawer.toggle(id, transition, focus)`
-
-Toggles a drawer opened or closed using the provided ID.
-
-**Parameters**
-
-- `id [String] (optional)` The ID of the drawer to toggle.
-- `transition [Boolean] (optional)` Whether or not to animate the transition.
-- `focus [Boolean] (optional)` Whether or not to handle focus management.
-
-**Returns**
-
-- `Object` The drawer object that was closed.
-
-```js
-const entry = await drawer.toggle();
-// => Object { id: 'drawer-id', ... }
-```

--- a/docs/src/content/packages/modal.mdx
+++ b/docs/src/content/packages/modal.mdx
@@ -6,6 +6,8 @@ state: "circle"
 ---
 
 import CodeExample from "../../components/CodeExample.astro";
+import DocBlock from "../../components/DocBlock.astro";
+import Icon from "../../components/Icon.astro";
 
 # Modal
 
@@ -30,87 +32,169 @@ npm install @vrembem/modal
 
 ## Basic usage
 
-Modals are composed using classes and data attributes for their triggers. The basic structure of a modal is an element with an `id` and the `modal` class containing a child element with the `modal__dialog` class. There are three types of modal triggers, each defined by a data attribute:
+Modals are composed using classes and data attributes for their triggers. The basic structure of a modal is an element with a unique `id` and the `modal` class containing a child element with the `modal__dialog` class. There are three types of modal triggers, each defined by a data attribute:
 
 - `data-modal-open`: Opens a modal. Should take the id of the modal it's meant to open. Will stack modals if triggered from inside an already opened modal.
 - `data-modal-close`: Closes a modal. Will close the last opened modal if left value-less. Can also take a modal id to close a specific modal, or `"*"` to close all open modals.
 - `data-modal-replace`: Replaces currently opened modal(s) with the modal of the id provided.
 
-```html
-<button data-modal-open="modal-id">...</button>
-
-<div id="modal-id" class="modal">
-  <div class="modal__dialog" role="dialog" aria-modal="true">
-    <button data-modal-close>...</button>
-    ...
-  </div>
-</div>
-```
-
-The dialog element of a modal is defined using the `modal__dialog` class. Modal dialogs should also be given the `role` attribute with a value of either [`dialog`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) or [`alertdialog`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role) and the `aria-modal` attribute with a value of `true`. Authors should provide modal dialogs with [`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) and [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) attributes if applicable to further improve accessibility.
-
-```html
-<div id="modal-id" class="modal">
-  <div class="modal__dialog dialog" role="dialog" aria-modal="true" aria-labelledby="dialog-title" aria-describedby="dialog-description">
-    <div class="dialog__header">
-      <h2 id="dialog-title">...</h2>
+<CodeExample lang="html">
+  <Fragment slot="output">
+    <button class="link" data-modal-open="modal-1">Open</button>
+    <div id="modal-1" class="modal">
+      <div class="modal__dialog background radius padding" role="dialog">
+        <div class="level flex-justify-between">
+          <span>Modal example</span>
+          <button class="link" data-modal-close>Close</button>
+        </div>
+      </div>
     </div>
-    <div class="dialog__body">
-      <p id="dialog-description">...</p>
-    </div>
-    <div class="dialog__footer">
+  </Fragment>
+  ```html
+  <button data-modal-open="[unique-id]">...</button>
+
+  <div id="[unique-id]" class="modal">
+    <div class="modal__dialog" role="dialog" aria-modal="true">
+      <button data-modal-close>...</button>
       ...
     </div>
   </div>
-</div>
 ```
+</CodeExample>
 
-> The [dialog component](https://github.com/sebnitu/vrembem/tree/main/packages/dialog) is a great fit for composing a modal’s dialog.
+The dialog element of a modal is defined using the `modal__dialog` class. Modal dialogs should also be given the `role` attribute with a value of either [`dialog`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) or [`alertdialog`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role) and the `aria-modal` attribute with a value of `true`. Authors should provide modal dialogs with [`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) and [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) attributes if applicable to further improve accessibility.
 
-#### Focus Management
+<CodeExample lang="html">
+  <Fragment slot="output">
+    <button class="link" data-modal-open="modal-2">Open</button>
+    <div id="modal-2" class="modal">
+      <div class="modal__dialog dialog" role="dialog" aria-modal="true" aria-labelledby="modal-2-title" aria-describedby="modal-2-description">
+        <div class="dialog__header">
+          <h2 class="dialog__title" id="modal-2-title">Modal dialog</h2>
+          <button class="link" data-modal-close>Close</button>
+        </div>
+        <div class="dialog__body">
+          <p id="modal-2-description">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean porta diam eget lectus interdum, eu aliquet augue rutrum. Morbi faucibus mauris lectus, in imperdiet augue cursus vel.</p>
+        </div>
+        <div class="dialog__footer">
+          <button class="button button_color_primary" data-modal-close>Confirm</button>
+          <button class="button" data-modal-close>Cancel</button>
+        </div>
+      </div>
+    </div>
+  </Fragment>
+  ```html
+  <div id="[unique-id]" class="modal">
+    <div class="modal__dialog dialog" role="dialog" aria-modal="true" aria-labelledby="dialog-title" aria-describedby="dialog-description">
+      <div class="dialog__header">
+        <h2 class="dialog__title" id="dialog-title">...</h2>
+        <button class="link" data-modal-close>Close</button>
+      </div>
+      <div class="dialog__body">
+        <p id="dialog-description">...</p>
+      </div>
+      <div class="dialog__footer">
+        ...
+      </div>
+    </div>
+  </div>
+  ```
+</CodeExample>
+
+> The [dialog component](/packages/dialog) is a great fit for composing a modal’s dialog.
+
+### Focus management
 
 Modal dialogs are given focus when opened as long as the `setTabindex` option is set to `true` or if the modal dialog has `tabindex="-1"` set manually. If focus on a specific element inside a modal is preferred, give that element the `data-focus` attribute. Focus is returned to the element that initially triggered the modal once closed.
 
-```html
-<!-- Focus is returned to the trigger when a modal is closed -->
-<button data-modal-open="modal-id">...</button>
+<CodeExample lang="html">
+  <Fragment slot="output">
+    <ul class="list">
+      <li>
+        <button class="link" data-modal-open="modal-3">Open</button> - Sets focus to the modal dialog when opened.
+      </li>
+      <li>
+        <button class="link" data-modal-open="modal-4">Open</button> - Sets focus to the `data-focus` element when opened.
+      </li>
+    </ul>
+    <div id="modal-3" class="modal">
+      <div class="modal__dialog dialog" role="dialog" aria-modal="true" tabindex="-1">
+        <div class="dialog__body flex flex-justify-between">
+          <span>Focus modal dialog when opened</span>
+          <button class="link" data-modal-close>Close</button>
+        </div>
+      </div>
+    </div>
+    <div id="modal-4" class="modal">
+      <div class="modal__dialog dialog" role="dialog" aria-modal="true">
+        <div class="dialog__body">
+          <div class="flex flex-justify-between margin-bottom">
+            <span>Focus input element when opened</span>
+            <button class="link" data-modal-close>Close</button>
+          </div>
+          <input class="input" data-focus type="text" />
+        </div>
+      </div>
+    </div>
+  </Fragment>
+  ```html
+  <!-- Focus is returned to the trigger when a modal is closed -->
+  <button data-modal-open="[unique-id]">...</button>
 
-<!-- Sets focus to modal dialog when opened -->
-<div id="modal-id" class="modal">
-  <div class="modal__dialog" role="dialog" aria-modal="true" tabindex="-1">
-    ...
+  <!-- Sets focus to modal dialog when opened -->
+  <div id="[unique-id]" class="modal">
+    <div class="modal__dialog" role="dialog" aria-modal="true" tabindex="-1">
+      ...
+    </div>
   </div>
-</div>
 
-<!-- Sets focus to data-focus element when opened -->
-<div id="modal-id" class="modal">
-  <div class="modal__dialog" role="dialog" aria-modal="true">
-    <input data-focus type="text">
-    ...
+  <!-- Sets focus to data-focus element when opened -->
+  <div id="[unique-id]" class="modal">
+    <div class="modal__dialog" role="dialog" aria-modal="true">
+      <input data-focus type="text" />
+      ...
+    </div>
   </div>
-</div>
-```
+  ```
+</CodeExample>
 
 While a modal is active, the contents obscured by the modal are made inaccessible to all users via a focus trap. This means that the `TAB` key, and a screen reader’s virtual cursor (arrow keys) should not be allowed to leave the modal dialog and traverse the content outside of the dialog.
 
 > To change the selector used in finding the preferred focus element, pass your own selector via the `selectorFocus` option (defaults to `'[data-focus]'`).
 
-#### Required Modals
+### Required modals
 
 Required modals are modals that need an explicit action to be closed. That means clicking on the background or pressing the escape key to close a required modal is disabled. Required modals are set by giving a dialog the attribute `role` with a value of `alertdialog`.
 
-```html
-<div id="modal-id" class="modal">
-  <div class="modal__dialog" role="alertdialog" aria-modal="true">
-    ...
-    <button data-modal-close>Agree</button>
+<CodeExample lang="html">
+  <Fragment slot="output">
+    <button class="link" data-modal-open="modal-5">Open</button>
+    <div id="modal-5" class="modal">
+      <div class="modal__dialog dialog" role="alertdialog" aria-modal="true" aria-labelledby="modal-5-title" aria-describedby="modal-5-description">
+        <div class="dialog__body gap-y">
+          <h2 class="dialog__title" id="modal-5-title">Required modal</h2>
+          <p id="modal-5-description">Required modals can not be closed without an explicit action. That means clicking on the background or pressing the escape key to close is disabled.</p>
+          <div class="flex flex-gap-x flex-justify-end margin-top-lg">
+            <button class="button button_color_primary" data-modal-close>I understand</button>
+            <button class="button" data-modal-close>Cancel</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Fragment>
+  ```html
+  <div id="[unique-id]" class="modal">
+    <div class="modal__dialog" role="alertdialog" aria-modal="true">
+      ...
+      <button data-modal-close>Agree</button>
+    </div>
   </div>
-</div>
-```
+  ```
+</CodeExample>
 
 > To change the selector used in creating required modals, pass your own selector via the `selectorRequired` option (defaults to `'[role="alertdialog"]'`).
 
-## Behavior and Accessibility
+### Behavior and accessibility
 
 Modals on the web have an expected set of patterns that this component follows. Here's what to expect:
 
@@ -121,68 +205,288 @@ Modals on the web have an expected set of patterns that this component follows. 
 
 To take full advantage of modal's accessibility features, it's recommended to set the `selectorInert` option to all elements that are outside the modal. If you have modal markup throughout your document, use the `teleport` option to consolidate all modals in the DOM to a single location. All elements that match the `selectorInert` selector will be given the `inert` attribute as well as `aria-hidden="true"` when a modal is opened.
 
-> Inert is not currently widely supported by all browsers. Consider using a polyfill such as [wicg-inert](https://github.com/WICG/inert) or Google's [inert-polyfill](https://github.com/GoogleChrome/inert-polyfill).
-
-### Example
+**Example**
 
 Here's an example where we want the `<main>` content area to be inaccessible while modals are open. We also want all modals to be moved outside the main content element using the `after` method.
 
-```js
-const modal = new Modal({
-  selectorInert: 'main',
-  teleport: 'main',
-  teleportMethod: 'after'
-});
+<CodeExample lang="js">
 
-await modal.init();
-```
+  ```js
+  const modal = new Modal({
+    selectorInert: "main",
+    teleport: "main",
+    teleportMethod: "after"
+  });
+
+  await modal.init();
+  ```
+</CodeExample>
 
 To return a modal to its original location, use the collection API method `teleportReturn()`:
 
-```js
-// Get an entry from the modal collection.
-const entry = modal.get('modal-id');
+<CodeExample lang="js">
 
-// Returns the modal to its previously teleported location.
-entry.teleportReturn();
-```
+  ```js
+  // Get an entry from the modal collection.
+  const entry = modal.get("modal-id");
 
-## Modifiers
+  // Returns the modal to its previously teleported location.
+  entry.teleportReturn();
+  ```
+</CodeExample>
 
-### `modal_full`
+## modal_full
 
 Adds styles to a modal that make it fill the entire viewport when opened.
 
-```html
-<div id="modal-id" class="modal modal_full">...</div>
-```
+<CodeExample lang="html">
+  <Fragment slot="output">
+    <button class="link" data-modal-open="modal-6">Open</button>
+    <div id="modal-6" class="modal modal_full">
+      <div class="modal__dialog dialog" role="dialog" aria-modal="true" aria-labelledby="modal-6-title">
+        <div class="dialog__header">
+          <h2 class="dialog__title" id="modal-6-title">Full modal</h2>
+          <button class="link" data-modal-close>Close</button>
+        </div>
+        <div class="dialog__body">
+          <p>This modal should fill the entire viewport when opened.</p>
+        </div>
+        <div class="dialog__footer">
+          <button class="button button_color_primary" data-modal-close>Accept</button>
+          <button class="button" data-modal-close>Cancel</button>
+        </div>
+      </div>
+    </div>
+  </Fragment>
+  ```html
+  <div id="[unique-id]" class="modal modal_full">...</div>
+  ```
+</CodeExample>
 
-### `modal_pos_[value]`
+## modal_pos_[value]
 
 The default position of modals is in the center of the viewport. The position modifier allows positioning a modal to the top, bottom, left and right side of the document viewport.
 
-```html
-<div id="..." class="modal modal_pos_top">...</div>
-<div id="..." class="modal modal_pos_bottom">...</div>
-<div id="..." class="modal modal_pos_left">...</div>
-<div id="..." class="modal modal_pos_right">...</div>
-```
+<CodeExample lang="html">
+  <div slot="output" class="level">
+    <button class="button" data-modal-open="modal-pos-top">
+      <span>Top</span>
+      <span class="arrow-up"></span>
+    </button>
+    <button class="button" data-modal-open="modal-pos-left">
+      <span>Left</span>
+      <span class="arrow-left"></span>
+    </button>
+    <button class="button" data-modal-open="modal-pos-right">
+      <span>Right</span>
+      <span class="arrow-right"></span>
+    </button>
+    <button class="button" data-modal-open="modal-pos-bottom">
+      <span>Bottom</span>
+      <span class="arrow-down"></span>
+    </button>
+    <div id="modal-pos-top" class="modal modal_pos_top">
+      <div class="modal__dialog dialog" role="dialog" aria-modal="true">
+        <div class="dialog__body">
+          <div class="flex flex-justify-between">
+             <p>Top position modal</p>
+             <button class="link" data-modal-close>Close</button>
+           </div>
+        </div>
+        <div class="dialog__footer flex-justify-between">
+          <button class="link" data-modal-open="modal-pos-left">
+            Left modal
+          </button>
+          <button class="link" data-modal-open="modal-pos-bottom">
+            Bottom modal
+          </button>
+          <button class="link" data-modal-open="modal-pos-right">
+            Right modal
+          </button>
+        </div>
+      </div>
+    </div>
+    <div id="modal-pos-left" class="modal modal_pos_left">
+      <div class="modal__dialog dialog" role="dialog" aria-modal="true">
+        <div class="dialog__body">
+          <div class="flex flex-justify-between">
+             <p>Left position modal</p>
+             <button class="link" data-modal-close>Close</button>
+           </div>
+        </div>
+        <div class="dialog__footer">
+          <button class="link" data-modal-open="modal-pos-top">
+            Top modal
+          </button>
+        </div>
+        <div class="dialog__footer">
+          <button class="link" data-modal-open="modal-pos-right">
+            Right modal
+          </button>
+        </div>
+        <div class="dialog__footer">
+          <button class="link" data-modal-open="modal-pos-bottom">
+            Bottom modal
+          </button>
+        </div>
+      </div>
+    </div>
+    <div id="modal-pos-right" class="modal modal_pos_right">
+      <div class="modal__dialog dialog" role="dialog" aria-modal="true">
+        <div class="dialog__body">
+          <div class="flex flex-justify-between">
+             <p>Right position modal</p>
+             <button class="link" data-modal-close>Close</button>
+           </div>
+        </div>
+        <div class="dialog__footer">
+          <button class="link" data-modal-open="modal-pos-top">
+            Top modal
+          </button>
+        </div>
+        <div class="dialog__footer">
+          <button class="link" data-modal-open="modal-pos-left">
+            Left modal
+          </button>
+        </div>
+        <div class="dialog__footer">
+          <button class="link" data-modal-open="modal-pos-bottom">
+            Bottom modal
+          </button>
+        </div>
+      </div>
+    </div>
+    <div id="modal-pos-bottom" class="modal modal_pos_bottom">
+      <div class="modal__dialog dialog" role="dialog" aria-modal="true">
+        <div class="dialog__body">
+          <div class="flex flex-justify-between">
+             <p>Bottom position modal</p>
+             <button class="link" data-modal-close>Close</button>
+           </div>
+        </div>
+        <div class="dialog__footer flex-justify-between">
+          <button class="link" data-modal-open="modal-pos-left">
+            Left modal
+          </button>
+          <button class="link" data-modal-open="modal-pos-top">
+            Top modal
+          </button>
+          <button class="link" data-modal-open="modal-pos-right">
+            Right modal
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+   ```html
+   <div id="[unique-id]" class="modal modal_pos_top">...</div>
+   <div id="[unique-id]" class="modal modal_pos_left">...</div>
+   <div id="[unique-id]" class="modal modal_pos_right">...</div>
+   <div id="[unique-id]" class="modal modal_pos_bottom">...</div>
+   ```
+</CodeExample>
 
-#### Available Variations
+**Available Variants**
+
 - `modal_pos_top`
 - `modal_pos_left`
 - `modal_pos_right`
 - `modal_pos_bottom`
 
-### `modal_size_[value]`
+## modal_size_[value]
 
-Adjusts the size of modals. This modifier provides five options that get built using the [`$size-scale`](#size-scale) variable map.
+Adjusts the size of modals. This modifier provides five options that are output using the [`$size-scale`](#scss-variables-file) variable map.
 
-```html
-<div id="modal-id" class="modal modal_size_sm">...</div>
-```
+<CodeExample lang="html">
+  <Fragment slot="output">
+    <ul class="list">
+      <li>
+        <button class="link" data-modal-open="modal-size-xs">
+          Open modal_size_xs
+        </button>
+      </li>
+      <li>
+        <button class="link" data-modal-open="modal-size-sm">
+          Open modal_size_sm
+        </button>
+      </li>
+      <li>
+        <button class="link" data-modal-open="modal-size-md">
+          Open modal_size_md
+        </button>
+      </li>
+      <li>
+        <button class="link" data-modal-open="modal-size-lg">
+          Open modal_size_lg
+        </button>
+      </li>
+      <li>
+        <button class="link" data-modal-open="modal-size-xl">
+          Open modal_size_xl
+        </button>
+      </li>
+    </ul>
+    <div id="modal-size-xs" class="modal modal_size_xs">
+      <div class="modal__dialog dialog" role="dialog" aria-modal="true">
+        <div class="dialog__body">
+          <div class="flex flex-justify-between">
+            <p>modal_size_xs</p>
+            <button class="link" data-modal-close>Close</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div id="modal-size-sm" class="modal modal_size_sm">
+      <div class="modal__dialog dialog" role="dialog" aria-modal="true">
+        <div class="dialog__body">
+          <div class="flex flex-justify-between">
+            <p>modal_size_sm</p>
+            <button class="link" data-modal-close>Close</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div id="modal-size-md" class="modal modal_size_md">
+      <div class="modal__dialog dialog" role="dialog" aria-modal="true">
+        <div class="dialog__body">
+          <div class="flex flex-justify-between">
+            <p>modal_size_md</p>
+            <button class="link" data-modal-close>Close</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div id="modal-size-lg" class="modal modal_size_lg">
+      <div class="modal__dialog dialog" role="dialog" aria-modal="true">
+        <div class="dialog__body">
+          <div class="flex flex-justify-between">
+            <p>modal_size_lg</p>
+            <button class="link" data-modal-close>Close</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div id="modal-size-xl" class="modal modal_size_xl">
+      <div class="modal__dialog dialog" role="dialog" aria-modal="true">
+        <div class="dialog__body">
+          <div class="flex flex-justify-between">
+            <p>modal_size_xl</p>
+            <button class="link" data-modal-close>Close</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Fragment>
+  ```html
+  <div id="[unique-id]" class="modal modal_size_xs">...</div>
+  <div id="[unique-id]" class="modal modal_size_sm">...</div>
+  <div id="[unique-id]" class="modal modal_size_md">...</div>
+  <div id="[unique-id]" class="modal modal_size_lg">...</div>
+  <div id="[unique-id]" class="modal modal_size_xl">...</div>
+  ```
+</CodeExample>
 
-#### Available Variations
+**Available Variants**
 
 - `modal_size_xs`
 - `modal_size_sm`
@@ -192,324 +496,325 @@ Adjusts the size of modals. This modifier provides five options that get built u
 
 ## Customization
 
-### Sass Variables
+Modals are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable via the `core` module.
 
-| Variable                      | Default                            | Description                                                                         |
-| ----------------------------- | ---------------------------------- | ----------------------------------------------------------------------------------- |
-| `$prefix-block`               | `null`                             | String to prefix blocks with.                                                       |
-| `$prefix-element`             | `"__"`                             | String to prefix elements with.                                                     |
-| `$prefix-modifier`            | `"_"`                              | String to prefix modifiers with.                                                    |
-| `$prefix-modifier-value`      | `"_"`                              | String to prefix modifier values with.                                              |
-| `$z-index`                    | `1000`                             | Base z-index of modals. Stacked modals are incremented by 1.                        |
-| `$width`                      | `36em`                             | The default max width of modals.                                                    |
-| `$travel`                     | `5em`                              | Distance that modal travel during their transition.                                 |
-| `$transition-duration`        | `core.$transition-duration`        | Duration of modal transition.                                                       |
-| `$transition-timing-function` | `core.$transition-timing-function` | Timing function used for modal transitions.                                         |
-| `$background`                 | `core.$night`                      | Background color of modal screen.                                                   |
-| `$background-alpha`           | `0.8`                              | The alpha channel for the modal screen.                                             |
-| `$box-shadow`                 | `core.$box-shadow-5`               | Box shadow applied to modal dialog elements.                                        |
-| `$outline`                    | `0 solid rgba(--vb-primary, 0)`    | Outline applied to modal dialog elements.                                           |
-| `$outline-focus`              | `4px solid rgba(--vb-primary, 1)`  | Outline applied to modal dialog elements in their focus state.                      |
-| `$outline-focus-alert`        | `4px solid rgba(core.$danger, 1)`  | Outline applied to required modal dialog elements in their focus state.             |
-| `$aside-width`                | `16em`                             | Width applied to modals using `modal_pos_left` and `modal_pos_right` modifiers.     |
-| `$aside-max-width`            | `90%`                              | Max width applied to modals using `modal_pos_left` and `modal_pos_right` modifiers. |
-| `$size-scale`                 | [Map Ref &darr;](#size-scale)      | The size scale map the `modal_size_[key]` modifier uses to build its styles.        |
+<DocBlock name="CSS Variables" type="file" src="modal/src/scss/_root.scss">
 
-#### $size-scale
+  ```scss
+  @use "./variables" as var;
 
-The size scale map the `modal_size_[key]` modifier uses to build its styles.
+  $_v: var.$prefix-variable;
 
-```scss
-$size-scale: (
-  'xs': 20em, // 288px
-  'sm': 24em, // 384px
-  'md': 36em, // 576px
-  'lg': 48em, // 768px
-  'xl': 60em  // 960px
-) !default;
-```
+  :root {
+    --#{$_v}modal-transition-duration: #{var.$transition-duration};
+    --#{$_v}modal-transition-timing-function: #{var.$transition-timing-function};
+  }
+  ```
+</DocBlock>
 
-### JavaScript Options
+<DocBlock name="SCSS Variables" type="file" src="modal/src/scss/_variables.scss">
 
-| Key                 | Default                  | Description                                                                                                   |
-| ------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------- |
-| `autoInit`          | `false`                  | Automatically initializes the instance.                                                                       |
-| `dataOpen`          | `'modal-open'`           | Data attribute for a modal open trigger.                                                                      |
-| `dataClose`         | `'modal-close'`          | Data attribute for a modal close trigger.                                                                     |
-| `dataReplace`       | `'modal-replace'`        | Data attribute for a modal replace trigger.                                                                   |
-| `dataConfig`        | `'modal-config'`         | Data attribute to find modal specific configuration settings. Value should be a JSON object.                  |
-| `selectorModal`     | `'.modal'`               | Selector for modal element.                                                                                   |
-| `selectorDialog`    | `'.modal__dialog'`       | Selector for modal dialog element.                                                                            |
-| `selectorRequired`  | `'[role="alertdialog"]'` | Selector used to apply required modal state.                                                                  |
-| `selectorFocus`     | `'[data-focus]'`         | Focus preference selector for when modals are initially opened.                                               |
-| `selectorInert`     | `null`                   | Applies `inert` and `aria-hidden` attributes to all matching elements when a modal is opened.                 |
-| `selectorOverflow`  | `'body'`                 | Applies `overflow:hidden` styles on all matching elements when a modal is opened.                             |
-| `stateOpened`       | `'is-opened'`            | Class used for open state.                                                                                    |
-| `stateOpening`      | `'is-opening'`           | Class used for transitioning to open state.                                                                   |
-| `stateClosing`      | `'is-closing'`           | Class used for transitioning to closed state.                                                                 |
-| `stateClosed`       | `'is-closed'`            | Class used for closed state.                                                                                  |
-| `customEventPrefix` | `'modal:'`               | Prefix to be used on custom events.                                                                           |
-| `eventListeners`    | `true`                   | Whether or not to set the document event listeners on init.                                                   |
-| `teleport`          | `null`                   | Teleport selector where modals get moved to. Leave as `null` to disable teleport.                             |
-| `teleportMethod`    | `'append'`               | Teleport method options include `after`, `before`, `append` and `prepend` relative to the teleport reference. |
-| `setTabindex`       | `true`                   | Whether or not to set `tabindex="-1"` on all modal dialog elements on init.                                   |
-| `transition`        | `true`                   | Toggle the transition animation of modals.                                                                    |
+  ```scss
+  @use "@vrembem/core";
+  @use "@vrembem/core/palette";
 
-## Events
+  $prefix-variable: core.$prefix-variable !default;
+  $prefix-block: core.$prefix-block !default;
+  $prefix-element: core.$prefix-element !default;
+  $prefix-modifier: core.$prefix-modifier !default;
+  $prefix-modifier-value: core.$prefix-modifier-value !default;
+
+  $_v: $prefix-variable;
+
+  $z-index: 1000 !default;
+  $width: 36em !default;
+  $travel: 5em !default;
+  $transition-duration: var(--#{$_v}transition-duration, #{core.$transition-duration}) !default;
+  $transition-timing-function: var(--#{$_v}transition-timing-function, #{core.$transition-timing-function}) !default;
+  $shadow: core.$shadow-5 !default;
+
+  $screen-background: palette.get("neutral", 10) !default;
+  $screen-opacity: 0.8 !default;
+
+  $outline: 0 solid transparent !default;
+  $outline-focus: 4px solid palette.get("primary") !default;
+  $outline-focus-alert: 4px solid palette.get("important") !default;
+
+  // modal_pos_[value]
+  $aside-width: 16em !default;
+  $aside-max-width: 90% !default;
+
+  // modal_size_[key]
+  $size-scale: (
+    "xs": 20em, // 288px
+    "sm": 24em, // 384px
+    "md": 36em, // 576px
+    "lg": 48em, // 768px
+    "xl": 60em  // 960px
+  ) !default;
+  ```
+</DocBlock>
+
+<DocBlock name="JS Config" type="file" src="modal/src/js/defaults.js">
+
+  ```js
+  export default {
+    autoInit: false,
+
+    // Data attributes
+    dataOpen: "modal-open",
+    dataClose: "modal-close",
+    dataReplace: "modal-replace",
+    dataConfig: "modal-config",
+
+    // Selectors
+    selectorModal: ".modal",
+    selectorDialog: ".modal__dialog",
+    selectorScreen: ".modal",
+    selectorRequired: "[role=\"alertdialog\"]",
+    selectorFocus: "[data-focus]",
+    selectorInert: null,
+    selectorOverflow: "body",
+
+    // State classes
+    stateOpened: "is-opened",
+    stateOpening: "is-opening",
+    stateClosing: "is-closing",
+    stateClosed: "is-closed",
+
+    // Feature settings
+    customEventPrefix: "modal:",
+    eventListeners: true,
+    teleport: null,
+    teleportMethod: "append",
+    setTabindex: true,
+    transition: true,
+    transitionDuration: "--vb-modal-transition-duration"
+  };
+  ```
+</DocBlock>
+
+## JavaScript usage
+
+After the modal component has been instantiated the modal object is returned with a robust API to help manage all modal components on your page.
+
+<DocBlock name="modal.collection" type="property" returns="array" src="core/src/js/Collection.js" line="3">
+  Returns an array where all modal objects are stored when registered. Each modal object contains the following properties:
+
+  ```scss
+  {
+    id: String, // The unique ID of the modal.
+    state: String, // The current state of the modal ('closing', 'closed', 'opening' or 'opened').
+    el: HTMLElement, // The modal HTML element.
+    dialog: HTMLElement // The modal dialog HTML element.
+    returnRef: HTMLComment // The return reference left when a modal is teleported.
+    settings: Object // The modal specific settings.
+    open: Function // Method to open this modal.
+    close: Function // Method to close this modal.
+    replace: Function // Method to replace open modal(s) with this modal.
+    deregister: Function // Method to deregister this modal.
+    teleport: Function // Method to teleport this modal.
+    teleportReturn: Function // Method to return this modal to its previous location.
+    getSetting: Function // Method that returns either a modal specific setting or global modal setting.
+  }
+  ```
+</DocBlock>
+
+<DocBlock name="modal.stack" type="property" returns="Array" src="modal/src/js/stack.js">
+  Returns an array of all currently opened modals. These are sorted in the order they're added to the array (first item was opened first, last item was opened last).
+</DocBlock>
+
+<DocBlock name="modal.active" type="property" returns="Object || undefined" src="modal/src/js/index.js" line="33">
+  Returns the currently active modal or the modal at the top of the stack if multiple modals are open. Will return `undefined` if no modals are open.
+</DocBlock>
+
+<DocBlock name="modal.init" type="method" returns="Object" src="modal/src/js/index.js" line="37" args={[
+  ["options", "Object (optional)", "An options object for passing custom settings."]
+]}>
+  Initializes the modal instance. During initialization, the following processes are run:
+
+  - Register each modal in the collection by running `registerCollection()`.
+  - Sets up global event listeners by running `initEventListeners()`.
+
+  <Fragment slot="example">
+    ```js
+    const modal = new Modal();
+    await modal.init();
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="modal.destroy" type="method" returns="Object" src="modal/src/js/index.js" line="55">
+  Destroys and cleans up the modal initialization. During cleanup, the following processes are run:
+
+  - Deregister the modal collection by running `deregisterCollection()`.
+  - Removes global event listeners by running `destroyEventListeners()`.
+
+  <Fragment slot="example">
+    ```js
+    const modal = new Modal();
+    await modal.init();
+    // ...
+    await modal.destroy();
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="modal.initEventListeners" type="method" returns="Object" src="modal/src/js/index.js" line="70">
+  Set document event listeners.
+
+  <Fragment slot="example">
+    ```js
+    const modal = new Modal({ eventListeners: false });
+    await modal.init();
+    modal.initEventListeners();
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="modal.destroyEventListeners" type="method" returns="Object" src="modal/src/js/index.js" line="75">
+  Remove document event listeners.
+
+  <Fragment slot="example">
+    ```js
+    const modal = new Modal();
+    await modal.init();
+    // ...
+    modal.destroyEventListeners();
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="modal.register" type="method" returns="Object" src="modal/src/js/register.js" args={[
+  ["query", "String || Object", "A modal ID or an HTML element of either the modal or its trigger."]
+]}>
+  Registers a modal into the collection. This also sets the initial state and applies missing accessibility attributes such as `role="dialog"` and `aria-modal="true"`. Returns the modal entry that got stored in the collection.
+
+  <Fragment slot="example">
+    ```js
+    const result = await modal.register('modal-id');
+    // => Object { id: 'modal-id', ... }
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="modal.deregister" type="method" returns="Array" src="modal/src/js/deregister.js" args={[
+  ["query", "String || Object", "A modal ID or an HTML element of either the modal or its trigger."]
+]}>
+  Deregister the modal from the collection. This closes the modal if it's opened, returns a modal if it has been teleported and removes the entry from the collection. Returns the newly modified collection array.
+
+  <Fragment slot="example">
+    ```js
+    const result = await modal.deregister('modal-id');
+    // => Array [{}, {}, ...]
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="modal.registerCollection" type="method" returns="Array" src="core/src/js/Collection.js" line="26" args={[
+  ["items", "Array", "An array of modals or modal IDs to register."]
+]}>
+  Registers array of modals to the collection. All modals in array are run through the `register()` method. Returns the collection array.
+
+  <Fragment slot="example">
+    ```js
+    const modals = document.querySelectorAll('.modal');
+    const result = await modal.registerCollection(modals);
+    // => Array [{}, {}, ...]
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="modal.deregisterCollection" type="method" returns="Array" src="core/src/js/Collection.js" line="33">
+  Deregister all modals in the collections array. All modals in collection are run through the `deregister()` method. Returns the empty collection array.
+
+  <Fragment slot="example">
+    ```js
+    const result = await modal.registerCollection();
+    // => Array []
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="modal.get" type="method" returns="Object || undefined" src="core/src/js/Collection.js" line="40" args={[
+  ["value", "String || Object", "The value to search for within the collection."],
+  ["key", "String (optional)", "The property key to search the value against (defaults to 'id')."]
+]}>
+  Used to retrieve a registered modal entry from the collection. The value should match the key type to search by: e.g. to search by modal elements, pass the modal html node with a key of `'el'`. Defaults to `'id'`.
+
+  Returns the first element in the collection that matches the provided query and key. Otherwise, undefined is returned.
+
+  <Fragment slot="example">
+    ```js
+    const entry = modal.get('modal-id');
+    // => Object { id: 'modal-id', ... }
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="modal.open" type="method" returns="Object" src="modal/src/js/open.js" args={[
+  ["id", "String", "The ID of the modal to open."],
+  ["transition", "Boolean (optional)", "Whether or not to animate the transition."],
+  ["focus", "Boolean (optional)", "Whether or not to handle focus management."]
+]}>
+  Opens a modal using the provided ID. Returns the modal object that was opened.
+
+  <Fragment slot="example">
+    ```js
+    const entry = await modal.open('modal-key');
+    // => Object { id: 'modal-id', ... }
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="modal.close" type="method" returns="Object" src="modal/src/js/close.js" args={[
+  ["id", "String", "The ID of the modal to close."],
+  ["transition", "Boolean (optional)", "Whether or not to animate the transition."],
+  ["focus", "Boolean (optional)", "Whether or not to handle focus management."]
+]}>
+  Closes a modal using the provided ID. Can be called without an ID to close most recently opened modal. Returns the modal object that was closed.
+
+  <Fragment slot="example">
+    ```js
+    const entry = await modal.close();
+    // => Object { id: 'modal-id', ... }
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="modal.replace" type="method" returns="Object" src="modal/src/js/replace.js" args={[
+  ["id", "String", "The ID of the modal to open. Will close all other opened modals."],
+  ["transition", "Boolean (optional)", "Whether or not to animate the transition."],
+  ["focus", "Boolean (optional)", "Whether or not to handle focus management."]
+]}>
+  Replaces currently opened modal(s) with the modal of the id provided. This could be used to trigger a modal when modal stacking is not desired. Returns an object with `opened` and `closed` properties whose values will be the opened modal and an array of modals that were closed.
+
+  <Fragment slot="example">
+    ```js
+    const obj = await modal.replace('modal-id');
+    // => Object { opened: { id: 'modal-id', ... }, closed: [...] }
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="modal.closeAll" type="method" returns="Object" src="modal/src/js/closeAll.js" args={[
+  ["exclude", "String (optional)", "The ID of a modal to exclude from closing. Will close all other opened modals."],
+  ["transition", "Boolean (optional)", "Whether or not to animate the transition."],
+  ["focus", "Boolean (optional)", "Whether or not to handle focus management."]
+]}>
+  Closes all open modals. Will exclude closing a modal using the provided ID. Returns an array of all modals that were closed.
+
+  <Fragment slot="example">
+    ```js
+    const array = await modal.closeAll();
+    // => Array [{}, {}, ...]
+    ```
+  </Fragment>
+</DocBlock>
+
+### Custom Events
+
+The modal component also exposes some custom events for hooking into the modal lifecycle. All modal events are fired on the root modal element (i.e. at the `<div id="[unique-id]" class="modal">`).
 
 - `modal:opened` Emits when a modal has opened.
 - `modal:closed` Emits when a modal has closed.
-
-## API
-
-### `modal.collection`
-
-Returns an array where all modal objects are stored when registered. Each modal object contains the following properties:
-
-```js
-{
-  id: String, // The unique ID of the modal.
-  state: String, // The current state of the modal ('closing', 'closed', 'opening' or 'opened').
-  el: HTMLElement, // The modal HTML element.
-  dialog: HTMLElement // The modal dialog HTML element.
-  returnRef: HTMLComment // The return reference left when a modal is teleported.
-  settings: Object // The modal specific settings.
-  open: Function // Method to open this modal.
-  close: Function // Method to close this modal.
-  replace: Function // Method to replace open modal(s) with this modal.
-  deregister: Function // Method to deregister this modal.
-  teleport: Function // Method to teleport this modal.
-  teleportReturn: Function // Method to return this modal to its previous location.
-  getSetting: Function // Method that returns either a modal specific setting or global modal setting.
-}
-```
-
-**Returns**
-
-- `Array` An array of collection entries.
-
-### `modal.stack`
-
-Returns an array of all currently opened modals. These are sorted in the order they're added to the array (first item was opened first, last item was opened last).
-
-**Returns**
-
-- `Array` An array of collection entries.
-
-### `modal.active`
-
-Returns the currently active modal or the modal at the top of the stack if multiple modals are open. Will return `undefined` if no modals are open.
-
-**Returns**
-
-- `Object || undefined` Collection entry.
-
-### `modal.init(options)`
-
-Initializes the modal instance. During initialization, the following processes are run:
-
-- Register each modal in the collection by running `registerCollection()`.
-- Sets up global event listeners by running `initEventListeners()`.
-
-**Parameters**
-
-- `options [Object] (optional)` An options object for passing custom settings.
-
-```js
-const modal = new Modal();
-await modal.init();
-```
-
-### `modal.destroy()`
-
-Destroys and cleans up the modal initialization. During cleanup, the following processes are run:
-
-- Deregister the modal collection by running `deregisterCollection()`.
-- Removes global event listeners by running `destroyEventListeners()`.
-
-```js
-const modal = new Modal();
-await modal.init();
-// ...
-await modal.destroy();
-```
-
-### `modal.initEventListeners()`
-
-Set document event listeners.
-
-```js
-const modal = new Modal({ eventListeners: false });
-await modal.init();
-modal.initEventListeners();
-```
-
-### `modal.destroyEventListeners()`
-
-Remove document event listeners.
-
-```js
-const modal = new Modal();
-await modal.init();
-// ...
-modal.destroyEventListeners();
-```
-
-### `modal.register(query)`
-
-Registers a modal into the collection. This also sets the initial state and applies missing accessibility attributes such as `role="dialog"` and `aria-modal="true"`.
-
-**Parameters**
-
-- `query [String || Object]` A modal ID or an HTML element of either the modal or its trigger.
-
-**Returns**
-
-- `Object` The modal object that got stored in the collection.
-
-```js
-const result = await modal.register('modal-id');
-// => Object { id: 'modal-id', ... }
-```
-
-### `modal.deregister(query)`
-
-Deregister the modal from the collection. This closes the modal if it's opened, returns a modal if it has been teleported and removes the entry from the collection.
-
-**Parameters**
-
-- `query [String || Object]` A modal ID or an HTML element of either the modal or its trigger.
-
-**Returns**
-
-- `Array` Returns the newly modified collection array.
-
-```js
-const result = await modal.deregister('modal-id');
-// => Array [{}, {}, ...]
-```
-
-### `modal.registerCollection(items)`
-
-Registers array of modals to the collection. All modals in array are run through the `register()` method.
-
-**Parameters**
-
-- `items [Array]` An array of modals or modal IDs to register.
-
-**Returns**
-
-- `Array` Returns the collection array.
-
-```js
-const modals = document.querySelectorAll('.modal');
-const result = await modal.registerCollection(modals);
-// => Array [{}, {}, ...]
-```
-
-### `modal.deregisterCollection()`
-
-Deregister all modals in the collections array. All modals in collection are run through the `deregister()` method.
-
-**Returns**
-
-- `Array` Returns the empty collection array.
-
-```js
-const result = await modal.registerCollection();
-// => Array []
-```
-
-### `modal.get(value, key)`
-
-Used to retrieve a registered modal object from the collection. The value should match the key type to search by: e.g. to search by modal elements, pass the modal html node with a key of `'el'`. Defaults to `'id'`.
-
-**Parameters**
-
-- `value [String || Object]` The value to search for within the collection.
-- `key [String] (optional) (default 'id')` The property key to search the value against.
-
-**Returns**
-
-- `Object || undefined` The first element in the collection that matches the provided query and key. Otherwise, undefined is returned.
-
-```js
-const entry = modal.get('modal-id');
-// => Object { id: 'modal-id', ... }
-```
-
-### `modal.open(id, transition, focus)`
-
-Opens a modal using the provided ID.
-
-**Parameters**
-
-- `id [String]` The ID of the modal to open.
-- `transition [Boolean] (optional)` Whether or not to animate the transition.
-- `focus [Boolean] (optional)` Whether or not to handle focus management.
-
-**Returns**
-
-- `Object` The modal object that was opened.
-
-```js
-const entry = await modal.open('modal-key');
-// => Object { id: 'modal-id', ... }
-```
-
-### `modal.close(id, transition, focus)`
-
-Closes a modal using the provided ID. Can be called without an ID to close most recently opened modal.
-
-**Parameters**
-
-- `id [String] (optional)` The ID of the modal to close.
-- `transition [Boolean] (optional)` Whether or not to animate the transition.
-- `focus [Boolean] (optional)` Whether or not to handle focus management.
-
-**Returns**
-
-- `Object` The modal object that was closed.
-
-```js
-const entry = await modal.close();
-// => Object { id: 'modal-id', ... }
-```
-
-### `modal.replace(id, transition, focus`
-
-Replaces currently opened modal(s) with the modal of the id provided. This could be used to trigger a modal when modal stacking is not desired.
-
-**Parameters**
-
-- `id [String]` The ID of the modal to open. Will close all other opened modals.
-- `transition [Boolean] (optional)` Whether or not to animate the transition.
-- `focus [Boolean] (optional)` Whether or not to handle focus management.
-
-**Returns**
-
-- `Object` An object with `opened` and `closed` properties whose values will be the opened modal and an array of modals that were closed.
-
-```js
-const obj = await modal.replace('modal-id');
-// => Object { opened: { id: 'modal-id', ... }, closed: [...] }
-```
-
-### `modal.closeAll(exclude, transition, focus)`
-
-Closes all open modals. Will exclude closing a modal using the provided ID.
-
-**Parameters**
-
-- `exclude [String] (optional)` The ID of a modal to exclude from closing. Will close all other opened modals.
-- `transition [Boolean] (optional)` Whether or not to animate the transition.
-- `focus [Boolean] (optional)` Whether or not to handle focus management.
-
-**Returns**
-
-- `Array` An array of all modals that were closed.
-
-```js
-const array = await modal.closeAll();
-// => Array [{}, {}, ...]
-```

--- a/docs/src/content/packages/modal.mdx
+++ b/docs/src/content/packages/modal.mdx
@@ -2,36 +2,33 @@
 title: Modal
 description: "A component for changing the mode of a page to complete a critical task. This is usually used in conjunction with the dialog component to make modal dialogs."
 package: "@vrembem/modal"
+state: "circle"
 ---
+
+import CodeExample from "../../components/CodeExample.astro";
 
 # Modal
 
 A component for changing the mode of a page to complete a critical task. This is usually used in conjunction with the dialog component to make modal dialogs.
 
-[![npm version](https://img.shields.io/npm/v/%40vrembem%2Fmodal.svg)](https://www.npmjs.com/package/%40vrembem%2Fmodal)
-
-[Documentation](https://vrembem.com/packages/modal)
-
-## Installation
-
 ```sh
 npm install @vrembem/modal
 ```
 
-### Styles
+<CodeExample lang="scss">
+  ```scss
+  @use "@vrembem/modal";
+  ```
+</CodeExample>
 
-```scss
-@use "@vrembem/modal";
-```
+<CodeExample lang="js">
+  ```js
+  import Modal from "@vrembem/modal";
+  const modal = new Modal({ autoInit: true });
+  ```
+</CodeExample>
 
-### JavaScript
-
-```js
-import Modal from '@vrembem/modal';
-const modal = new Modal({ autoInit: true });
-```
-
-### Markup
+## Basic usage
 
 Modals are composed using classes and data attributes for their triggers. The basic structure of a modal is an element with an `id` and the `modal` class containing a child element with the `modal__dialog` class. There are three types of modal triggers, each defined by a data attribute:
 

--- a/docs/src/content/packages/popover.mdx
+++ b/docs/src/content/packages/popover.mdx
@@ -7,6 +7,7 @@ state: "circle"
 
 import CodeExample from "../../components/CodeExample.astro";
 import DocBlock from "../../components/DocBlock.astro";
+import Menu from "../../examples/Menu.astro";
 
 # Popover
 
@@ -35,9 +36,9 @@ The popover is a simple container component consisting of the `popover` class an
 
 <CodeExample>
   <Fragment slot="output">
-    <button class="link" aria-controls="popover-1">Popover</button>
+    <button class="button button_color_primary" aria-controls="popover-1">Popover</button>
     <div class="popover" id="popover-1">
-      Popover example
+      <Menu name="text" />
     </div>
   </Fragment>
   ```html
@@ -52,9 +53,9 @@ Add an arrow to a popover using an empty `<div>` or `<span>` with the `popover__
 
 <CodeExample>
   <Fragment slot="output">
-    <button class="link" aria-controls="popover-2">Popover</button>
+    <button class="button button_color_primary" aria-controls="popover-2">Popover</button>
     <div class="popover" id="popover-2">
-      Popover example
+      <Menu name="utility" />
       <span class="popover__arrow"></span>
     </div>
   </Fragment>
@@ -90,10 +91,9 @@ Alternatively, this value can be overridden using the [`--vb-popover-event` CSS 
 
 <CodeExample>
   <Fragment slot="output">
-    <button class="link" aria-describedby="popover-3">Popover</button>
+    <button class="button button_color_primary" aria-describedby="popover-3">Popover</button>
     <div id="popover-3" class="popover" style="--vb-popover-event: hover;">
-      Popover example
-      <span class="popover__arrow"></span>
+      <Menu name="utility" />
     </div>
   </Fragment>
   ```html
@@ -126,9 +126,9 @@ Alternatively, this value can be overridden using the [`--vb-popover-placement` 
 
 <CodeExample>
   <Fragment slot="output">
-    <button class="link" aria-describedby="popover-4">Popover</button>
+    <button class="button button_color_primary" aria-describedby="popover-4">Popover</button>
     <div id="popover-4" class="popover" style="--vb-popover-placement: right;">
-      Popover example
+      <Menu name="text" />
       <span class="popover__arrow"></span>
     </div>
   </Fragment>
@@ -171,7 +171,7 @@ The advantage to having these values set by a CSS variable is that they can be g
           <span class="arrow-right"></span>
         </button>
         <div id="popover-5" class="popover">
-          Popover example
+          <Menu name="utility" />
           <span class="popover__arrow"></span>
         </div>
       </div>
@@ -180,7 +180,7 @@ The advantage to having these values set by a CSS variable is that they can be g
           <span class="arrow-left"></span>
         </button>
         <div id="popover-6" class="popover">
-          Popover example
+          <Menu name="utility" />
           <span class="popover__arrow"></span>
         </div>
       </div>
@@ -206,23 +206,19 @@ Adjusts the size of the popover. There are two options relative to the default s
   <div slot="output" class="level">
     <button class="button" aria-describedby="popover-7">Auto</button>
     <div id="popover-7" class="popover popover_size_auto">
-      Popover example
-      <span class="popover__arrow"></span>
+      <Menu name="utility" />
     </div>
     <button class="button" aria-describedby="popover-8">Small</button>
     <div id="popover-8" class="popover popover_size_sm">
-      Popover example
-      <span class="popover__arrow"></span>
+      <Menu name="utility" />
     </div>
     <button class="button" aria-describedby="popover-9">Default</button>
     <div id="popover-9" class="popover">
-      Popover example
-      <span class="popover__arrow"></span>
+      <Menu name="utility" />
     </div>
     <button class="button" aria-describedby="popover-10">Large</button>
     <div id="popover-10" class="popover popover_size_lg">
-      Popover example
-      <span class="popover__arrow"></span>
+      <Menu name="utility" />
     </div>
   </div>
   ```html

--- a/docs/src/content/packages/popover.mdx
+++ b/docs/src/content/packages/popover.mdx
@@ -6,6 +6,7 @@ state: "circle"
 ---
 
 import CodeExample from "../../components/CodeExample.astro";
+import DocBlock from "../../components/DocBlock.astro";
 
 # Popover
 
@@ -32,74 +33,113 @@ npm install @vrembem/popover
 
 The popover is a simple container component consisting of the `popover` class and an `id`. Popover triggers should have an `aria-controls` attribute set to the ID of the popover element.
 
-```html
-<button aria-controls="unique-id">...</button>
-<div class="popover" id="unique-id">
-  ...
-</div>
-```
+<CodeExample>
+  <Fragment slot="output">
+    <button class="link" aria-controls="popover-1">Popover</button>
+    <div class="popover" id="popover-1">
+      Popover example
+    </div>
+  </Fragment>
+  ```html
+  <button aria-controls="unique-id">...</button>
+  <div class="popover" id="unique-id">
+    ...
+  </div>
+  ```
+</CodeExample>
 
-#### `popover__arrow`
+Add an arrow to a popover using an empty `<div>` or `<span>` with the `popover__arrow` class. Popover arrows are positioned center relative to the reference element.
 
-Adds an arrow to a popover using an empty `<div>` or `<span>` with the `popover__arrow` class. Popover arrows are positioned center relative to the reference element.
+<CodeExample>
+  <Fragment slot="output">
+    <button class="link" aria-controls="popover-2">Popover</button>
+    <div class="popover" id="popover-2">
+      Popover example
+      <span class="popover__arrow"></span>
+    </div>
+  </Fragment>
+  ```html
+  <button aria-controls="unique-id">...</button>
+  <div id="unique-id" class="popover">
+    ...
+    <span class="popover__arrow"></span>
+  </div>
+  ```
+</CodeExample>
 
-```html
-<button aria-controls="unique-id">...</button>
-<div id="unique-id" class="popover">
-  ...
-  <span class="popover__arrow"></span>
-</div>
-```
-
-#### Event Type
+### Event type
 
 There are two event types that can trigger a popover: `click` (the default) and `hover` (hover also applies focus events). You an set your preferred default event type by passing it as an option on instantiation or initialization.
 
-```js
-// Set on instantiation
-const popover = new Popover({
-  eventType: 'click'
-});
+<CodeExample lang="js">
 
-// Set on initialization
-popover.init({
-  eventType: 'hover'
-});
-```
+  ```js
+  // Set on instantiation
+  const popover = new Popover({
+    eventType: "click"
+  });
+
+  // Set on initialization
+  popover.init({
+    eventType: "hover"
+  });
+  ```
+</CodeExample>
 
 Alternatively, this value can be overridden using the [`--vb-popover-event` CSS variable](#css-variables). This can be done either through your own custom CSS or using the `style` attribute.
 
-```html
-<div class="popover" style="--vb-popover-event: hover;">
-  ...
-</div>
-```
+<CodeExample>
+  <Fragment slot="output">
+    <button class="link" aria-describedby="popover-3">Popover</button>
+    <div id="popover-3" class="popover" style="--vb-popover-event: hover;">
+      Popover example
+      <span class="popover__arrow"></span>
+    </div>
+  </Fragment>
+  ```html
+  <div class="popover" style="--vb-popover-event: hover;">
+    ...
+  </div>
+  ```
+</CodeExample>
 
-#### Placement
+### Placement
 
 Popover uses the [Popper JS positioning engine](https://popper.js.org/) to determine the optimal place to display a popover. The default preference is `bottom` but can be changed by passing it as an option on instantiation or initialization.
 
-```js
-// Set on instantiation
-const popover = new Popover({
-  placement: 'top'
-});
+<CodeExample lang="js">
 
-// Set on initialization
-popover.init({
-  placement: 'bottom'
-});
-```
+  ```js
+  // Set on instantiation
+  const popover = new Popover({
+    placement: "top"
+  });
+
+  // Set on initialization
+  popover.init({
+    placement: "bottom"
+  });
+  ```
+</CodeExample>
 
 Alternatively, this value can be overridden using the [`--vb-popover-placement` CSS variable](#css-variables). This can be done either through your own custom CSS or using the `style` attribute.
 
-```html
-<div class="popover" style="--vb-popover-placement: top;">
-  ...
-</div>
-```
+<CodeExample>
+  <Fragment slot="output">
+    <button class="link" aria-describedby="popover-4">Popover</button>
+    <div id="popover-4" class="popover" style="--vb-popover-placement: right;">
+      Popover example
+      <span class="popover__arrow"></span>
+    </div>
+  </Fragment>
+  ```html
+  <div class="popover" style="--vb-popover-placement: right;">
+    ...
+  </div>
+  ```
+</CodeExample>
 
-#### Available Placement Values
+**Available Variants**
 
 - `auto`
 - `auto-start`
@@ -117,304 +157,377 @@ Alternatively, this value can be overridden using the [`--vb-popover-placement` 
 - `right-start`
 - `right-end`
 
-#### CSS Variables
+### CSS Variables
 
 Popover provides CSS variables on the `:root` element for controlling the event type, preferred placement, offset and overflow-padding. They're consumed by the JavaScript implementation to set options dynamically. The following Sass variable are output as CSS variables:
 
-| Sass                | CSS                             | Description                                                                                                                                                                                   |
-| ------------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `$event`            | `--vb-popover-event`            | Controls the event type. Can be set to `click` or `hover`.                                                                                                                                    |
-| `$placement`        | `--vb-popover-placement`        | Controls the preferred placement for the popover. [More details &rarr;](https://popper.js.org/docs/v2/constructors/#placement)                                                                |
-| `$offset`           | `--vb-popover-offset`           | Controls the distance from the popover trigger element (`aria-controls`) that a popover will position itself. [More details &rarr;](https://popper.js.org/docs/v2/modifiers/offset/)          |
-| `$overflow-padding` | `--vb-popover-overflow-padding` | Controls the distance before a popover is cut off and will try to reposition itself to stay visible. [More details &rarr;](https://popper.js.org/docs/v2/modifiers/prevent-overflow/#padding) |
-| `$flip-padding`     | `--vb-popover-flip-padding`     | Controls the distance before a popover is cut off and will try to flip it's placement to stay visible. [More details &rarr;](https://popper.js.org/docs/v2/modifiers/flip/#padding)           |
-| `$arrow-padding`    | `--vb-popover-arrow-padding`    | Controls the distance before a popover arrow reaches the edge of the popover. [More details &rarr;](https://popper.js.org/docs/v2/modifiers/arrow/#padding)                                   |
-
 The advantage to having these values set by a CSS variable is that they can be given new values for specific use cases either in your own stylesheet or by setting the variables in a `style` attribute.
 
-```html
-<div style="--vb-popover-offset: 0;">
-  <div style="--vb-popover-placement: right;">
-    ...
+<CodeExample>
+  <Fragment slot="output">
+    <div class="flex flex-justify-between" style="--vb-popover-offset: 0;">
+      <div style="--vb-popover-placement: right;">
+        <button class="button button_icon button_color_secondary" aria-describedby="popover-5">
+          <span class="arrow-right"></span>
+        </button>
+        <div id="popover-5" class="popover">
+          Popover example
+          <span class="popover__arrow"></span>
+        </div>
+      </div>
+      <div style="--vb-popover-placement: left;">
+        <button class="button button_icon button_color_secondary" aria-describedby="popover-6">
+          <span class="arrow-left"></span>
+        </button>
+        <div id="popover-6" class="popover">
+          Popover example
+          <span class="popover__arrow"></span>
+        </div>
+      </div>
+    </div>
+  </Fragment>
+  ```html
+  <div style="--vb-popover-offset: 0;">
+    <div style="--vb-popover-placement: right;">
+      ...
+    </div>
+    <div style="--vb-popover-placement: left;">
+      ...
+    </div>
   </div>
-  <div style="--vb-popover-placement: left;">
-    ...
-  </div>
-</div>
-```
+  ```
+</CodeExample>
 
-## Modifiers
-
-### `popover_size_[value]`
+## popover_size_[value]
 
 Adjusts the size of the popover. There are two options relative to the default size, `popover_size_sm` and `popover_size_lg`. Also available is `popover_size_auto` which allows the popover to adjust size based on its content.
 
-```html
-<div id="unique-id" class="popover popover_size_sm">
-  ...
-</div>
-```
+<CodeExample>
+  <div slot="output" class="level">
+    <button class="button" aria-describedby="popover-7">Auto</button>
+    <div id="popover-7" class="popover popover_size_auto">
+      Popover example
+      <span class="popover__arrow"></span>
+    </div>
+    <button class="button" aria-describedby="popover-8">Small</button>
+    <div id="popover-8" class="popover popover_size_sm">
+      Popover example
+      <span class="popover__arrow"></span>
+    </div>
+    <button class="button" aria-describedby="popover-9">Default</button>
+    <div id="popover-9" class="popover">
+      Popover example
+      <span class="popover__arrow"></span>
+    </div>
+    <button class="button" aria-describedby="popover-10">Large</button>
+    <div id="popover-10" class="popover popover_size_lg">
+      Popover example
+      <span class="popover__arrow"></span>
+    </div>
+  </div>
+  ```html
+  <div id="unique-id" class="popover popover_size_sm">
+    ...
+  </div>
+  ```
+</CodeExample>
 
-#### Available Variations
+**Available Variants**
 
 - `popover_size_auto`
 - `popover_size_sm`
 - `popover_size_lg`
 
-### `popover_tooltip`
+## popover_tooltip
 
 Applies styles to create a popover tooltip. The default placement of a tooltip is `top` and are triggered by the `hover` and `focus` events. Tooltips also require a different set of attributes for accessibility:
 
 - The popover element should have the `role="tooltip"` set.
 - The popover trigger should have `aria-describedby` (instead of `aria-controls`) set to the ID of the popover element.
 
-```html
-<span aria-describedby="unique-id">HTML</span>
-<div id="unique-id" class="popover popover_tooltip" role="tooltip">
-  Hypertext Markup Language
-  <span class="popover__arrow"></span>
-</div>
-```
+<CodeExample>
+  <Fragment slot="output">
+    <span class="link" aria-describedby="popover-tooltip">HTML</span>
+    <div id="popover-tooltip" class="popover popover_tooltip" role="tooltip">
+      Hypertext Markup Language
+      <span class="popover__arrow"></span>
+    </div>
+  </Fragment>
+  ```html
+  <span aria-describedby="unique-id">HTML</span>
+  <div id="unique-id" class="popover popover_tooltip" role="tooltip">
+    Hypertext Markup Language
+    <span class="popover__arrow"></span>
+  </div>
+  ```
+</CodeExample>
 
-> For more information regarding tooltip accessibility and best practices: [ARIA: tooltip role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role)
+> For more information regarding tooltip accessibility and best practices, please see: [ARIA: tooltip role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role).
 
 ## Customization
 
-### Sass Variables
-
-| Variable                 | Default               | Description                                                                                                                     |
-| ------------------------ | --------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `$prefix-variable`       | `null`                | String to prefix CSS variables with.                                                                                            |
-| `$prefix-block`          | `null`                | String to prefix blocks with.                                                                                                   |
-| `$prefix-element`        | `"__"`                | String to prefix elements with.                                                                                                 |
-| `$prefix-modifier`       | `"_"`                 | String to prefix modifiers with.                                                                                                |
-| `$prefix-modifier-value` | `"_"`                 | String to prefix modifier values with.                                                                                          |
-| `$event`                 | `null`                | Outputs a CSS variable for setting the default popover behavior. Can either be `click` or `hover`.                              |
-| `$placement`             | `null`                | Outputs a CSS variable for setting the preferred popover placement.                                                             |
-| `$offset`                | `8`                   | Sets the distance from the reference element that a popover will position itself. Also outputs a CSS variable.                  |
-| `$overflow-padding`      | `10`                  | Sets the distance before a popover is cut off and will try to reposition itself to stay visible. Also outputs a CSS variable.   |
-| `$flip-padding`          | `10`                  | Sets the distance before a popover is cut off and will try to flip it's placement to stay visible. Also outputs a CSS variable. |
-| `$z-index`               | `10`                  | Sets the z-index property.                                                                                                      |
-| `$width`                 | `16em`                | Sets the width property.                                                                                                        |
-| `$max-width`             | `calc(100vw - 20px)`  | Sets the max-width property.                                                                                                    |
-| `$padding`               | `0.5em`               | Sets the padding property.                                                                                                      |
-| `$border`                | `null`                | Sets the border property.                                                                                                       |
-| `$border-radius`         | `core.$border-radius` | Sets the border-radius property.                                                                                                |
-| `$background`            | `white`               | Sets the background property.                                                                                                   |
-| `$background-clip`       | `padding-box`         | Sets the background-clip property.                                                                                              |
-| `$box-shadow`            | `core.$box-shadow-2`  | Sets the box-shadow property.                                                                                                   |
-| `$font-size`             | `core.$font-size-sm`  | Sets the font-size property.                                                                                                    |
-| `$line-height`           | `null`                | Sets the line-height property.                                                                                                  |
-| `$arrow-size`            | `8px`                 | Sets the width and height properties of the `popover__arrow` element.                                                           |
-| `$arrow-padding`         | `10`                  | Sets the distance before a popover arrow reaches the edge of the popover.                                                       |
-| `$arrow-border`          | `core.$border-light`  | Sets the border property of the `popover__arrow` element.                                                                       |
-| `$size-sm-width`         | `12em`                | Sets the width property of the `popover_size_sm` modifier.                                                                      |
-| `$size-lg-width`         | `20em`                | Sets the width property of the `popover_size_lg` modifier.                                                                      |
-
-### JavaScript Options
-
-| Key               | Default             | Description                                                   |
-| ----------------- | ------------------- | ------------------------------------------------------------- |
-| `autoInit`        | `false`             | Automatically initializes the instance.                       |
-| `selectorPopover` | `'.popover'`        | Selector for finding popover elements.                        |
-| `selectorArrow`   | `'.popover__arrow'` | Selector for finding popover arrow elements.                  |
-| `stateActive`     | `'is-active'`       | Class used for active state.                                  |
-| `eventType`       | `'click'`           | The default event type. Can be either `'click'` or `'hover'`. |
-| `eventListeners`  | `true`              | Whether or not to output global event listeners.              |
-| `placement`       | `'bottom'`          | The default preferred placement.                              |
-
-## API
-
-### `popover.collection`
-
-An array where all popover objects are stored when registered. Each popover object contains the following properties:
-
-```js
-{
-  id: String, // The unique ID of the popover.
-  state: String, // The current state of the popover ('closed' or 'opened').
-  el: HTMLElement, // The popover HTML element.
-  trigger: HTMLElement, // The popover trigger HTML element.
-  popper: Object // The popper JS instance.
-  config: Object // Stores the popover configuration options.
-  open: Function // Method to open this popover.
-  close: Function // Method to close this popover.
-  deregister: Function // Method to deregister this popover.
-}
-```
-
-### `popover.init(options)`
-
-Initializes the popover instance. During initialization, the following processes are run:
-
-- Builds the popover collection by running `registerCollection()`
-- Sets up the global event listeners by running `initEventListeners()`
-
-**Parameters**
-
-- `options [Object] (optional)` An options object for passing custom settings.
-
-```js
-const popover = new Popover();
-await popover.init();
-```
-
-### `popover.destroy()`
-
-Destroys and cleans up the popover initialization. During cleanup, the following processes are run:
-
-- Deregister the popover collection by running `deregisterCollection()`
-- Removes global event listeners by running `destroyEventListeners()`
-
-```js
-const popover = new Popover();
-await popover.init();
-// ...
-await popover.destroy();
-```
-
-### `popover.initEventListeners(processCollection)`
-
-Set document and collection entry event listeners.
-
-**Parameters**
-
-- `processCollection [Boolean] (default true)` Whether or not to process the event listeners of popover collection.
-
-```js
-const popover = new Popover({ eventListeners: false });
-await popover.init();
-popover.initEventListeners();
-```
-
-### `popover.destroyEventListeners(processCollection)`
-
-Remove document and collection entry event listeners.
-
-**Parameters**
-
-- `processCollection [Boolean] (default true)` Whether or not to process the event listeners of popover collection.
-
-```js
-const popover = new Popover();
-await popover.init();
-// ...
-popover.destroyEventListeners();
-```
-
-### `popover.register(query)`
-
-Registers a popover into the collection. This also sets the initial state, creates the popper instance and attaches event listeners.
-
-**Parameters**
-
-- `query [String | Object]` A popover ID or an HTML element of either a popover or its trigger.
-
-**Returns**
-
-- `Object` The popover object that got stored in the collection.
-
-```js
-const result = await popover.register('popover-id');
-// => Object { id: 'popover-id', ... }
-```
-
-### `popover.deregister(query)`
-
-Deregister the popover from the collection. This closes the popover if it's opened, cleans up the popper instance, removes event listeners and then removes the entry from the collection.
-
-**Parameters**
-
-- `query [String | Object]` A popover ID or an HTML element of either a popover or its trigger.
-
-**Returns**
-
-- `Array` Returns the newly modified collection array.
-
-```js
-const result = await popover.deregister('popover-id');
-// => Array [{}, {}, ...]
-```
-
-### `popover.registerCollection(items)`
-
-Registers array of popovers to the collection. All popovers in array are run through the `register()` method.
-
-**Parameters**
-
-- `items [Array]` An array of popovers or popover IDs to register.
-
-**Returns**
-
-- `Array` Returns the collection array.
-
-```js
-const popovers = document.querySelectorAll('.popover');
-const result = await popover.registerCollection(popovers);
-// => Array [{}, {}, ...]
-```
-
-### `popover.deregisterCollection()`
-
-Deregister all popovers in the collections array. All popovers in collection are run through the `deregister()` method.
-
-**Returns**
-
-- `Array` Returns an empty collection array.
-
-```js
-const result = await popover.registerCollection();
-// => Array []
-```
-
-### `popover.get(value, key)`
-
-Used to retrieve a registered popover object from the collection. Query should match the key type to search by: e.g. to search by popover elements, pass the popover html node with a key of `'el'`. Defaults to `'id'`.
-
-**Parameters**
-
-- `value [String | Object]` The value to search for within the collection.
-- `key [String] (optional) (default 'id')` The property key to search the value against.
-
-**Returns**
-
-- `Object | undefined` The first element in the collection that matches the provided query and key. Otherwise, undefined is returned.
-
-```js
-const entry = popover.get('popover-id');
-// => Object { id: 'popover-id', ... }
-```
-
-### `popover.open(id)`
-
-Opens a popover using the provided ID.
-
-**Parameters**
-
-- `id [String]` The ID of the popover that should be opened.
-
-**Returns**
-
-- `Object` The popover object that was opened.
-
-```js
-popover.open('popover-id')
-// => Object { state: 'opened', ... }
-```
-
-### `popover.close(id)`
-
-Close a popover using the provided ID. Can be called without an ID to close all open popovers.
-
-**Parameters**
-
-- `id [String] (optional)` The ID of the popover that should be closed.
-
-**Returns**
-
-- `Object | Array` The popover object or array of popover objects that were closed.
-
-```js
-const entry = await popover.close();
-// => Array [{}, {}, ...]
-```
+Popovers are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable via the `core` module.
+
+<DocBlock name="CSS Variables" type="file" src="popover/src/scss/_root.scss">
+
+  ```scss
+  @use "./variables" as var;
+
+  $_v: var.$prefix-variable;
+
+  :root {
+    @if (var.$event) {
+      --#{$_v}popover-event: #{var.$event};
+    }
+    @if (var.$placement) {
+      --#{$_v}popover-placement: #{var.$placement};
+    }
+
+    --#{$_v}popover-offset: #{var.$offset};
+    --#{$_v}popover-overflow-padding: #{var.$overflow-padding};
+    --#{$_v}popover-flip-padding: #{var.$flip-padding};
+    --#{$_v}popover-arrow-padding: #{var.$arrow-padding};
+  }
+  ```
+</DocBlock>
+
+<DocBlock name="SCSS Variables" type="file" src="popover/src/scss/_variables.scss">
+
+  ```scss
+  @use "@vrembem/core/theme";
+  @use "@vrembem/core";
+
+  $prefix-variable: core.$prefix-variable !default;
+  $prefix-block: core.$prefix-block !default;
+  $prefix-element: core.$prefix-element !default;
+  $prefix-modifier: core.$prefix-modifier !default;
+  $prefix-modifier-value: core.$prefix-modifier-value !default;
+
+  $event: null !default;
+  $placement: null !default;
+  $offset: 8 !default;
+  $overflow-padding: 10 !default;
+  $flip-padding: 10 !default;
+
+  $z-index: 10 !default;
+  $width: 16em !default;
+  $max-width: calc(100vw - 20px) !default;
+  $padding: 0.5em !default;
+  $border: null !default;
+  $border-radius: core.$border-radius !default;
+  $foreground: theme.get("foreground") !default;
+  $background: theme.get("background") !default;
+  $background-clip: padding-box !default;
+  $shadow: core.$shadow-2 !default;
+  $font-size: core.$font-size-sm !default;
+  $line-height: null !default;
+
+  $arrow-size: 12px !default;
+  $arrow-padding: 10 !default;
+  $arrow-border: core.$border !default;
+
+  $size-sm-width: 12em !default;
+  $size-lg-width: 20em !default;
+  ```
+</DocBlock>
+
+<DocBlock name="JS Config" type="file" src="popover/src/js/defaults.js">
+
+  ```js
+  export default {
+    autoInit: false,
+
+    // Selectors
+    selectorPopover: ".popover",
+    selectorArrow: ".popover__arrow",
+
+    // State classes
+    stateActive: "is-active",
+
+    // Feature settings
+    eventListeners: true,
+    eventType: "click",
+    placement: "bottom"
+  };
+  ```
+</DocBlock>
+
+## JavaScript usage
+
+After the popover component has been instantiated the popover object is returned with a robust API to help manage all the popovers on your page.
+
+<DocBlock name="popover.collection" type="property" returns="array" src="core/src/js/Collection.js" line="3">
+  Returns an array where all popover objects are stored when registered. Each popover object contains the following properties:
+
+  ```scss
+  {
+    id: String, // The unique ID of the popover.
+    state: String, // The current state of the popover ('closed' or 'opened').
+    el: HTMLElement, // The popover HTML element.
+    trigger: HTMLElement, // The popover trigger HTML element.
+    popper: Object // The popper JS instance.
+    config: Object // Stores the popover configuration options.
+    open: Function // Method to open this popover.
+    close: Function // Method to close this popover.
+    deregister: Function // Method to deregister this popover.
+  }
+  ```
+</DocBlock>
+
+<DocBlock name="popover.init" type="method" returns="Object" src="popover/src/js/index.js" line="23" args={[
+  ["options", "Object (optional)", "An options object for passing custom settings."]
+]}>
+  Initializes the popover instance. During initialization, the following processes are run:
+
+  - Builds the popover collection by running `registerCollection()`
+  - Sets up the global event listeners by running `initEventListeners()`
+
+  <Fragment slot="example">
+    ```js
+    const popover = new Popover();
+    await popover.init();
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="popover.destroy" type="method" returns="Object" src="popover/src/js/index.js" line="43">
+  Destroys and cleans up the popover initialization. During cleanup, the following processes are run:
+
+  - Deregister the popover collection by running `deregisterCollection()`
+  - Removes global event listeners by running `destroyEventListeners()`
+
+  <Fragment slot="example">
+    ```js
+    const popover = new Popover();
+    await popover.init();
+    // ...
+    await popover.destroy();
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="popover.initEventListeners" type="method" returns="Object" src="popover/src/js/index.js" line="60" args={[
+  ["processCollection", "Boolean", "Whether or not to process the event listeners of popover collection. Defaults to true."]
+]}>
+  Set document and collection entry event listeners.
+
+  <Fragment slot="example">
+    ```js
+    const popover = new Popover({ eventListeners: false });
+    await popover.init();
+    popover.initEventListeners();
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="popover.destroyEventListeners" type="method" returns="Object" src="popover/src/js/index.js" line="72" args={[
+  ["processCollection", "Boolean", "Whether or not to process the event listeners of popover collection. Defaults to true."]
+]}>
+  Remove document and collection entry event listeners.
+
+  <Fragment slot="example">
+    ```js
+    const popover = new Popover();
+    await popover.init();
+    // ...
+    popover.destroyEventListeners();
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="popover.register" type="method" returns="Object" src="popover/src/js/register.js" args={[
+  ["query", "String || Object", "A popover ID or an HTML element of either a popover or its trigger."]
+]}>
+Registers a popover into the collection. This also sets the initial state, creates the popper instance and attaches event listeners. Returns the popover object that got stored in the collection.
+
+  <Fragment slot="example">
+    ```js
+    const result = await popover.register("popover-id");
+    // => Object { id: "popover-id", ... }
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="popover.deregister" type="method" returns="Array" src="popover/src/js/deregister.js" args={[
+  ["query", "String || Object", "A popover ID or an HTML element of either a popover or its trigger."]
+]}>
+Deregister the popover from the collection. This closes the popover if it's opened, cleans up the popper instance, removes event listeners and then removes the entry from the collection. Returns the newly modified collection array.
+
+  <Fragment slot="example">
+    ```js
+    const result = await popover.deregister("popover-id");
+    // => Array [{}, {}, ...]
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="popover.registerCollection" type="method" returns="Array" src="core/src/js/Collection.js" line="26" args={[
+  ["items", "Array", "An array of popovers or popover IDs to register."]
+]}>
+Registers array of popovers to the collection. All popovers in array are run through the `register()` method. Returns the collection array.
+
+  <Fragment slot="example">
+    ```js
+    const popovers = document.querySelectorAll(".popover");
+    const result = await popover.registerCollection(popovers);
+    // => Array [{}, {}, ...]
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="popover.deregisterCollection" type="method" returns="Array" src="core/src/js/Collection.js" line="33">
+Deregister all popovers in the collections array. All popovers in collection are run through the `deregister()` method. Returns an empty collection array.
+
+  <Fragment slot="example">
+    ```js
+    const result = await popover.registerCollection();
+    // => Array []
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="popover.get" type="method" returns="Object || undefined" src="core/src/js/Collection.js" line="40" args={[
+  ["value", "String || Object", "The value to search for within the collection."],
+  ["key", "String (optional)", "The property key to search the value against (defaults to 'id')."]
+]}>
+  Used to retrieve a registered popover object from the collection. Query should match the key type to search by: e.g. to search by popover elements, pass the popover html node with a key of `'el'`. Defaults to `'id'`.
+
+  Returns the first element in the collection that matches the provided query and key. Otherwise, undefined is returned.
+
+  <Fragment slot="example">
+    ```js
+    const entry = popover.get("popover-id");
+    // => Object { id: "popover-id", ... }
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="popover.open" type="method" returns="Object" src="popover/src/js/open.js" args={[
+  ["id", "String", "The ID of the popover to open."],
+  ["transition", "Boolean (optional)", "Whether or not to animate the transition."],
+  ["focus", "Boolean (optional)", "Whether or not to handle focus management."]
+]}>
+  Opens a popover using the provided ID. Returns the popover object that was opened.
+
+  <Fragment slot="example">
+    ```js
+    const entry = await popover.open("popover-id");
+    // => Object { state: 'opened', ... }
+    ```
+  </Fragment>
+</DocBlock>
+
+<DocBlock name="popover.close" type="method" returns="Object" src="popover/src/js/close.js" args={[
+  ["id", "String", "The ID of the popover to close."],
+  ["transition", "Boolean (optional)", "Whether or not to animate the transition."],
+  ["focus", "Boolean (optional)", "Whether or not to handle focus management."]
+]}>
+  Close a popover using the provided ID. Can be called without an ID to close all open popovers. Returns the popover object or array of popover objects that were closed.
+
+  <Fragment slot="example">
+    ```js
+    const entry = await popover.close();
+    // => Array [{}, {}, ...]
+    ```
+  </Fragment>
+</DocBlock>

--- a/docs/src/content/packages/popover.mdx
+++ b/docs/src/content/packages/popover.mdx
@@ -2,36 +2,33 @@
 title: Popover
 description: "A component that is initially hidden and revealed upon user interaction either through a click or hover event. Popover can contain lists of actions, links, or additional supplementary content."
 package: "@vrembem/popover"
+state: "circle"
 ---
+
+import CodeExample from "../../components/CodeExample.astro";
 
 # Popover
 
 A component that is initially hidden and revealed upon user interaction either through a click or hover event. Popover can contain lists of actions, links, or additional supplementary content.
 
-[![npm version](https://img.shields.io/npm/v/%40vrembem%2Fpopover.svg)](https://www.npmjs.com/package/%40vrembem%2Fpopover)
-
-[Documentation](https://vrembem.com/packages/popover)
-
-## Installation
-
 ```sh
 npm install @vrembem/popover
 ```
 
-### Styles
+<CodeExample lang="scss">
+  ```scss
+  @use "@vrembem/popover";
+  ```
+</CodeExample>
 
-```scss
-@use "@vrembem/popover";
-```
+<CodeExample lang="js">
+  ```js
+  import Popover from "@vrembem/popover";
+  const popover = new Popover({ autoInit: true });
+  ```
+</CodeExample>
 
-### JavaScript
-
-```js
-import Popover from '@vrembem/popover';
-const popover = new Popover({ autoInit: true });
-```
-
-### Markup
+## Basic usage
 
 The popover is a simple container component consisting of the `popover` class and an `id`. Popover triggers should have an `aria-controls` attribute set to the ID of the popover element.
 

--- a/docs/src/examples/Menu.astro
+++ b/docs/src/examples/Menu.astro
@@ -1,0 +1,105 @@
+---
+export interface Props {
+	name: string;
+}
+
+const { name } = Astro.props;
+
+---
+
+{ name == "utility" && (
+  <ul class="menu">
+    <li class="menu__item">
+      <button class="menu__action">
+        <span class="menu__text">Cut</span>
+        <span class="foreground-lighter">⌘X</span>
+      </button>
+    </li>
+    <li class="menu__item">
+      <button class="menu__action">
+        <span class="menu__text">Copy</span>
+        <span class="foreground-lighter">⌘C</span>
+      </button>
+    </li>
+    <li class="menu__item">
+      <button class="menu__action">
+        <span class="menu__text">Paste</span>
+        <span class="foreground-lighter">⌘V</span>
+      </button>
+    </li>
+    <li class="menu__sep"></li>
+    <li class="menu__item">
+      <button class="menu__action">
+        <span class="menu__text">Find</span>
+        <span class="foreground-lighter">⌘F</span>
+      </button>
+    </li>
+    <li class="menu__item">
+      <button class="menu__action">
+        <span class="menu__text">Replace</span>
+        <span class="foreground-lighter">⌥⌘F</span>
+      </button>
+    </li>
+  </ul>
+)}
+
+{ name == "text" && (
+  <ul class="menu">
+    <li class="menu__item">
+      <button class="menu__action">
+        <span class="menu__text">Bold</span>
+        <span class="foreground-lighter">⌘B</span>
+      </button>
+    </li>
+    <li class="menu__item">
+      <button class="menu__action">
+        <span class="menu__text">Italic</span> 
+        <span class="foreground-lighter">⌘I</span>
+      </button>
+    </li>
+    <li class="menu__item">
+      <button class="menu__action">
+        <span class="menu__text">Underline</span>
+        <span class="foreground-lighter">⌘U</span>
+      </button>
+    </li>
+    <li class="menu__sep"></li>
+    <li class="menu__item">
+      <button class="menu__action">
+        <span class="menu__text">Paragraph Styles</span>
+        <span class="foreground-lighter arrow-right"></span>
+      </button>
+    </li>
+    <li class="menu__item">
+      <button class="menu__action">
+        <span class="menu__text">Align</span>
+        <span class="foreground-lighter arrow-right"></span>
+      </button>
+    </li>
+    <li class="menu__item">
+      <button class="menu__action">
+        <span class="menu__text">Line spacing</span>
+        <span class="foreground-lighter arrow-right"></span>
+      </button>
+    </li>
+    <li class="menu__item">
+      <button class="menu__action">
+        <span class="menu__text">Numbered lists</span>
+        <span class="foreground-lighter arrow-right"></span>
+      </button>
+    </li>
+    <li class="menu__item">
+      <button class="menu__action">
+        <span class="menu__text">List options</span>
+        <span class="foreground-lighter arrow-right"></span>
+      </button>
+    </li>
+    <li class="menu__sep"></li>
+    <li class="menu__item">
+      <button class="menu__action">
+        <span class="menu__text">Clear formatting</span>
+        <span class="foreground-lighter">⌘/</span>
+      </button>
+    </li>
+  </ul>
+)}

--- a/docs/src/layouts/Page.astro
+++ b/docs/src/layouts/Page.astro
@@ -27,14 +27,14 @@ const layout = {
   {
     layout.hasDrawer && (
       <div slot="drawer">
-        <Navi {entries} collection={collection} menuClass="layout__menu" />
+        <Navi {entries} collection={collection} />
       </div>
     )
   }
   {
     layout.hasAside && (
       <div slot="aside">
-        <OnThisPage {headings} menuClass="layout__menu" />
+        <OnThisPage {headings} />
       </div>
     )
   }

--- a/docs/src/modules/currentViewport.js
+++ b/docs/src/modules/currentViewport.js
@@ -1,0 +1,15 @@
+const els = document.querySelectorAll(".vp-width");
+
+if (els.length) {
+  update(els);
+  window.addEventListener("resize", function() {
+    update(els);
+  });
+}
+
+function update(els) {
+  const vpw = window.innerWidth;
+  els.forEach((el) => {
+    el.innerText = vpw;
+  });
+}

--- a/docs/src/modules/makeSafeForCSS.js
+++ b/docs/src/modules/makeSafeForCSS.js
@@ -2,6 +2,7 @@ function makeSafeForCSS(name) {
   return name.replace(/[^a-z0-9]/g, function(s) {
     const c = s.charCodeAt(0);
     if (c == 32) return "-";
+    if (c == 46) return "-";
     return s.toLowerCase();
   });
 }

--- a/docs/src/pages/getting-started.mdx
+++ b/docs/src/pages/getting-started.mdx
@@ -54,7 +54,7 @@ Vrembem packages all bundles in two areas, `dist` contains all compressed produc
 | __CJS__    | `.js`        | CommonJS bundles that are intended for older bundlers like [Browserify](http://browserify.org/) or [Webpack 1](https://webpack.github.io/). This is the default file from `pkg.main` pointing to `scripts.js`.                  |
 | __Modern__ | `.modern.js` | Modern bundles specially designed to work in all modern browsers. Specifically compiles down to browsers that support `<script type="module">` which are smaller and faster to execute than the `esm` bundle.                   |
 
-#### CDN Link Format
+### CDN Link Format
 
 ```html
 # Styles

--- a/docs/src/pages/packages/[slug].astro
+++ b/docs/src/pages/packages/[slug].astro
@@ -34,7 +34,7 @@ const layout = {
 
 <Base title={entry.data.title} {layout}>
   <div slot="drawer">
-    <Navi {entries} collection="packages" menuClass="layout__menu" />
+    <Navi {entries} collection="packages" />
   </div>
   <div slot="aside">
     <OnThisPage {headings} />
@@ -51,6 +51,7 @@ const layout = {
   import { headerAnchor } from "../../modules/headerAnchor";
   import { tabs } from "../../modules/tabs";
   import { toggle } from "../../modules/toggle";
+  import "../../modules/currentViewport";
 
   headerAnchor.mount();
   tabs.mount();

--- a/docs/src/styles/_code-example.scss
+++ b/docs/src/styles/_code-example.scss
@@ -53,6 +53,10 @@
 
 .code-example__output {
   padding: 2rem;
+
+  .drawer-frame {
+    height: 100%;
+  }
 }
 
 .code-example__toolbar {

--- a/docs/src/styles/_doc-block.scss
+++ b/docs/src/styles/_doc-block.scss
@@ -31,6 +31,12 @@
       margin: 0;
     }
   }
+
+  .type {
+    @include core.gap(1rem, "y");
+    font-size: core.$font-size;
+    line-height: core.$line-height;
+  }
 }
 
 .doc-block__header {
@@ -49,7 +55,7 @@
 
 .doc-block__meta {
   display: flex;
-  gap: 2rem;
+  gap: 0.5rem 2rem;
   flex-wrap: wrap;
 }
 

--- a/docs/src/styles/_layout.scss
+++ b/docs/src/styles/_layout.scss
@@ -1,5 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/palette";
+@use "@vrembem/core/theme";
 @use "./root";
 
 .layout {
@@ -71,6 +72,11 @@
     scroll-margin-top: calc(var(--layout-navibar-height) + 1rem);
   }
 
+  h3 {
+    font-size: 1.5em;
+    font-weight: 500;
+  }
+
   @media (min-width: root.$bp-aside) {
     width: calc(100% - (var(--layout-aside-width) + 4rem));
   }
@@ -132,17 +138,5 @@
   .is-opening ~ &,
   .is-closing ~ & {
     inset: 0;
-  }
-}
-
-/**
- * Layout menu
- */
-
-.layout__menu {
-  margin-top: 0.5rem;
-
-  .menu__action.is-active {
-    background: var(--vb-background);
   }
 }

--- a/docs/src/styles/_menu_collection.scss
+++ b/docs/src/styles/_menu_collection.scss
@@ -1,0 +1,7 @@
+.menu_collection {
+  margin-top: 0.5rem;
+
+  .menu__action.is-active {
+    background: var(--vb-background);
+  }
+}

--- a/docs/src/styles/_menu_otp.scss
+++ b/docs/src/styles/_menu_otp.scss
@@ -14,8 +14,8 @@
       left: 0;
       width: 6px;
       height: 6px;
-      background: palette.get("primary");
       border-radius: 1rem;
+      background: palette.get("primary");
     }
   }
 

--- a/docs/src/styles/_menu_otp.scss
+++ b/docs/src/styles/_menu_otp.scss
@@ -1,0 +1,25 @@
+@use "@vrembem/core/palette";
+
+.menu_otp {
+  .menu__action {
+    position: relative;
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &.is-active::before {
+      content: "";
+      position: absolute;
+      top: calc(50% - 3px);
+      left: 0;
+      width: 6px;
+      height: 6px;
+      background: palette.get("primary");
+      border-radius: 1rem;
+    }
+  }
+
+  .menu {
+    margin-left: 1rem;
+  }
+}

--- a/docs/src/styles/global.scss
+++ b/docs/src/styles/global.scss
@@ -20,6 +20,8 @@
 @use "./fold-shadow";
 @use "./header-anchor";
 @use "./icon_external";
+@use "./menu_collection";
+@use "./menu_otp";
 @use "./pagi";
 @use "./swatch";
 @use "./tabs";


### PR DESCRIPTION
## What changed?

This PR applies the new documentation format to the modal and popover components. Also included are some minor tweaks and fixes to the drawer docs. Other general documentation improvements include:

- Made "On this page" title a clickable "main" anchor.
- "On this page" menu now displays `h2` and `h3` anchors.
- Added examples directory to put reusable code examples (such as menus used in popover docs).
- Used `String.trim()` more consistently in component class usage.
- Wrapped `DocBlock` slot with type module.