### PR TITLE
Rename init and destroy methods to mount and unmount

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you'd like to use Vrembem for prototyping or just want to take it for a test 
 <!-- Instantiate the component rendered in the document -->
 <script>
   const modal = new vrembem.Modal();
-  modal.init();
+  modal.mount();
 </script>
 ```
 
@@ -115,21 +115,21 @@ Vrembem uses [Sass' module system](https://sass-lang.com/blog/the-module-system-
 
 #### JavaScript
 
-Some packages also have included modules for their functionality. You can include these in your JavaScript files by importing, instantiate and initialize:
+Some packages also have included modules for their functionality. You can include these in your JavaScript files by importing the modules you'll need then instantiate and mount them:
 
 ```js
 // Import your component
 import Modal from "@vrembem/modal";
 
-// Instantiate and initialize
+// Instantiate and mount
 const modal = new Modal();
-modal.init();
+modal.mount();
 ```
 
-Alternatively, you can use the `autoInit` option to auto initialize and optionally omit saving the instance to a variable if the returned API won't be needed later.
+Alternatively, you can use the `autoMount` option to auto mount and optionally omit saving the instance to a variable if the returned API won't be needed later.
 
 ```js
-new Modal({ autoInit: true });
+new Modal({ autoMount: true });
 ```
 
 #### HTML
@@ -175,14 +175,12 @@ Via your project's JavaScript manifest file:
 ```js
 // Import all under the vb namespace
 import * as vb from "vrembem";
-const drawer = new vb.Drawer({ autoInit: true });
+const drawer = new vb.Drawer({ autoMount: true });
 
 // Or import individual components
 import { Drawer } from "vrembem";
-const drawer = new Drawer({ autoInit: true });
+const drawer = new Drawer({ autoMount: true });
 ```
-
-> Note that `core` helpers do not need to be initialized since they're just a set of helpful utility functions.
 
 ## Copyright and License
 

--- a/docs/src/content/packages/drawer.mdx
+++ b/docs/src/content/packages/drawer.mdx
@@ -25,7 +25,7 @@ npm install @vrembem/drawer
 <CodeExample lang="js">
   ```js
   import Drawer from "@vrembem/drawer";
-  const drawer = new Drawer({ autoInit: true });
+  const drawer = new Drawer({ autoMount: true });
   ```
 </CodeExample>
 
@@ -341,7 +341,7 @@ Here's an example where we want the `drawer-main` content area to be inaccessibl
      selectorOverflow: "body, .drawer-main"
    });
 
-   await drawer.init();
+   await drawer.mount();
    ```
 </CodeExample>
 
@@ -461,7 +461,7 @@ Drawers are primarily customized using CSS variables but can also be modified us
 
   ```js
   export default {
-    autoInit: false,
+    autoMount: false,
 
     // Data attributes
     dataOpen: "drawer-open",
@@ -533,7 +533,7 @@ After the drawer component has been instantiated the drawer object is returned w
   Returns the currently active modal drawer. Returns `undefined` if there are no modal drawer open.
 </DocBlock>
 
-<DocBlock name="drawer.init" type="method" returns="Object" src="drawer/src/js/index.js" line="35" args={[
+<DocBlock name="drawer.mount" type="method" returns="Object" src="drawer/src/js/index.js" line="35" args={[
   ["options", "Object (optional)", "An options object for passing custom settings."]
 ]}>
   Initializes the drawer instance. During initialization, the following processes are run:
@@ -544,48 +544,48 @@ After the drawer component has been instantiated the drawer object is returned w
   <Fragment slot="example">
     ```js
     const drawer = new Drawer();
-    await drawer.init();
+    await drawer.mount();
     ```
   </Fragment>
 </DocBlock>
 
-<DocBlock name="drawer.destroy" type="method" returns="Object" src="drawer/src/js/index.js" line="53">
+<DocBlock name="drawer.unmount" type="method" returns="Object" src="drawer/src/js/index.js" line="53">
   Destroys and cleans up the drawer initialization. During cleanup, the following processes are run:
 
   - Deregister the drawer collection by running `deregisterCollection()`.
-  - Removes global event listeners by running `destroyEventListeners()`.
+  - Removes global event listeners by running `unmountEventListeners()`.
 
   <Fragment slot="example">
     ```js
     const drawer = new Drawer();
-    await drawer.init();
+    await drawer.mount();
     // ...
-    await drawer.destroy();
+    await drawer.unmount();
     ```
   </Fragment>
 </DocBlock>
 
-<DocBlock name="drawer.initEventListeners" type="method" returns="Object" src="drawer/src/js/index.js" line="65">
+<DocBlock name="drawer.mountEventListeners" type="method" returns="Object" src="drawer/src/js/index.js" line="65">
   Set document event listeners.
 
   <Fragment slot="example">
     ```js
     const drawer = new Drawer({ eventListeners: false });
-    await drawer.init();
-    drawer.initEventListeners();
+    await drawer.mount();
+    drawer.mountEventListeners();
     ```
   </Fragment>
 </DocBlock>
 
-<DocBlock name="drawer.destroyEventListeners" type="method" returns="Object" src="drawer/src/js/index.js" line="70">
+<DocBlock name="drawer.unmountEventListeners" type="method" returns="Object" src="drawer/src/js/index.js" line="70">
   Remove document event listeners.
 
   <Fragment slot="example">
     ```js
     const drawer = new Drawer();
-    await drawer.init();
+    await drawer.mount();
     // ...
-    drawer.destroyEventListeners();
+    drawer.unmountEventListeners();
     ```
   </Fragment>
 </DocBlock>

--- a/docs/src/content/packages/modal.mdx
+++ b/docs/src/content/packages/modal.mdx
@@ -26,7 +26,7 @@ npm install @vrembem/modal
 <CodeExample lang="js">
   ```js
   import Modal from "@vrembem/modal";
-  const modal = new Modal({ autoInit: true });
+  const modal = new Modal({ autoMount: true });
   ```
 </CodeExample>
 
@@ -218,7 +218,7 @@ Here's an example where we want the `<main>` content area to be inaccessible whi
     teleportMethod: "after"
   });
 
-  await modal.init();
+  await modal.mount();
   ```
 </CodeExample>
 
@@ -559,7 +559,7 @@ Modals are primarily customized using CSS variables but can also be modified usi
 
   ```js
   export default {
-    autoInit: false,
+    autoMount: false,
 
     // Data attributes
     dataOpen: "modal-open",
@@ -628,7 +628,7 @@ After the modal component has been instantiated the modal object is returned wit
   Returns the currently active modal or the modal at the top of the stack if multiple modals are open. Will return `undefined` if no modals are open.
 </DocBlock>
 
-<DocBlock name="modal.init" type="method" returns="Object" src="modal/src/js/index.js" line="37" args={[
+<DocBlock name="modal.mount" type="method" returns="Object" src="modal/src/js/index.js" line="37" args={[
   ["options", "Object (optional)", "An options object for passing custom settings."]
 ]}>
   Initializes the modal instance. During initialization, the following processes are run:
@@ -639,48 +639,48 @@ After the modal component has been instantiated the modal object is returned wit
   <Fragment slot="example">
     ```js
     const modal = new Modal();
-    await modal.init();
+    await modal.mount();
     ```
   </Fragment>
 </DocBlock>
 
-<DocBlock name="modal.destroy" type="method" returns="Object" src="modal/src/js/index.js" line="55">
+<DocBlock name="modal.unmount" type="method" returns="Object" src="modal/src/js/index.js" line="55">
   Destroys and cleans up the modal initialization. During cleanup, the following processes are run:
 
   - Deregister the modal collection by running `deregisterCollection()`.
-  - Removes global event listeners by running `destroyEventListeners()`.
+  - Removes global event listeners by running `unmountEventListeners()`.
 
   <Fragment slot="example">
     ```js
     const modal = new Modal();
-    await modal.init();
+    await modal.mount();
     // ...
-    await modal.destroy();
+    await modal.unmount();
     ```
   </Fragment>
 </DocBlock>
 
-<DocBlock name="modal.initEventListeners" type="method" returns="Object" src="modal/src/js/index.js" line="70">
+<DocBlock name="modal.mountEventListeners" type="method" returns="Object" src="modal/src/js/index.js" line="70">
   Set document event listeners.
 
   <Fragment slot="example">
     ```js
     const modal = new Modal({ eventListeners: false });
-    await modal.init();
-    modal.initEventListeners();
+    await modal.mount();
+    modal.mountEventListeners();
     ```
   </Fragment>
 </DocBlock>
 
-<DocBlock name="modal.destroyEventListeners" type="method" returns="Object" src="modal/src/js/index.js" line="75">
+<DocBlock name="modal.unmountEventListeners" type="method" returns="Object" src="modal/src/js/index.js" line="75">
   Remove document event listeners.
 
   <Fragment slot="example">
     ```js
     const modal = new Modal();
-    await modal.init();
+    await modal.mount();
     // ...
-    modal.destroyEventListeners();
+    modal.unmountEventListeners();
     ```
   </Fragment>
 </DocBlock>

--- a/docs/src/content/packages/popover.mdx
+++ b/docs/src/content/packages/popover.mdx
@@ -26,7 +26,7 @@ npm install @vrembem/popover
 <CodeExample lang="js">
   ```js
   import Popover from "@vrembem/popover";
-  const popover = new Popover({ autoInit: true });
+  const popover = new Popover({ autoMount: true });
   ```
 </CodeExample>
 
@@ -81,7 +81,7 @@ There are two event types that can trigger a popover: `click` (the default) and 
   });
 
   // Set on initialization
-  popover.init({
+  popover.mount({
     eventType: "hover"
   });
   ```
@@ -116,7 +116,7 @@ Popover uses the [Popper JS positioning engine](https://popper.js.org/) to deter
   });
 
   // Set on initialization
-  popover.init({
+  popover.mount({
     placement: "bottom"
   });
   ```
@@ -331,7 +331,7 @@ Popovers are primarily customized using CSS variables but can also be modified u
 
   ```js
   export default {
-    autoInit: false,
+    autoMount: false,
 
     // Selectors
     selectorPopover: ".popover",
@@ -370,7 +370,7 @@ After the popover component has been instantiated the popover object is returned
   ```
 </DocBlock>
 
-<DocBlock name="popover.init" type="method" returns="Object" src="popover/src/js/index.js" line="23" args={[
+<DocBlock name="popover.mount" type="method" returns="Object" src="popover/src/js/index.js" line="23" args={[
   ["options", "Object (optional)", "An options object for passing custom settings."]
 ]}>
   Initializes the popover instance. During initialization, the following processes are run:
@@ -381,28 +381,28 @@ After the popover component has been instantiated the popover object is returned
   <Fragment slot="example">
     ```js
     const popover = new Popover();
-    await popover.init();
+    await popover.mount();
     ```
   </Fragment>
 </DocBlock>
 
-<DocBlock name="popover.destroy" type="method" returns="Object" src="popover/src/js/index.js" line="43">
+<DocBlock name="popover.unmount" type="method" returns="Object" src="popover/src/js/index.js" line="43">
   Destroys and cleans up the popover initialization. During cleanup, the following processes are run:
 
   - Deregister the popover collection by running `deregisterCollection()`
-  - Removes global event listeners by running `destroyEventListeners()`
+  - Removes global event listeners by running `unmountEventListeners()`
 
   <Fragment slot="example">
     ```js
     const popover = new Popover();
-    await popover.init();
+    await popover.mount();
     // ...
-    await popover.destroy();
+    await popover.unmount();
     ```
   </Fragment>
 </DocBlock>
 
-<DocBlock name="popover.initEventListeners" type="method" returns="Object" src="popover/src/js/index.js" line="60" args={[
+<DocBlock name="popover.mountEventListeners" type="method" returns="Object" src="popover/src/js/index.js" line="60" args={[
   ["processCollection", "Boolean", "Whether or not to process the event listeners of popover collection. Defaults to true."]
 ]}>
   Set document and collection entry event listeners.
@@ -410,13 +410,13 @@ After the popover component has been instantiated the popover object is returned
   <Fragment slot="example">
     ```js
     const popover = new Popover({ eventListeners: false });
-    await popover.init();
-    popover.initEventListeners();
+    await popover.mount();
+    popover.mountEventListeners();
     ```
   </Fragment>
 </DocBlock>
 
-<DocBlock name="popover.destroyEventListeners" type="method" returns="Object" src="popover/src/js/index.js" line="72" args={[
+<DocBlock name="popover.unmountEventListeners" type="method" returns="Object" src="popover/src/js/index.js" line="72" args={[
   ["processCollection", "Boolean", "Whether or not to process the event listeners of popover collection. Defaults to true."]
 ]}>
   Remove document and collection entry event listeners.
@@ -424,9 +424,9 @@ After the popover component has been instantiated the popover object is returned
   <Fragment slot="example">
     ```js
     const popover = new Popover();
-    await popover.init();
+    await popover.mount();
     // ...
-    popover.destroyEventListeners();
+    popover.unmountEventListeners();
     ```
   </Fragment>
 </DocBlock>

--- a/docs/src/modules/useDrawer.js
+++ b/docs/src/modules/useDrawer.js
@@ -3,7 +3,7 @@ let drawer = null;
 
 if (typeof window !== "undefined") {
   drawer = new Drawer();
-  window["drawer"] = await drawer.init();
+  window["drawer"] = await drawer.mount();
 }
 
 export { drawer };

--- a/docs/src/modules/useModal.js
+++ b/docs/src/modules/useModal.js
@@ -6,7 +6,7 @@ if (typeof window !== "undefined") {
     selectorInert: "main",
     teleport: ".modals"
   });
-  window["modal"] = await modal.init();
+  window["modal"] = await modal.mount();
 }
 
 export { modal };

--- a/docs/src/modules/usePopover.js
+++ b/docs/src/modules/usePopover.js
@@ -3,7 +3,7 @@ let popover = null;
 
 if (typeof window !== "undefined") {
   popover = new Popover();
-  window["popover"] = await popover.init();
+  window["popover"] = await popover.mount();
 }
 
 export { popover };

--- a/docs/src/pages/getting-started.mdx
+++ b/docs/src/pages/getting-started.mdx
@@ -37,7 +37,7 @@ If you'd like to use Vrembem for prototyping or just want to take it for a test 
 <!-- Instantiate the component rendered in the document -->
 <script>
   const modal = new vrembem.Modal();
-  modal.init();
+  modal.mount();
 </script>
 ```
 
@@ -109,21 +109,21 @@ Vrembem uses [Sass' module system](https://sass-lang.com/blog/the-module-system-
 
 ### JavaScript
 
-Some packages also have included modules for their functionality. You can include these in your JavaScript files by importing, instantiate and initialize:
+Some packages also have included modules for their functionality. You can include these in your JavaScript files by importing the modules you'll need then instantiate and mount them:
 
 ```js
-// Import your component
+// Import your component.
 import Modal from "@vrembem/modal";
 
-// Instantiate and initialize
+// Instantiate and mount.
 const modal = new Modal();
-modal.init();
+modal.mount();
 ```
 
-Alternatively, you can use the `autoInit` option to auto initialize and optionally omit saving the instance to a variable if the returned API won't be needed later.
+Alternatively, you can use the `autoMount` option to auto mount and optionally omit saving the instance to a variable if the returned API won't be needed later.
 
 ```js
-new Modal({ autoInit: true });
+new Modal({ autoMount: true });
 ```
 
 ### HTML
@@ -169,12 +169,9 @@ Via your project's JavaScript manifest file:
 ```js
 // Import all under the vb namespace
 import * as vb from "vrembem";
-const drawer = new vb.Drawer({ autoInit: true });
+const drawer = new vb.Drawer({ autoMount: true });
 
 // Or import individual components
 import { Drawer } from "vrembem";
-const drawer = new Drawer({ autoInit: true });
+const drawer = new Drawer({ autoMount: true });
 ```
-
-> Note that `core` helpers do not need to be initialized since they're just a set of helpful utility functions.
-

--- a/packages/core/src/js/updateGlobalState.js
+++ b/packages/core/src/js/updateGlobalState.js
@@ -26,10 +26,7 @@ function setInert(state, selector) {
   }
 }
 
-export function updateGlobalState(param, config) {
-  // Set inert state based on if a modal is active.
-  setInert(!!param, config.selectorInert);
-
-  // Set overflow state based on if a modal is active.
-  setOverflowHidden(!!param, config.selectorOverflow);
+export function updateGlobalState(state, config) {
+  setInert(!!state, config.selectorInert);
+  setOverflowHidden(!!state, config.selectorOverflow);
 }

--- a/packages/drawer/README.md
+++ b/packages/drawer/README.md
@@ -20,5 +20,5 @@ npm install @vrembem/drawer
 
 ```js
 import Drawer from '@vrembem/drawer';
-const drawer = new Drawer({ autoInit: true });
+const drawer = new Drawer({ autoMount: true });
 ```

--- a/packages/drawer/index.html
+++ b/packages/drawer/index.html
@@ -83,7 +83,7 @@
 
     // Init and attach instance to window
     const drawer = new Drawer();
-    window.drawer = await drawer.init({
+    window.drawer = await drawer.mount({
       selectorInert: '.drawer-main'
     });
 

--- a/packages/drawer/src/js/defaults.js
+++ b/packages/drawer/src/js/defaults.js
@@ -1,5 +1,5 @@
 export default {
-  autoInit: false,
+  autoMount: false,
 
   // Data attributes
   dataOpen: "drawer-open",

--- a/packages/drawer/src/js/index.js
+++ b/packages/drawer/src/js/index.js
@@ -23,7 +23,7 @@ export default class Drawer extends Collection {
 
     this.#handleClick = handleClick.bind(this);
     this.#handleKeydown = handleKeydown.bind(this);
-    if (this.settings.autoInit) this.init();
+    if (this.settings.autoMount) this.mount();
   }
 
   get activeModal() {
@@ -32,7 +32,7 @@ export default class Drawer extends Collection {
     });
   }
 
-  async init(options = null) {
+  async mount(options = null) {
     // Update settings with passed options.
     if (options) this.settings = { ...this.settings, ...options };
 
@@ -42,32 +42,32 @@ export default class Drawer extends Collection {
     // Register the collections array with modal instances.
     await this.registerCollection(drawers);
 
-    // If eventListeners are enabled, init event listeners.
+    // If eventListeners are enabled, mount event listeners.
     if (this.settings.eventListeners) {
-      this.initEventListeners();
+      this.mountEventListeners();
     }
 
     return this;
   }
 
-  async destroy() {
+  async unmount() {
     // Remove all entries from the collection.
     await this.deregisterCollection();
 
-    // If eventListeners are enabled, init event listeners.
+    // If eventListeners are enabled, unmount event listeners.
     if (this.settings.eventListeners) {
-      this.destroyEventListeners();
+      this.unmountEventListeners();
     }
 
     return this;
   }
 
-  initEventListeners() {
+  mountEventListeners() {
     document.addEventListener("click", this.#handleClick, false);
     document.addEventListener("keydown", this.#handleKeydown, false);
   }
 
-  destroyEventListeners() {
+  unmountEventListeners() {
     document.removeEventListener("click", this.#handleClick, false);
     document.removeEventListener("keydown", this.#handleKeydown, false);
   }

--- a/packages/drawer/tests/accessibility.test.js
+++ b/packages/drawer/tests/accessibility.test.js
@@ -34,7 +34,7 @@ test("should set accessibility attributes to modal drawer dialog", async () => {
   expect(dialog.getAttribute("aria-modal")).toBe(null);
   expect(dialog.getAttribute("tabindex")).toBe(null);
 
-  await drawer.init();
+  await drawer.mount();
 
   expect(dialog.getAttribute("aria-modal")).toBe("true");
   expect(dialog.getAttribute("tabindex")).toBe("-1");

--- a/packages/drawer/tests/api.test.js
+++ b/packages/drawer/tests/api.test.js
@@ -49,29 +49,29 @@ const markupConfig = `
 document.body.innerHTML = markup;
 
 const drawer = new Drawer({ transitionDuration: 300 });
-const drawerAuto = new Drawer({ autoInit: true, transitionDuration: 300 });
+const drawerAuto = new Drawer({ autoMount: true, transitionDuration: 300 });
 
-describe("init() & destroy()", () => {
-  it("should correctly register all drawers on init()", async () => {
-    await drawer.init();
+describe("mount() & unmount()", () => {
+  it("should correctly register all drawers on mount()", async () => {
+    await drawer.mount();
     expect(drawer.collection.length).toBe(2);
   });
 
-  it("should correctly deregister all drawers on destroy()", async () => {
-    await drawer.destroy();
+  it("should correctly deregister all drawers on unmount()", async () => {
+    await drawer.unmount();
     expect(drawer.collection.length).toBe(0);
   });
 
-  it("should initialize with custom settings passed on init", async () => {
-    await drawer.init({ eventListeners: false });
+  it("should mount with custom settings passed on init", async () => {
+    await drawer.mount({ eventListeners: false });
     expect(drawer.collection.length).toBe(2);
     expect(drawer.defaults.eventListeners).toBe(true);
     expect(drawer.settings.eventListeners).toBe(false);
-    await drawer.destroy();
+    await drawer.unmount();
     expect(drawer.collection.length).toBe(0);
   });
 
-  it("should automatically initialize when autoInit option set to true", () => {
+  it("should automatically mount when autoMount option set to true", () => {
     expect(drawerAuto.collection.length).toBe(2);
   });
 });
@@ -95,7 +95,7 @@ describe("open(), close() & toggle()", () => {
   });
 
   it("should open and close using open() and close() methods", async () => {
-    await drawer.init();
+    await drawer.mount();
     const entry = drawer.get("drawer-1");
     expect(entry.state).toBe("closed");
     expect(entry.mode).toBe("inline");
@@ -171,7 +171,7 @@ describe("activeModal", () => {
 describe("register() & deregister()", () => {
   beforeAll(async () => {
     document.body.innerHTML = markupInitState;
-    await drawer.destroy();
+    await drawer.unmount();
   });
 
   it("should disable setting tabindex on drawer dialog", async () => {
@@ -252,7 +252,7 @@ describe("register() & deregister()", () => {
 describe("data-drawer-config", () => {
   beforeAll(async () => {
     document.body.innerHTML = markupInitState;
-    await drawer.destroy();
+    await drawer.unmount();
   });
 
   it("should override global drawer configs using drawer specific data configuration", async () => {

--- a/packages/drawer/tests/handlers.test.js
+++ b/packages/drawer/tests/handlers.test.js
@@ -39,7 +39,7 @@ document.body.style.setProperty("--vb-prefix", "vb-");
 drawerEl.style.setProperty("--vb-drawer-transition-duration", "0.3s");
 
 beforeAll(async () => {
-  await drawer.init();
+  await drawer.mount();
   entry = drawer.get("drawer");
 });
 

--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -20,5 +20,5 @@ npm install @vrembem/modal
 
 ```js
 import Modal from '@vrembem/modal';
-const modal = new Modal({ autoInit: true });
+const modal = new Modal({ autoMount: true });
 ```

--- a/packages/modal/index.html
+++ b/packages/modal/index.html
@@ -309,7 +309,7 @@
       selectorInert: 'main',
       teleport: '.modals'
     });
-    window.modal = await modal.init();
+    window.modal = await modal.mount();
 
     // Post message to console
     console.log('Modal instance has been attached to window:', modal);

--- a/packages/modal/src/js/defaults.js
+++ b/packages/modal/src/js/defaults.js
@@ -1,5 +1,5 @@
 export default {
-  autoInit: false,
+  autoMount: false,
 
   // Data attributes
   dataOpen: "modal-open",

--- a/packages/modal/src/js/index.js
+++ b/packages/modal/src/js/index.js
@@ -27,14 +27,14 @@ export default class Modal extends Collection {
 
     this.#handleClick = handleClick.bind(this);
     this.#handleKeydown = handleKeydown.bind(this);
-    if (this.settings.autoInit) this.init();
+    if (this.settings.autoMount) this.mount();
   }
 
   get active() {
     return this.stack.top;
   }
 
-  async init(options) {
+  async mount(options) {
     // Update settings with passed options.
     if (options) this.settings = { ...this.settings, ...options };
 
@@ -44,35 +44,35 @@ export default class Modal extends Collection {
     // Register the collections array with modal instances.
     await this.registerCollection(modals);
 
-    // If eventListeners are enabled, init event listeners.
+    // If eventListeners are enabled, mount event listeners.
     if (this.settings.eventListeners) {
-      this.initEventListeners();
+      this.mountEventListeners();
     }
 
     return this;
   }
 
-  async destroy() {
+  async unmount() {
     // Clear stored trigger.
     this.trigger = null;
 
     // Remove all entries from the collection.
     await this.deregisterCollection();
 
-    // If eventListeners are enabled, destroy event listeners.
+    // If eventListeners are enabled, unmount event listeners.
     if (this.settings.eventListeners) {
-      this.destroyEventListeners();
+      this.unmountEventListeners();
     }
 
     return this;
   }
 
-  initEventListeners() {
+  mountEventListeners() {
     document.addEventListener("click", this.#handleClick, false);
     document.addEventListener("keydown", this.#handleKeydown, false);
   }
 
-  destroyEventListeners() {
+  unmountEventListeners() {
     document.removeEventListener("click", this.#handleClick, false);
     document.removeEventListener("keydown", this.#handleKeydown, false);
   }

--- a/packages/modal/tests/api.test.js
+++ b/packages/modal/tests/api.test.js
@@ -39,7 +39,7 @@ const markupPreOpened = `
   <div class="modals"></div>
 `;
 
-describe("init() & destroy()", () => {
+describe("mount() & unmount()", () => {
   let modal, entry, el, btnOpen;
 
   beforeAll(() => {
@@ -49,25 +49,25 @@ describe("init() & destroy()", () => {
     btnOpen = document.querySelector("[data-modal-open]");
   });
 
-  it("should initialize the modal instance", async () => {
-    await modal.init({ transition: false });
+  it("should mount the modal instance", async () => {
+    await modal.mount({ transition: false });
     entry = modal.get("modal-default");
     btnOpen.click();
     expect(entry.state).toBe("opened");
     expect(entry.el).toHaveClass("is-opened");
   });
 
-  it("should destroy the modal instance", async () => {
-    await modal.destroy();
+  it("should unmount the modal instance", async () => {
+    await modal.unmount();
     expect(modal.collection.length).toBe(0);
     expect(el).toHaveClass("is-closed");
     btnOpen.click();
     expect(el).toHaveClass("is-closed");
   });
 
-  it("should initialize the modal instance with event listeners disabled", async () => {
-    const spy = vi.spyOn(modal, "initEventListeners");
-    await modal.init({
+  it("should mount the modal instance with event listeners disabled", async () => {
+    const spy = vi.spyOn(modal, "mountEventListeners");
+    await modal.mount({
       eventListeners: false,
       transition: false
     });
@@ -75,15 +75,15 @@ describe("init() & destroy()", () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it("should destroy the modal instance with event listeners disabled", async () => {
-    const spy = vi.spyOn(modal, "destroyEventListeners");
-    expect(modal.settings.eventListeners).toBe(false);
-    await modal.destroy();
+  it("should unmount the modal instance with event listeners disabled", async () => {
+    const spy = vi.spyOn(modal, "unmountEventListeners");
+    expect(modal.settings.eventListeners).toBe(false); 
+    await modal.unmount();
     expect(spy).not.toHaveBeenCalled();
   });
 });
 
-describe("initEventListeners() & destroyEventListeners()", () => {
+describe("mountEventListeners() & unmountEventListeners()", () => {
   let modal, entry, btnOpen, btnClose;
 
   beforeAll(async () => {
@@ -92,21 +92,21 @@ describe("initEventListeners() & destroyEventListeners()", () => {
       eventListeners: false,
       transition: false
     });
-    await modal.init();
+    await modal.mount();
     entry = modal.get("modal-default");
     btnOpen = document.querySelector("[data-modal-open]");
     btnClose = document.querySelector("[data-modal-close]");
   });
 
-  it("should initialize event listeners", async () => {
-    modal.initEventListeners();
+  it("should mount event listeners", async () => {
+    modal.mountEventListeners();
     btnOpen.click();
     expect(entry.state).toBe("opened");
     expect(entry.el).toHaveClass("is-opened");
   });
 
-  it("should destroy event listeners", async () => {
-    modal.destroyEventListeners();
+  it("should unmount event listeners", async () => {
+    modal.unmountEventListeners();
     btnClose.click();
     expect(entry.state).toBe("opened");
     expect(entry.el).toHaveClass("is-opened");
@@ -160,7 +160,7 @@ describe("register() & deregister()", () => {
       selectorOverflow: "body, main",
       teleport: ".modals"
     });
-    await modal.init();
+    await modal.mount();
     expect(document.body.style.overflow).toBe("hidden");
     expect(main).toHaveAttribute("aria-hidden", "true");
     expect(main.inert).toBe(true);
@@ -171,7 +171,7 @@ describe("register() & deregister()", () => {
   it("re-registering a modal that is already open should retain the open state", async () => {
     document.body.innerHTML = markupPreOpened;
     modal = new Modal({ teleport: ".modals" });
-    await modal.init();
+    await modal.mount();
     await modal.open("modal-default");
     expect(modal.active.id).toBe("modal-default");
     await modal.register("modal-default");
@@ -193,7 +193,7 @@ describe("open() & close()", () => {
     document.body.innerHTML = markup;
     document.querySelector("#modal-default").style.setProperty("--modal-transition-duration", "0.3s");
     modal = new Modal();
-    await modal.init();
+    await modal.mount();
     el = document.querySelector(".modal");
     entry = modal.get("modal-default");
   });
@@ -286,7 +286,7 @@ describe("replace()", () => {
 
   it("should close a modal and open a new one simultaneously", async () => {
     const modal = new Modal();
-    await modal.init();
+    await modal.mount();
 
     let entry = modal.get("modal-1");
 
@@ -311,7 +311,7 @@ describe("replace()", () => {
 
   it("should close all open modals except for the replacement", async () => {
     const modal = new Modal();
-    await modal.init();
+    await modal.mount();
 
     modal.open("modal-1");
     modal.open("modal-2");
@@ -343,7 +343,7 @@ describe("replace()", () => {
 
   it("should correctly handle focus management when focus param is passed", async () => {
     const modal = new Modal({ transition: false });
-    await modal.init();
+    await modal.mount();
 
     const entry = modal.get("modal-2");
 
@@ -379,7 +379,7 @@ describe("closeAll()", () => {
 
   it("should close all open modals", async () => {
     const modal = new Modal();
-    await modal.init();
+    await modal.mount();
 
     modal.open("modal-1");
     modal.open("modal-2");
@@ -415,7 +415,7 @@ describe("closeAll()", () => {
 
   it("should return focus to stored trigger when all modals are closed", async () => {
     const modal = new Modal({ transition: false });
-    await modal.init();
+    await modal.mount();
 
     const btn = document.querySelector("button");
     modal.trigger = btn;
@@ -436,7 +436,7 @@ describe("closeAll()", () => {
 
   it("should not handle focus when param is set to false", async () => {
     const modal = new Modal({ transition: false });
-    await modal.init();
+    await modal.mount();
 
     const btn = document.querySelector("button");
     modal.trigger = btn;

--- a/packages/modal/tests/collection.test.js
+++ b/packages/modal/tests/collection.test.js
@@ -65,7 +65,7 @@ describe("entry.open() & entry.close() & entry.replace()", () => {
   beforeAll(async () => {
     document.body.innerHTML = markup;
     modal = new Modal({ transition: false });
-    await modal.init();
+    await modal.mount();
   });
 
   it("should open modal with transitions disabled", async () => {

--- a/packages/modal/tests/events.test.js
+++ b/packages/modal/tests/events.test.js
@@ -18,7 +18,7 @@ beforeEach(() => {
 
 test("should emit custom event when modal has opened", async () => {
   const modal = new Modal();
-  await modal.init();
+  await modal.mount();
   const el = document.querySelector("#modal-default");
   const btn = document.querySelector("[data-modal-open]");
   let eventFired = false;
@@ -36,7 +36,7 @@ test("should emit custom event when modal has opened", async () => {
 
 test("should emit custom event when modal has closed", async () => {
   const modal = new Modal();
-  await modal.init();
+  await modal.mount();
   const el = document.querySelector("#modal-default");
   const btn = document.querySelector("[data-modal-open]");
   const btnClose = document.querySelector("[data-modal-close]");
@@ -63,7 +63,7 @@ test("should be able to set a custom event prefix", async () => {
   const modal = new Modal({
     customEventPrefix: "vrembem:"
   });
-  await modal.init();
+  await modal.mount();
   const btn = document.querySelector("[data-modal-open]");
   const btnClose = document.querySelector("[data-modal-close]");
   let eventOpened = false;

--- a/packages/modal/tests/focus.test.js
+++ b/packages/modal/tests/focus.test.js
@@ -35,7 +35,7 @@ beforeEach(() => {
 
 test("should focus modal dialog when opened and refocus trigger when closed", async () => {
   const modal = new Modal();
-  await modal.init();
+  await modal.mount();
   const el = document.querySelector("#modal-one");
   const dialog = el.querySelector(".modal__dialog");
   const btnOpen = document.querySelector("[data-modal-open=\"modal-one\"]");
@@ -47,7 +47,7 @@ test("should focus modal dialog when opened and refocus trigger when closed", as
 
 test("should focus inner modal element and refocus trigger when closed", async () => {
   const modal = new Modal();
-  await modal.init();
+  await modal.mount();
   const el = document.querySelector("#modal-two");
   const btnOpen = document.querySelector("[data-modal-open=\"modal-two\"]");
   const btnClose = el.querySelector("[data-modal-close]");
@@ -63,7 +63,7 @@ test("should focus inner modal element and refocus trigger when closed", async (
 
 test("should remember initial trigger when opening modal through another modal", async () => {
   const modal = new Modal();
-  await modal.init();
+  await modal.mount();
   const elOne = document.querySelector("#modal-one");
   const elTwo = document.querySelector("#modal-two");
   const btnOpen = document.querySelector("[data-modal-open=\"modal-one\"]");
@@ -85,7 +85,7 @@ test("should remember initial trigger when opening modal through another modal",
 
 test("should retain focus on modal if nothing inner is focusable", async () => {
   const modal = new Modal();
-  await modal.init();
+  await modal.mount();
   const elModal = document.querySelector("#modal-empty");
   const dialog = elModal.querySelector(".modal__dialog");
   modal.open("modal-empty");

--- a/packages/modal/tests/handlers.test.js
+++ b/packages/modal/tests/handlers.test.js
@@ -34,7 +34,7 @@ beforeEach(() => {
 test("should close when root modal (screen) is clicked", async () => {
   document.body.innerHTML = markup;
   const modal = new Modal();
-  await modal.init();
+  await modal.mount();
   const el = document.querySelector(".modal");
   const dialog = document.querySelector(".modal__dialog");
   const btnOpen = document.querySelector("[data-modal-open]");
@@ -59,7 +59,7 @@ test("should close when root modal (screen) is clicked", async () => {
 test("should close when the escape key is pressed", async () => {
   document.body.innerHTML = markup;
   const modal = new Modal();
-  await modal.init();
+  await modal.mount();
   const el = document.querySelector(".modal");
   const btnOpen = document.querySelector("[data-modal-open]");
 
@@ -80,7 +80,7 @@ test("should close when the escape key is pressed", async () => {
 test("should do nothing if none escape key is pressed", async () => {
   document.body.innerHTML = markup;
   const modal = new Modal();
-  await modal.init();
+  await modal.mount();
   const el = document.querySelector(".modal");
   const btnOpen = document.querySelector("[data-modal-open]");
 
@@ -101,7 +101,7 @@ test("should do nothing if none escape key is pressed", async () => {
 test("should not be able to close while modal transition is in process", async () => {
   document.body.innerHTML = markup;
   const modal = new Modal();
-  await modal.init();
+  await modal.mount();
   const el = document.querySelector(".modal");
   const btnOpen = document.querySelector("[data-modal-open]");
 
@@ -119,7 +119,7 @@ test("should not be able to close while modal transition is in process", async (
 test("should prevent escape or screen click closing modal if required", async () => {
   document.body.innerHTML = markupReq;
   const modal = new Modal();
-  await modal.init();
+  await modal.mount();
   const el = document.querySelector(".modal");
   const btnOpen = document.querySelector("[data-modal-open]");
   const btnClose = el.querySelector("[data-modal-close]");
@@ -147,7 +147,7 @@ test("should prevent escape or screen click closing modal if required", async ()
 test("should run the replace method when replace button is clicked", async () => {
   document.body.innerHTML = markup;
   const modal = new Modal();
-  await modal.init();
+  await modal.mount();
   const el = document.querySelector(".modal");
   const btnReplace = document.querySelector("[data-modal-replace]");
 

--- a/packages/modal/tests/inert.test.js
+++ b/packages/modal/tests/inert.test.js
@@ -17,7 +17,7 @@ describe("when selectorInert is set:", () => {
   beforeAll(() => {
     document.body.innerHTML = markup;
     new Modal({
-      autoInit: true,
+      autoMount: true,
       selectorInert: "main"
     });
     main = document.querySelector("main");

--- a/packages/modal/tests/stack.test.js
+++ b/packages/modal/tests/stack.test.js
@@ -26,7 +26,7 @@ document.body.innerHTML = `
 
 beforeAll(async () => {
   modal = new Modal({ transition: false });
-  await modal.init();
+  await modal.mount();
 
   modal1 = modal.get("modal-1");
   modal2 = modal.get("modal-2");

--- a/packages/modal/tests/teleport.test.js
+++ b/packages/modal/tests/teleport.test.js
@@ -15,13 +15,13 @@ const markup = `
   <div class="modals"></div>
 `;
 
-describe("init()", () => {
+describe("mount()", () => {
   it("should teleport modals to the provided reference selector using the default method", async () => {
     document.body.innerHTML = markup;
     const modal = new Modal({ teleport: ".modals" });
     const div = document.querySelector(".modals");
     expect(div.children.length).toBe(0);
-    await modal.init();
+    await modal.mount();
     expect(div.children.length).toBe(2);
   });
 });
@@ -32,7 +32,7 @@ describe("entry.teleport() & entry.teleportReturn()", () => {
   beforeAll(async () => {
     document.body.innerHTML = markup;
     modal = new Modal();
-    await modal.init();
+    await modal.mount();
     entry = modal.collection[0];
     div = document.querySelector(".modals");
   });

--- a/packages/modal/tests/transition.test.js
+++ b/packages/modal/tests/transition.test.js
@@ -37,7 +37,7 @@ test("should apply state classes on `click` and `transitionend` events", async (
   const btnOpen = document.querySelector("[data-modal-open]");
   const btnClose = el.querySelector("[data-modal-close]");
 
-  await modal.init();
+  await modal.mount();
   expect(el).toHaveClass("modal");
 
   btnOpen.click();
@@ -62,7 +62,7 @@ test("should apply custom state classes", async () => {
     stateClosing: "disable",
     stateClosed: "off"
   });
-  await modal.init();
+  await modal.mount();
   const el = document.querySelector(".modal");
   const btnOpen = document.querySelector("[data-modal-open]");
   const btnClose = el.querySelector("[data-modal-close]");
@@ -85,7 +85,7 @@ test("should not apply transition classes when transitions are disabled", async 
   document.body.innerHTML = markup;
   const el = document.querySelector(".modal");
   const modal = new Modal({ transition: false });
-  await modal.init();
+  await modal.mount();
   await modal.open("modal-default");
   expect(el).toHaveClass("is-opened");
   expect(el.classList.length).toBe(2);
@@ -98,7 +98,7 @@ test("should not apply transition classes when transitions are disabled", async 
 test("should open and close modal while using the data modal config attribute", async () => {
   document.body.innerHTML = markupConfig;
   const modal = new Modal();
-  await modal.init();
+  await modal.mount();
 
   const modalObj = modal.get("modal-default");
   await modalObj.open();
@@ -113,7 +113,7 @@ test("should open and close modal while using the data modal config attribute", 
 test("should return modal config if set, otherwise should return global settings", async () => {
   document.body.innerHTML = markupConfig;
   const modal = new Modal();
-  await modal.init();
+  await modal.mount();
 
   const entry = modal.get("modal-default");
   expect(entry.getSetting("transition")).toBe(false);

--- a/packages/popover/README.md
+++ b/packages/popover/README.md
@@ -20,5 +20,5 @@ npm install @vrembem/popover
 
 ```js
 import Popover from '@vrembem/popover';
-const popover = new Popover({ autoInit: true });
+const popover = new Popover({ autoMount: true });
 ```

--- a/packages/popover/index.html
+++ b/packages/popover/index.html
@@ -72,7 +72,7 @@
 
     // Init and attach instance to window
     const popover = new Popover();
-    window.popover = await popover.init();
+    window.popover = await popover.mount();
 
     // Post message to console
     console.log('Popover instance has been attached to window:', popover);

--- a/packages/popover/src/js/defaults.js
+++ b/packages/popover/src/js/defaults.js
@@ -1,5 +1,5 @@
 export default {
-  autoInit: false,
+  autoMount: false,
 
   // Selectors
   selectorPopover: ".popover",

--- a/packages/popover/src/js/index.js
+++ b/packages/popover/src/js/index.js
@@ -17,10 +17,10 @@ export default class Popover extends Collection {
     this.settings = { ...this.defaults, ...options };
     this.trigger = null;
     this.#handleKeydown = handleKeydown.bind(this);
-    if (this.settings.autoInit) this.init();
+    if (this.settings.autoMount) this.mount();
   }
 
-  async init(options) {
+  async mount(options) {
     // Update settings with passed options.
     if (options) this.settings = { ...this.settings, ...options };
 
@@ -30,34 +30,34 @@ export default class Popover extends Collection {
     // Register the collections array with popover instances.
     await this.registerCollection(popovers);
 
-    // If eventListeners are enabled, init event listeners.
+    // If eventListeners are enabled, mount event listeners.
     if (this.settings.eventListeners) {
-      // Pass false to initEventListeners() since registerCollection()
+      // Pass false to mountEventListeners() since registerCollection()
       // already adds event listeners to popovers.
-      this.initEventListeners(false);
+      this.mountEventListeners(false);
     }
 
     return this;
   }
 
-  async destroy() {
+  async unmount() {
     // Clear stored trigger.
     this.trigger = null;
 
     // Remove all entries from the collection.
     await this.deregisterCollection();
 
-    // If eventListeners are enabled, destroy event listeners.
+    // If eventListeners are enabled, unmount event listeners.
     if (this.settings.eventListeners) {
-      // Pass false to destroyEventListeners() since deregisterCollection()
+      // Pass false to unmountEventListeners() since deregisterCollection()
       // already removes event listeners from popovers.
-      this.destroyEventListeners(false);
+      this.unmountEventListeners(false);
     }
 
     return this;
   }
 
-  initEventListeners(processCollection = true) {
+  mountEventListeners(processCollection = true) {
     if (processCollection) {
       // Loop through collection and setup event listeners.
       this.collection.forEach((popover) => {
@@ -69,7 +69,7 @@ export default class Popover extends Collection {
     document.addEventListener("keydown", this.#handleKeydown, false);
   }
 
-  destroyEventListeners(processCollection = true) {
+  unmountEventListeners(processCollection = true) {
     if (processCollection) {
       // Loop through collection and remove event listeners.
       this.collection.forEach((popover) => {

--- a/packages/popover/tests/api.test.js
+++ b/packages/popover/tests/api.test.js
@@ -15,36 +15,36 @@ const markup = `
 `;
 
 afterEach(() => {
-  popover.destroy();
+  popover.unmount();
   popover = null;
   document.body.innerHTML = null;
 });
 
-describe("init() & destroy()", () => {
-  it("should initialize the popover module when init is run", () => {
+describe("mount() & unmount()", () => {
+  it("should mount the popover module when init is run", () => {
     document.body.innerHTML = markup;
     popover = new Popover();
-    popover.init();
+    popover.mount();
     expect(popover.collection.length).toBe(2);
   });
 
-  it("should auto initialize the popover module autoInit is set to true", () => {
+  it("should auto mount the popover module autoMount is set to true", () => {
     document.body.innerHTML = markup;
-    popover = new Popover({ autoInit: true });
+    popover = new Popover({ autoMount: true });
     expect(popover.collection.length).toBe(2);
   });
 
   it("running init multiple times should not create duplicates in collection", async () => {
     document.body.innerHTML = markup;
-    popover = new Popover({ autoInit: true });
-    await popover.init();
+    popover = new Popover({ autoMount: true });
+    await popover.mount();
     expect(popover.collection.length).toBe(2);
   });
 
   it("should not attach keyboard event listener if eventListeners is set to false", () => {
     document.body.innerHTML = markup;
     popover = new Popover({
-      autoInit: true,
+      autoMount: true,
       eventListeners: false
     });
 
@@ -61,48 +61,48 @@ describe("init() & destroy()", () => {
     document.body.innerHTML = markup;
     popover = new Popover({ selectorPopover: ".asdf" });
     expect(popover.settings.selectorPopover).toBe(".asdf");
-    await popover.init({ selectorPopover: ".popover" });
+    await popover.mount({ selectorPopover: ".popover" });
     expect(popover.settings.selectorPopover).toBe(".popover");
   });
 
   it("should remove all event listeners and clear collection", async () => {
     document.body.innerHTML = markup;
-    popover = new Popover({ autoInit: true });
+    popover = new Popover({ autoMount: true });
 
     const trigger = document.querySelector("button");
     const target = document.querySelector(".popover");
 
     expect(popover.collection.length).toBe(2);
-    await popover.destroy();
+    await popover.unmount();
     expect(popover.collection.length).toBe(0);
     trigger.click();
     expect(target).not.toHaveClass("is-active");
   });
 });
 
-describe("initEventListeners() & destroyEventListeners()", () => {
+describe("initEventListeners() & unmountEventListeners()", () => {
   it("should remove event listeners", () => {
     document.body.innerHTML = markup;
-    popover = new Popover({ autoInit: true });
+    popover = new Popover({ autoMount: true });
 
     const trigger = document.querySelector("button");
     const target = document.querySelector(".popover");
 
-    popover.destroyEventListeners();
+    popover.unmountEventListeners();
 
     trigger.click();
     expect(target).not.toHaveClass("is-active");
   });
 
-  it("should re-initialize event listeners", () => {
+  it("should re-mount event listeners", () => {
     document.body.innerHTML = markup;
-    popover = new Popover({ autoInit: true });
+    popover = new Popover({ autoMount: true });
 
     const trigger = document.querySelector("button");
     const target = document.querySelector(".popover");
 
-    popover.destroyEventListeners();
-    popover.initEventListeners();
+    popover.unmountEventListeners();
+    popover.mountEventListeners();
 
     trigger.click();
     expect(target).toHaveClass("is-active");
@@ -110,7 +110,7 @@ describe("initEventListeners() & destroyEventListeners()", () => {
 
   it("should remove keyboard event listener", () => {
     document.body.innerHTML = markup;
-    popover = new Popover({ autoInit: true });
+    popover = new Popover({ autoMount: true });
 
     const trigger = document.querySelector("button");
     const target = document.querySelector(".popover");
@@ -118,15 +118,15 @@ describe("initEventListeners() & destroyEventListeners()", () => {
     trigger.click();
     expect(target).toHaveClass("is-active");
 
-    popover.destroyEventListeners();
+    popover.unmountEventListeners();
 
     document.dispatchEvent(keyEsc);
     expect(target).toHaveClass("is-active");
   });
 
-  it("should re-initialize keyboard event listener", () => {
+  it("should re-mount keyboard event listener", () => {
     document.body.innerHTML = markup;
-    popover = new Popover({ autoInit: true });
+    popover = new Popover({ autoMount: true });
 
     const trigger = document.querySelector("button");
     const target = document.querySelector(".popover");
@@ -134,8 +134,8 @@ describe("initEventListeners() & destroyEventListeners()", () => {
     trigger.click();
     expect(target).toHaveClass("is-active");
 
-    popover.destroyEventListeners();
-    popover.initEventListeners();
+    popover.unmountEventListeners();
+    popover.mountEventListeners();
 
     document.dispatchEvent(keyEsc);
     expect(target).not.toHaveClass("is-active");
@@ -160,7 +160,7 @@ describe("register() & deregister()", () => {
 
   it("should be able to manually deregister a popover", () => {
     document.body.innerHTML = markup;
-    popover = new Popover({ autoInit: true });
+    popover = new Popover({ autoMount: true });
 
     expect(popover.collection.length).toBe(2);
     popover.deregister(popover.collection[0]);
@@ -174,7 +174,7 @@ describe("register() & deregister()", () => {
   });
 
   it("should reject promise with error if deregister is called on non-existent entry", async () => {
-    popover = new Popover({ autoInit: true });
+    popover = new Popover({ autoMount: true });
     const result = await popover.deregister("asdf").catch((error) => { return error.message; });
     expect(result).toBe("Failed to deregister; popover does not exist in collection with ID of: \"asdf\".");
   });
@@ -183,7 +183,7 @@ describe("register() & deregister()", () => {
 describe("registerCollection() & deregisterCollection()", () => {
   it("should remove all items from collection and their event listeners", async () => {
     document.body.innerHTML = markup;
-    popover = new Popover({ autoInit: true });
+    popover = new Popover({ autoMount: true });
 
     const trigger = document.querySelector("button");
     const target = document.querySelector(".popover");
@@ -223,7 +223,7 @@ describe("registerCollection() & deregisterCollection()", () => {
 describe("open() & close()", () => {
   it("should open the provided popover", () => {
     document.body.innerHTML = markup;
-    popover = new Popover({ autoInit: true });
+    popover = new Popover({ autoMount: true });
 
     const target = document.querySelector(".popover");
 
@@ -234,7 +234,7 @@ describe("open() & close()", () => {
 
   it("should close the provided popover", () => {
     document.body.innerHTML = markup;
-    popover = new Popover({ autoInit: true });
+    popover = new Popover({ autoMount: true });
 
     const target = document.querySelector(".popover");
 
@@ -246,7 +246,7 @@ describe("open() & close()", () => {
   it("should close all popovers", async () => {
     document.body.innerHTML = markup;
     popover = new Popover();
-    await popover.init();
+    await popover.mount();
 
     popover.collection.forEach(async (item) => {
       await popover.open(item.id);
@@ -268,7 +268,7 @@ describe("open() & close()", () => {
   it("should reject promise with error when open is run on popover it could not find", async () => {
     document.body.innerHTML = markup;
     popover = new Popover();
-    await popover.init();
+    await popover.mount();
 
     let catchError = false;
     await popover.open("missing").catch((error) => {
@@ -280,7 +280,7 @@ describe("open() & close()", () => {
 
   it("should reject promise with error when close is run on popover it could not find", async () => {
     document.body.innerHTML = markup;
-    popover = new Popover({ autoInit: true });
+    popover = new Popover({ autoMount: true });
 
     let catchError = false;
     await popover.close("missing").catch((error) => {

--- a/packages/popover/tests/close.test.js
+++ b/packages/popover/tests/close.test.js
@@ -16,7 +16,7 @@ const markup = `
 `;
 
 afterEach(() => {
-  popover.destroy();
+  popover.unmount();
   popover = null;
   document.body.innerHTML = null;
 });
@@ -24,7 +24,7 @@ afterEach(() => {
 describe("close()", () => {
   it("should close the provided popover", () => {
     document.body.innerHTML = markup;
-    popover = new Popover({ autoInit: true });
+    popover = new Popover({ autoMount: true });
     const entry = popover.get("asdf");
     expect(entry.state).toBe("opened");
     expect(entry.el).toHaveClass("is-active");
@@ -37,7 +37,7 @@ describe("close()", () => {
 
   it("should close the provided popover tooltip", () => {
     document.body.innerHTML = markup;
-    popover = new Popover({ autoInit: true });
+    popover = new Popover({ autoMount: true });
     const entry = popover.get("afsd");
     expect(entry.state).toBe("opened");
     expect(entry.el).toHaveClass("is-active");
@@ -52,7 +52,7 @@ describe("close()", () => {
 describe("closeAll()", () => {
   it("should close all popovers", () => {
     document.body.innerHTML = markup;
-    popover = new Popover({ autoInit: true });
+    popover = new Popover({ autoMount: true });
     expect(popover.collection.length).toBe(3);
     expect(popover.collection[0].el).toHaveClass("is-active");
     expect(popover.collection[1].el).toHaveClass("is-active");
@@ -65,7 +65,7 @@ describe("closeAll()", () => {
 describe("closeCheck()", () => {
   it("should close popover if closeCheck does not detect a hover or focus on trigger or popover elements", () => {
     document.body.innerHTML = markup;
-    popover = new Popover({ autoInit: true });
+    popover = new Popover({ autoMount: true });
     expect(popover.collection.length).toBe(3);
     closeCheck.call(popover, popover.collection[0]);
     vi.advanceTimersByTime(100);
@@ -74,7 +74,7 @@ describe("closeCheck()", () => {
 
   it("should not close popover if closeCheck detects a focus on trigger elements", () => {
     document.body.innerHTML = markup;
-    popover = new Popover({ autoInit: true });
+    popover = new Popover({ autoMount: true });
     popover.collection[0].trigger.focus();
     closeCheck.call(popover, popover.collection[0]);
     vi.advanceTimersByTime(100);
@@ -83,7 +83,7 @@ describe("closeCheck()", () => {
 
   it("should not close popover if closeCheck detects a focus on popover elements", () => {
     document.body.innerHTML = markup;
-    popover = new Popover({ autoInit: true });
+    popover = new Popover({ autoMount: true });
     popover.collection[0].el.focus();
     closeCheck.call(popover, popover.collection[0]);
     vi.advanceTimersByTime(100);

--- a/packages/popover/tests/collection.test.js
+++ b/packages/popover/tests/collection.test.js
@@ -23,7 +23,7 @@ beforeAll(() => {
 });
 
 afterEach(() => {
-  popover.destroy();
+  popover.unmount();
   popover = null;
   document.body.innerHTML = null;
 });

--- a/packages/popover/tests/handlers.test.js
+++ b/packages/popover/tests/handlers.test.js
@@ -31,7 +31,7 @@ const markup = `
 `;
 
 afterEach(async () => {
-  await popover.destroy();
+  await popover.unmount();
   popover = null;
   document.body.innerHTML = null;
 });
@@ -40,7 +40,7 @@ describe("handleClick()", () => {
   it("should open popover if it does not contain the active class", async () => {
     document.body.innerHTML = markup;
     popover = new Popover();
-    await popover.init();
+    await popover.mount();
 
     expect(popover.collection.length).toBe(2);
 
@@ -51,7 +51,7 @@ describe("handleClick()", () => {
   it("should close popover if it contains the active class", async () => {
     document.body.innerHTML = markup;
     popover = new Popover();
-    await popover.init();
+    await popover.mount();
 
     expect(popover.collection.length).toBe(2);
 
@@ -62,7 +62,7 @@ describe("handleClick()", () => {
   it("should attach document click event listener when popover is opened", async () => {
     document.body.innerHTML = markup;
     popover = new Popover();
-    await popover.init();
+    await popover.mount();
 
     handleClick.bind(popover, popover.collection[0])();
     expect(popover.collection[0].el).toHaveClass("is-active");
@@ -80,7 +80,7 @@ describe("handlerKeydown()", () => {
   it("should close open popover when escape key is pressed", async () => {
     document.body.innerHTML = markup;
     popover = new Popover();
-    await popover.init();
+    await popover.mount();
 
     expect(popover.collection[1].el).toHaveClass("is-active");
     document.dispatchEvent(keyEsc);
@@ -91,7 +91,7 @@ describe("handlerKeydown()", () => {
   it("should do nothing when a non-escape key is pressed", async () => {
     document.body.innerHTML = markup;
     popover = new Popover();
-    await popover.init();
+    await popover.mount();
 
     expect(popover.collection[1].el).toHaveClass("is-active");
     document.dispatchEvent(keySpace);
@@ -102,7 +102,7 @@ describe("handlerKeydown()", () => {
   it("should return focus to the trigger element when escape key is pressed", async () => {
     document.body.innerHTML = markup;
     popover = new Popover();
-    await popover.init();
+    await popover.mount();
 
     const button = document.querySelector(".focus-test");
 
@@ -123,7 +123,7 @@ describe("handlerKeydown()", () => {
   it("should run close check when the tab key is pressed", async () => {
     document.body.innerHTML = markup;
     popover = new Popover();
-    await popover.init();
+    await popover.mount();
 
     expect(popover.collection.length).toBe(2);
     expect(popover.collection[1].el).toHaveClass("is-active");
@@ -137,7 +137,7 @@ describe("documentClick()", () => {
   it("should close other popover instances when a new one is toggled", async () => {
     document.body.innerHTML = markup;
     popover = new Popover();
-    await popover.init();
+    await popover.mount();
 
     expect(popover.collection[0].el).not.toHaveClass("is-active");
     expect(popover.collection[1].el).toHaveClass("is-active");
@@ -151,7 +151,7 @@ describe("documentClick()", () => {
   it("should remove document event listener when popover is closed", async () => {
     document.body.innerHTML = markup;
     popover = new Popover();
-    await popover.init();
+    await popover.mount();
 
     expect(popover.collection[0].el).not.toHaveClass("is-active");
     expect(popover.collection[1].el).toHaveClass("is-active");

--- a/packages/popover/tests/helpers.test.js
+++ b/packages/popover/tests/helpers.test.js
@@ -27,8 +27,8 @@ const markup = `
 `;
 
 afterEach(() => {
-  if (popover && "destroy" in popover) {
-    popover.destroy();
+  if (popover && "unmount" in popover) {
+    popover.unmount();
   }
   popover = null;
   document.body.innerHTML = null;

--- a/packages/popover/tests/open.test.js
+++ b/packages/popover/tests/open.test.js
@@ -13,7 +13,7 @@ const markup = `
 `;
 
 afterEach(() => {
-  popover.destroy();
+  popover.unmount();
   popover = null;
   document.body.innerHTML = null;
 });
@@ -22,7 +22,7 @@ describe("open()", () => {
   it("should open the provided popover", async () => {
     document.body.innerHTML = markup;
     popover = new Popover();
-    await popover.init();
+    await popover.mount();
     const entry = popover.get("asdf");
     expect(entry.state).toBe("closed");
     expect(entry.el).not.toHaveClass("is-active");
@@ -35,7 +35,7 @@ describe("open()", () => {
 
   it("should open the provided popover tooltip", () => {
     document.body.innerHTML = markup;
-    popover = new Popover({ autoInit: true });
+    popover = new Popover({ autoMount: true });
     const entry = popover.get("fdsa");
     expect(entry.state).toBe("closed");
     expect(entry.el).not.toHaveClass("is-active");

--- a/packages/vrembem/README.md
+++ b/packages/vrembem/README.md
@@ -53,19 +53,17 @@ Customize core variables which all components inherit from. The example below wi
 
 ## JavaScript
 
-Import and initialize the components you'll need:
+Import and mount the components you'll need:
 
 ```js
 // Import all under the vb namespace
 import * as vb from 'vrembem';
-const drawer = new vb.Drawer({ autoInit: true });
+const drawer = new vb.Drawer({ autoMount: true });
 
 // Or import individual components
 import { Drawer } from 'vrembem';
-const drawer = new Drawer({ autoInit: true });
+const drawer = new Drawer({ autoMount: true });
 ```
-
-> Note that `core` modules do not need to be initialized since they're just a set of helpful utility and functional modules.
 
 ## Markup
 


### PR DESCRIPTION
## What changed?

To help make JavaScript module APIs more consistent and intuitive, I've renamed the following methods across Modal, Drawer and Popover components:

- `init` -> `mount`
- `destroy` -> `unmount`
- `initEventListeners` -> `mountEventListeners`
- `destroyEventListeners` -> `unmountEventListeners`

Fixes #1859