### PR TITLE
Refactor cssVar core function to not require the double dash

### DIFF
--- a/packages/core/index.html
+++ b/packages/core/index.html
@@ -98,7 +98,7 @@
     }
 
     // Post message to console
-    console.log('Core instance has been attached to window:', vb);
+    console.log('Core instance has been attached to window as "vb":', vb);
   </script>
 
 </body>

--- a/packages/core/src/js/cssVar.js
+++ b/packages/core/src/js/cssVar.js
@@ -4,7 +4,6 @@ import { getPrefix } from "./getPrefix";
  * Get the value of a CSS custom property (variable).
  * @param {String} property - The CSS custom property to query for.
  * @param {Node} [el=document.body] - The element to get computed styles from.
- * @param {Boolean} [prefix=true] - Whether or not to apply a CSS var prefix.
  * @return {String || Error} Return the CSS value or an error if none is found.
  */
 export function cssVar(property, el = document.body) {

--- a/packages/core/src/js/cssVar.js
+++ b/packages/core/src/js/cssVar.js
@@ -7,21 +7,19 @@ import { getPrefix } from "./getPrefix";
  * @param {Boolean} [prefix=true] - Whether or not to apply a CSS var prefix.
  * @return {String || Error} Return the CSS value or an error if none is found.
  */
-export function cssVar(property, el = document.body, prefix = true) {
-  // Apply CSS prefix if enabled.
-  if (prefix) {
-    // Get the prefix value.
-    const prefixValue = getPrefix();
-    if (prefixValue) {
-      // Remove leading "--" if it exists in the property string.
-      if (property.slice(0, 2) === "--") {
-        property = property.substring(2);
-      }
+export function cssVar(property, el = document.body) {
+  // Get the prefix value.
+  const prefixValue = getPrefix();
+  if (prefixValue) {
+    // Remove leading "--" if it exists in the property string.
+    if (property.slice(0, 2) === "--") {
+      property = property.substring(2);
+    }
 
-      // If there is a prefix value and it doesn't already exist on the prop...
-      if (property.slice(0, prefixValue.length) !== prefixValue) {
-        property = `--${prefixValue}${property}`;
-      }
+    // If there is a prefix value and it doesn't already exist on the prop...
+    if (property.slice(0, prefixValue.length) !== prefixValue) {
+      // Add the prefix.
+      property = `${prefixValue}${property}`;
     }
   }
 

--- a/packages/core/src/js/cssVar.js
+++ b/packages/core/src/js/cssVar.js
@@ -8,35 +8,30 @@ import { getPrefix } from "./getPrefix";
  * @return {String || Error} Return the CSS value or an error if none is found.
  */
 export function cssVar(property, el = document.body) {
-  // Get the prefix value.
-  const prefixValue = getPrefix();
-  if (prefixValue) {
-    // Remove leading "--" if it exists in the property string.
-    if (property.slice(0, 2) === "--") {
-      property = property.substring(2);
-    }
+  // If property doesn't have CSS variable double dash...
+  if (property.slice(0, 2) !== "--") {
+    // Get the prefix value.
+    const prefixValue = getPrefix();
 
-    // If there is a prefix value and it doesn't already exist on the prop...
-    if (property.slice(0, prefixValue.length) !== prefixValue) {
-      // Add the prefix.
+    // If a prefix was found, add it to the property name.
+    if (prefixValue) {
       property = `${prefixValue}${property}`;
     }
-  }
 
-  // Add the double dash for CSS variables if it's missing.
-  if (property.slice(0, 2) !== "--") {
+    // Add the double dash for CSS variables to the property name.
     property = `--${property}`;
   }
 
   // Get the CSS value.
   const cssValue = getComputedStyle(el).getPropertyValue(property).trim();
 
-  // If a CSS value was found...
+  // If a CSS value was found, return the CSS value.
   if (cssValue) {
-    // Return the CSS value.
     return cssValue;
-  } else {
-    // Else, return a blocking error.
+  }
+  
+  // Else, return a blocking error.
+  else {
     throw new Error(`CSS variable "${property}" was not found!`);
   }
 }

--- a/packages/core/src/js/cssVar.js
+++ b/packages/core/src/js/cssVar.js
@@ -12,12 +12,22 @@ export function cssVar(property, el = document.body, prefix = true) {
   if (prefix) {
     // Get the prefix value.
     const prefixValue = getPrefix();
+    if (prefixValue) {
+      // Remove leading "--" if it exists in the property string.
+      if (property.slice(0, 2) === "--") {
+        property = property.substring(2);
+      }
 
-    // If there is a prefix value and it doesn't already exist on the var...
-    if (prefixValue && !property.includes(`--${prefixValue}`)) {
-      // Apply the prefix.
-      property = property.replace("--", `--${prefixValue}`);
+      // If there is a prefix value and it doesn't already exist on the prop...
+      if (property.slice(0, prefixValue.length) !== prefixValue) {
+        property = `--${prefixValue}${property}`;
+      }
     }
+  }
+
+  // Add the double dash for CSS variables if it's missing.
+  if (property.slice(0, 2) !== "--") {
+    property = `--${property}`;
   }
 
   // Get the CSS value.

--- a/packages/core/src/js/getPrefix.js
+++ b/packages/core/src/js/getPrefix.js
@@ -1,3 +1,3 @@
 export function getPrefix() {
-  return getComputedStyle(document.body).getPropertyValue("--vrembem-prefix").trim();
+  return getComputedStyle(document.body).getPropertyValue("--vb-prefix").trim();
 }

--- a/packages/core/src/js/transition.js
+++ b/packages/core/src/js/transition.js
@@ -7,13 +7,13 @@ import { cssVar } from "./cssVar";
  *   transition from.
  * @param {Object} to - An object with a start and finish classes to 
  *   transition to.
- * @param {String || Number} [duration='--transition-duration'] - Either a CSS 
+ * @param {String || Number} [duration="transition-duration"] - Either a CSS 
  *   custom property to get a duration value from or a millisecond value used 
  *   for the transition duration.
  * @return {Promise} Return a promise that resolves when the transition 
  *   has finished.
  */
-export function transition(el, from, to, duration = "--transition-duration") {
+export function transition(el, from, to, duration = "transition-duration") {
   return new Promise((resolve) => {
     // If duration is a string, query for the css var value.
     if (typeof duration === "string") {

--- a/packages/core/src/scss/root/prefix.scss
+++ b/packages/core/src/scss/root/prefix.scss
@@ -2,6 +2,6 @@
 
 :root {
   @if (prefix.$variable) {
-    --vrembem-prefix: #{prefix.$variable};
+    --vb-prefix: #{prefix.$variable};
   }
 }

--- a/packages/core/tests/cssVar.test.js
+++ b/packages/core/tests/cssVar.test.js
@@ -4,7 +4,7 @@ document.body.style.setProperty("--background-color", "pink");
 document.body.style.setProperty("--vb-background-color", "green");
 
 beforeEach(() => {
-  document.body.style.removeProperty("--vrembem-prefix");
+  document.body.style.removeProperty("--vb-prefix");
 });
 
 test("should return a CSS custom property", () => {
@@ -13,13 +13,13 @@ test("should return a CSS custom property", () => {
 });
 
 test("should return a CSS custom property using vrembem prefix", () => {
-  document.body.style.setProperty("--vrembem-prefix", "vb-");
+  document.body.style.setProperty("--vb-prefix", "vb-");
   const data = cssVar("--background-color");
   expect(data).toBe("green");
 });
 
 test("should return a CSS custom property with an already appended prefix", () => {
-  document.body.style.setProperty("--vrembem-prefix", "vb-");
+  document.body.style.setProperty("--vb-prefix", "vb-");
   const data = cssVar("--vb-background-color");
   expect(data).toBe("green");
 });

--- a/packages/core/tests/cssVar.test.js
+++ b/packages/core/tests/cssVar.test.js
@@ -8,18 +8,22 @@ beforeEach(() => {
 });
 
 test("should return a CSS custom property", () => {
+  const data = cssVar("--background-color");
+  expect(data).toBe("pink");
+});
+
+test("should return a CSS custom property with no prefix defined", () => {
   const data = cssVar("background-color");
   expect(data).toBe("pink");
 });
 
-test("should return a CSS custom property using vrembem prefix", () => {
+test("should return a CSS custom property with vrembem prefix", () => {
   document.body.style.setProperty("--vb-prefix", "vb-");
-  const data = cssVar("--background-color");
+  const data = cssVar("background-color");
   expect(data).toBe("green");
 });
 
 test("should return a CSS custom property with an already appended prefix", () => {
-  document.body.style.setProperty("--vb-prefix", "vb-");
   const data = cssVar("--vb-background-color");
   expect(data).toBe("green");
 });

--- a/packages/core/tests/cssVar.test.js
+++ b/packages/core/tests/cssVar.test.js
@@ -8,7 +8,7 @@ beforeEach(() => {
 });
 
 test("should return a CSS custom property", () => {
-  const data = cssVar("--background-color");
+  const data = cssVar("background-color");
   expect(data).toBe("pink");
 });
 
@@ -25,6 +25,6 @@ test("should return a CSS custom property with an already appended prefix", () =
 });
 
 test("should throw an error if a CSS custom property is not found", () => {
-  const func = cssVar.bind(null, "--asdf");
+  const func = cssVar.bind(null, "asdf");
   expect(func).toThrow("CSS variable \"--asdf\" was not found!");
 });

--- a/packages/core/tests/getPrefix.test.js
+++ b/packages/core/tests/getPrefix.test.js
@@ -6,7 +6,7 @@ test("should return the vrembem prefix value", () => {
 });
 
 test("should return the vrembem prefix value", () => {
-  document.body.style.setProperty("--vrembem-prefix", "vb-");
+  document.body.style.setProperty("--vb-prefix", "vb-");
   const data = getPrefix();
   expect(data).toBe("vb-");
 });

--- a/packages/drawer/src/js/defaults.js
+++ b/packages/drawer/src/js/defaults.js
@@ -33,5 +33,5 @@ export default {
   storeKey: "VB:DrawerState",
   setTabindex: true,
   transition: true,
-  transitionDuration: "--vb-drawer-transition-duration"
+  transitionDuration: "drawer-transition-duration"
 };

--- a/packages/drawer/tests/accessibility.test.js
+++ b/packages/drawer/tests/accessibility.test.js
@@ -23,6 +23,7 @@ const dialog = document.querySelector(".drawer__dialog");
 const main = document.querySelector(".drawer-main");
 const btn = document.querySelector("[data-drawer-toggle]");
 
+document.body.style.setProperty("--vrembem-prefix", "vb-");
 el.style.setProperty("--vb-drawer-transition-duration", "0.3s");
 
 beforeEach(() => {

--- a/packages/drawer/tests/accessibility.test.js
+++ b/packages/drawer/tests/accessibility.test.js
@@ -23,7 +23,7 @@ const dialog = document.querySelector(".drawer__dialog");
 const main = document.querySelector(".drawer-main");
 const btn = document.querySelector("[data-drawer-toggle]");
 
-document.body.style.setProperty("--vrembem-prefix", "vb-");
+document.body.style.setProperty("--vb-prefix", "vb-");
 el.style.setProperty("--vb-drawer-transition-duration", "0.3s");
 
 beforeEach(() => {

--- a/packages/drawer/tests/handlers.test.js
+++ b/packages/drawer/tests/handlers.test.js
@@ -35,6 +35,7 @@ const btnClose = document.querySelector("[data-drawer-close=\"drawer\"]");
 const btnCloseInner = document.querySelector(".drawer [data-drawer-close]");
 const btnCloseEmpty = document.querySelector(".empty");
 
+document.body.style.setProperty("--vrembem-prefix", "vb-");
 drawerEl.style.setProperty("--vb-drawer-transition-duration", "0.3s");
 
 beforeAll(async () => {

--- a/packages/drawer/tests/handlers.test.js
+++ b/packages/drawer/tests/handlers.test.js
@@ -35,7 +35,7 @@ const btnClose = document.querySelector("[data-drawer-close=\"drawer\"]");
 const btnCloseInner = document.querySelector(".drawer [data-drawer-close]");
 const btnCloseEmpty = document.querySelector(".empty");
 
-document.body.style.setProperty("--vrembem-prefix", "vb-");
+document.body.style.setProperty("--vb-prefix", "vb-");
 drawerEl.style.setProperty("--vb-drawer-transition-duration", "0.3s");
 
 beforeAll(async () => {

--- a/packages/drawer/tests/helpers.test.js
+++ b/packages/drawer/tests/helpers.test.js
@@ -24,7 +24,7 @@ describe("getBreakpoint()", () => {
   beforeAll(() => {
     document.body.innerHTML = markup;
     document.body.style.setProperty("--breakpoint-lg", "800px");
-    document.body.style.setProperty("--vrembem-breakpoint-lg", "900px");
+    document.body.style.setProperty("--asdf-breakpoint-lg", "900px");
   });
 
   it("should return a fixed breakpoint value", () => {
@@ -46,7 +46,7 @@ describe("getBreakpoint()", () => {
   });
 
   it("should return a breakpoint from a CSS variable with prefix", () => {
-    document.body.style.setProperty("--vrembem-prefix", "vrembem-");
+    document.body.style.setProperty("--vb-prefix", "asdf-");
     const el = document.querySelector("#drawer-3");
     const result = getBreakpoint.call(mockObj, el);
     expect(result).toBe("900px");

--- a/packages/modal/src/js/defaults.js
+++ b/packages/modal/src/js/defaults.js
@@ -29,5 +29,5 @@ export default {
   teleportMethod: "append",
   setTabindex: true,
   transition: true,
-  transitionDuration: "--vb-modal-transition-duration"
+  transitionDuration: "modal-transition-duration"
 };

--- a/packages/modal/tests/api.test.js
+++ b/packages/modal/tests/api.test.js
@@ -191,7 +191,7 @@ describe("open() & close()", () => {
 
   beforeAll(async () => {
     document.body.innerHTML = markup;
-    document.querySelector("#modal-default").style.setProperty("--vb-modal-transition-duration", "0.3s");
+    document.querySelector("#modal-default").style.setProperty("--modal-transition-duration", "0.3s");
     modal = new Modal();
     await modal.init();
     el = document.querySelector(".modal");
@@ -279,7 +279,7 @@ describe("replace()", () => {
   beforeEach(() => {
     document.body.innerHTML = markupMulti;
     document.querySelectorAll(".modal").forEach((el) => {
-      el.style.setProperty("--vb-modal-transition-duration", "0.3s");
+      el.style.setProperty("--modal-transition-duration", "0.3s");
     });
     vi.useFakeTimers();
   });
@@ -372,7 +372,7 @@ describe("closeAll()", () => {
   beforeEach(() => {
     document.body.innerHTML = markupMulti;
     document.querySelectorAll(".modal").forEach((el) => {
-      el.style.setProperty("--vb-modal-transition-duration", "0.3s");
+      el.style.setProperty("--modal-transition-duration", "0.3s");
     });
     vi.useFakeTimers();
   });

--- a/packages/modal/tests/events.test.js
+++ b/packages/modal/tests/events.test.js
@@ -12,7 +12,7 @@ const markup = `
 
 beforeEach(() => {
   document.body.innerHTML = markup;
-  document.querySelector("#modal-default").style.setProperty("--vb-modal-transition-duration", "0.3s");
+  document.querySelector("#modal-default").style.setProperty("--modal-transition-duration", "0.3s");
   vi.useFakeTimers();
 });
 

--- a/packages/modal/tests/focus.test.js
+++ b/packages/modal/tests/focus.test.js
@@ -28,7 +28,7 @@ const markup = `
 beforeEach(() => {
   document.body.innerHTML = markup;
   document.querySelectorAll(".modal").forEach((el) => {
-    el.style.setProperty("--vb-modal-transition-duration", "0.3s");
+    el.style.setProperty("--modal-transition-duration", "0.3s");
   });
   vi.useFakeTimers();
 });

--- a/packages/modal/tests/handlers.test.js
+++ b/packages/modal/tests/handlers.test.js
@@ -11,7 +11,7 @@ const keySpace = new KeyboardEvent("keydown", {
 const markup = `
   <button data-modal-open="modal-default">...</button>
   <button data-modal-replace="modal-default">...</button>
-  <div id="modal-default" class="modal" style="--vb-modal-transition-duration: 300ms">
+  <div id="modal-default" class="modal" style="--modal-transition-duration: 300ms">
     <div class="modal__dialog">
       <button data-modal-close>...</button>
     </div>
@@ -20,7 +20,7 @@ const markup = `
 
 const markupReq = `
   <button data-modal-open="modal-default">...</button>
-  <div id="modal-default" class="modal" style="--vb-modal-transition-duration: 300ms">
+  <div id="modal-default" class="modal" style="--modal-transition-duration: 300ms">
     <div class="modal__dialog" role="alertdialog">
       <button data-modal-close data-focus>...</button>
     </div>

--- a/packages/modal/tests/inert.test.js
+++ b/packages/modal/tests/inert.test.js
@@ -22,7 +22,7 @@ describe("when selectorInert is set:", () => {
     });
     main = document.querySelector("main");
     el = document.querySelector("#modal-default");
-    el.style.setProperty("--vb-modal-transition-duration", "0.3s");
+    el.style.setProperty("--modal-transition-duration", "0.3s");
   });
 
   beforeEach(() => {

--- a/packages/modal/tests/transition.test.js
+++ b/packages/modal/tests/transition.test.js
@@ -3,7 +3,7 @@ import Modal from "../index";
 
 const markup = `
   <button data-modal-open="modal-default">Modal Default</button>
-  <div id="modal-default" class="modal is-closed" style="--vb-modal-transition-duration: 300ms">
+  <div id="modal-default" class="modal is-closed" style="--modal-transition-duration: 300ms">
     <div class="modal__dialog">
       <button data-modal-close>Close</button>
     </div>
@@ -12,7 +12,7 @@ const markup = `
 
 const markupCustomState = `
   <button data-modal-open="modal-default">Modal Default</button>
-  <div id="modal-default" class="modal off" style="--vb-modal-transition-duration: 300ms">
+  <div id="modal-default" class="modal off" style="--modal-transition-duration: 300ms">
     <div class="modal__dialog">
       <button data-modal-close>Close</button>
     </div>

--- a/packages/popover/tests/collection.test.js
+++ b/packages/popover/tests/collection.test.js
@@ -19,7 +19,7 @@ const markup = `
 `;
 
 beforeAll(() => {
-  document.body.style.setProperty("--vrembem-prefix", "vb-");
+  document.body.style.setProperty("--vb-prefix", "vb-");
 });
 
 afterEach(() => {


### PR DESCRIPTION
## What changed?

This PR refactors the `cssVar()` function so that it no longer requires the passed property name to include the `--`. If the property name is passed without double dashes, it will be prefixed using `--vb-prefix` as well as have the `--` added. This allows passing a custom CSS variable property name that won't be modified as well a one that will get automatically prefixed. Here's an example of this logic:

- Passing `--background` will return the value of `--background`.
- Passing `background` will return the value of `--vb-background`.
- Passing `background` with no prefix variable set will return the value of `--background`.

The `prefix` parameter has been removed from `cssVar()` since this new logic makes that option redundant. The value of `vb-` previously came from the custom property `--vrembem-prefix`. This has been renamed to `--vb-prefix`, its value can be set in the core module `prefix.$variable`.

Fixes #1860