### PR TITLE
Improve error messages on modal and drawer event handlers

### DIFF
--- a/packages/drawer/src/js/handlers.js
+++ b/packages/drawer/src/js/handlers.js
@@ -1,3 +1,5 @@
+import { getDrawer } from "./helpers";
+
 export async function handleClick(event) {
   // If an open, close or toggle button was clicked, handle the click event.
   const trigger = event.target.closest(`
@@ -15,7 +17,7 @@ export async function handleClick(event) {
       const selectors = trigger.getAttribute(`data-${this.settings.dataToggle}`).trim().split(" ");
       selectors.forEach((selector) => {
         // Get the entry from collection using the attribute value.
-        const entry = this.get(selector);
+        const entry = getDrawer.call(this, selector);
         // Store the trigger on the entry.
         entry.trigger = trigger;
         // Toggle the drawer
@@ -28,7 +30,7 @@ export async function handleClick(event) {
       const selectors = trigger.getAttribute(`data-${this.settings.dataOpen}`).trim().split(" ");
       selectors.forEach((selector) => {
         // Get the entry from collection using the attribute value.
-        const entry = this.get(selector);
+        const entry = getDrawer.call(this, selector);
         // Store the trigger on the entry.
         entry.trigger = trigger;
         // Open the drawer.
@@ -42,7 +44,7 @@ export async function handleClick(event) {
       selectors.forEach((selector) => {
         if (selector) {
           // Get the entry from collection using the attribute value.
-          const entry = this.get(selector);
+          const entry = getDrawer.call(this, selector);
           // Store the trigger on the entry.
           entry.trigger = trigger;
           // Close the drawer.

--- a/packages/modal/src/js/handlers.js
+++ b/packages/modal/src/js/handlers.js
@@ -1,3 +1,5 @@
+import { getModal } from "./helpers";
+
 export async function handleClick(event) {
   // If an open, close or replace button was clicked, handle the click event.
   const trigger = event.target.closest(`
@@ -14,7 +16,7 @@ export async function handleClick(event) {
     if (trigger.matches(`[data-${this.settings.dataOpen}]`)) {
       const selector = trigger.getAttribute(`data-${this.settings.dataOpen}`).trim();
       // Get the entry from collection using the attribute value.
-      const entry = this.get(selector);
+      const entry = getModal.call(this, selector);
       // Store the trigger on the entry if it's not from inside a modal.
       const fromModal = event.target.closest(this.settings.selectorModal);
       if (!fromModal) this.trigger = trigger;
@@ -26,7 +28,7 @@ export async function handleClick(event) {
     if (trigger.matches(`[data-${this.settings.dataReplace}]`)) {
       const selector = trigger.getAttribute(`data-${this.settings.dataReplace}`).trim();
       // Get the entry from collection using the attribute value.
-      const entry = this.get(selector);
+      const entry = getModal.call(this, selector);
       // Store the trigger on the entry if it's not from inside a modal.
       const fromModal = event.target.closest(this.settings.selectorModal);
       if (!fromModal) this.trigger = trigger;


### PR DESCRIPTION
## What changed?

This PR directly improves the error messages of Modal and Drawer event handlers by throwing an error if the element that is queried does not exist on the page. This is done by using `getModal` and `getDrawer` helper functions instead of the `this.get` which only returns `undefined` if entry does not exist in the collection.

Fixes #1850