### PR TITLE
Migrate the grid component to custom property methods

### DIFF
--- a/docs/src/components/CollectionNavi.astro
+++ b/docs/src/components/CollectionNavi.astro
@@ -38,8 +38,8 @@ const cp = currentPage(new URL(Astro.request.url).pathname, {
           >
             <span class="flex-grow-1">{entry.data.title}</span>
             {
-              entry.data.state && (
-                <Icon name={entry.data.state} iconClass="icon_size_sm foreground-primary" />
+              entry.data.status && (
+                <Icon name={entry.data.status} iconClass="icon_size_sm foreground-primary" />
               )
             }
           </a>

--- a/docs/src/content/config.ts
+++ b/docs/src/content/config.ts
@@ -7,7 +7,7 @@ const packages = defineCollection({
     title: z.string(),
     description: z.string(),
     package: z.string(),
-    state: z.string().optional(),
+    status: z.string().optional(),
   }),
 });
 

--- a/docs/src/content/packages/base.mdx
+++ b/docs/src/content/packages/base.mdx
@@ -2,7 +2,7 @@
 title: Base
 description: "Includes useful default styles and base modules for common HTML elements."
 package: "@vrembem/base"
-state: "layers"
+status: "layers"
 ---
 
 import CodeExample from '../../components/CodeExample.astro';

--- a/docs/src/content/packages/button.mdx
+++ b/docs/src/content/packages/button.mdx
@@ -2,7 +2,7 @@
 title: Button
 description: "Buttons are a simple component that allow users to take actions."
 package: "@vrembem/button"
-state: "check"
+status: "check"
 ---
 
 import CodeExample from '../../components/CodeExample.astro';

--- a/docs/src/content/packages/card.mdx
+++ b/docs/src/content/packages/card.mdx
@@ -31,7 +31,7 @@ Cards are a highly composable container component that comes with a variety of e
 - `card__image`
 - `card__title`
 
-<CodeExample lang="html">
+<CodeExample>
   <div slot="output">
     <div class="card">
       <img class="card__image" src="https://picsum.photos/id/335/600/300" />
@@ -57,7 +57,7 @@ For creating more distinct sections in a card, header and footer elements can be
 - `card__header`
 - `card__footer`
 
-<CodeExample lang="html">
+<CodeExample>
   <div slot="output" class="gap-y">
     <div class="card">
       <div class="card__header">
@@ -98,7 +98,7 @@ Card screens and backgrounds are displayed behind other card elements. These can
 - `card__screen`
 - `card__background`
 
-<CodeExample lang="html">
+<CodeExample>
   <div slot="output" class="gap-y">
     <div class="card vb-theme-light">
       <div class="card__header">
@@ -132,7 +132,7 @@ Card screens and backgrounds are displayed behind other card elements. These can
 
 When creating a card using the `<a>` element, additional styles are applied to make the card more visually interactive with hover and focus styles.
 
-<CodeExample lang="html">
+<CodeExample>
   <div slot="output" class="gap-y">
     <a href="#" class="card">
       <img class="card__image" src="https://picsum.photos/id/106/600/300" />

--- a/docs/src/content/packages/card.mdx
+++ b/docs/src/content/packages/card.mdx
@@ -2,7 +2,7 @@
 title: Card
 description: "The card component provides a flexible and highly composable content container."
 package: "@vrembem/card"
-state: "check"
+status: "check"
 ---
 
 import CodeExample from '../../components/CodeExample.astro';

--- a/docs/src/content/packages/checkbox.mdx
+++ b/docs/src/content/packages/checkbox.mdx
@@ -2,7 +2,7 @@
 title: Checkbox
 description: "Checkboxes allow the user to select multiple options from a set."
 package: "@vrembem/checkbox"
-state: "check"
+status: "check"
 ---
 
 import CodeExample from '../../components/CodeExample.astro';

--- a/docs/src/content/packages/checkbox.mdx
+++ b/docs/src/content/packages/checkbox.mdx
@@ -85,7 +85,7 @@ Indeterminate checkboxes need to be set in JavaScript though styling is provided
 
 For checkboxes with labels, wrap the checkbox component along with the text label using the `<label>` element.
 
-<CodeExample lang="html">
+<CodeExample>
   <Fragment slot="output">
     <label class="display-inline-flex flex-align-center flex-gap-xs">
       <span class="checkbox">
@@ -137,7 +137,7 @@ For checkboxes with labels, wrap the checkbox component along with the text labe
 
 Adjust the size of a checkbox by increasing or decreasing its width and height. By default, the checkbox scale will provide a checkbox height of 30px (small `checkbox_size_sm`), 40px (default) and 50px (large `checkbox_size_lg`).
 
-<CodeExample lang="html">
+<CodeExample>
   <Fragment slot="output">
     <span class="checkbox checkbox_size_sm">
       <input class="checkbox__native" type="checkbox" checked />

--- a/docs/src/content/packages/core.mdx
+++ b/docs/src/content/packages/core.mdx
@@ -2,7 +2,7 @@
 title: Core
 description: "Shared variables, functions and mixins for Vrembem components."
 package: "@vrembem/core"
-state: "settings"
+status: "settings"
 ---
 
 import CodeExample from '../../components/CodeExample.astro';

--- a/docs/src/content/packages/dialog.mdx
+++ b/docs/src/content/packages/dialog.mdx
@@ -2,7 +2,7 @@
 title: Dialog
 description: "A component that facilitates a conversation between the system and the user. They often request information or an action from the user."
 package: "@vrembem/dialog"
-state: "check"
+status: "check"
 ---
 
 import CodeExample from '../../components/CodeExample.astro';

--- a/docs/src/content/packages/dialog.mdx
+++ b/docs/src/content/packages/dialog.mdx
@@ -27,7 +27,7 @@ npm install @vrembem/dialog
 
 Dialog is a highly composable container component that comes with a variety of elements. The most basic implementation being `dialog` and a `dialog__body` element:
 
-<CodeExample lang="html">
+<CodeExample>
   <Fragment slot="output">
     <div class="dialog">
       <div class="dialog__body">
@@ -48,7 +48,7 @@ Dialog is a highly composable container component that comes with a variety of e
 
 The dialog component comes with a variety of elements to help fit a wide range of use cases and applications. You can mix and match these elements within the dialog component as needed.
 
-<CodeExample lang="html">
+<CodeExample>
   <Fragment slot="output">
     <div class="dialog">
       <div class="dialog__header">

--- a/docs/src/content/packages/drawer.mdx
+++ b/docs/src/content/packages/drawer.mdx
@@ -198,7 +198,7 @@ In cases where you'd like a drawer to switch modes based on a specific viewport 
         </div>
       </aside>
       <div class="drawer-main padding gap-y">
-        <p>Current viewport width: <code class="vp-width">...</code></p>
+        <p>Current viewport width: <code data-vp-width>...</code></p>
         <ul class="list">
           <li>
             <button class="link" data-drawer-toggle="drawer-4">Toggle</button> - Switches to modal below `1200px` viewports.

--- a/docs/src/content/packages/drawer.mdx
+++ b/docs/src/content/packages/drawer.mdx
@@ -36,7 +36,7 @@ Drawers are composed using classes and data attributes for their triggers. The b
 - `drawer-frame`: Applied to the parent element wrapping all drawers and the main content.
 - `drawer-main`: Applied to the element containing the main content. This should be the last child of the `drawer-frame` element.
 
-<CodeExample lang="html" flush={true}>
+<CodeExample flush={true}>
   <Fragment slot="output">
     <div class="drawer-frame">
       <aside id="drawer-1" class="drawer">
@@ -81,7 +81,7 @@ Drawer triggers are defined using three data attributes:
 - `data-drawer-close`: Closes a drawer. Will close the parent drawer if left value-less. Can also take an id of a drawer to close.
 - `data-drawer-toggle`: Toggles a drawer opened or closed. Takes the id of the drawer it's meant to toggle.
 
-<CodeExample lang="html">
+<CodeExample>
   ```html
   <button data-drawer-open="[unique-id]">...</button>
   <button data-drawer-close="[unique-id]">...</button>
@@ -91,7 +91,7 @@ Drawer triggers are defined using three data attributes:
 
 The dialog element of a drawer is defined using the `drawer__dialog` class. Along with a role attribute (e.g. `role="dialog"`), authors should provide drawer dialogs with [`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) and [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) attributes if applicable to further improve accessibility. The `aria-modal` attribute is applied automatically based on if the drawer is currently in modal mode.
 
-<CodeExample lang="html" flush={true}>
+<CodeExample flush={true}>
   <Fragment slot="output">
     <div class="drawer-frame" style="min-height: 16rem;">
       <aside id="drawer-2" class="drawer">
@@ -176,7 +176,7 @@ There are multiple ways a modal drawer can be created. The simplest being applyi
 
 In cases where you'd like a drawer to switch modes based on a specific viewport width, use the `data-drawer-breakpoint` data attribute with either a width value or a breakpoint key.
 
-<CodeExample lang="html" flush={true}>
+<CodeExample flush={true}>
   <Fragment slot="output">
     <div class="drawer-frame">
       <aside id="drawer-4" class="drawer" data-drawer-breakpoint="1200px" data-drawer-config="{ 'selectorInert': null, 'selectorOverflow': null }">
@@ -257,7 +257,7 @@ While a modal drawer is active, the contents obscured by the modal are made inac
 
 Drawer dialogs are given focus when opened as long as the `setTabindex` option is set to `true` or if the drawer dialog has `tabindex="-1"` set manually. If focus on a specific element inside a drawer is preferred, give that element the `data-focus` attribute. Focus is returned to the element that initially triggered the drawer once closed.
 
-<CodeExample lang="html" flush={true}>
+<CodeExample flush={true}>
   <Fragment slot="output">
     <div class="drawer-frame" style="min-height: 8rem;">
       <aside id="drawer-6" class="drawer">
@@ -349,7 +349,7 @@ Here's an example where we want the `drawer-main` content area to be inaccessibl
 
 Applies modal drawer styles to a drawer. This modifier should be applied before the drawer has been registered to properly setup the modal drawer. For more details on modal drawers and how to create them dynamically, please see the [modal drawer](#modal-drawers) documentation.
 
-<CodeExample lang="html" flush={true}>
+<CodeExample flush={true}>
   <Fragment slot="output">
     <div class="drawer-frame" style="min-height: 8rem;">
       <aside id="drawer-8" class="drawer drawer_modal" data-drawer-config="{ 'selectorInert': null, 'selectorOverflow': null }">
@@ -376,7 +376,7 @@ Applies modal drawer styles to a drawer. This modifier should be applied before 
 
 Drawers slide in from the left by default. To create a right side drawer, use the `drawer_switch` modifier.
 
-<CodeExample lang="html" flush={true}>
+<CodeExample flush={true}>
   <Fragment slot="output">
     <div class="drawer-frame" style="min-height: 8rem;">
       <aside id="drawer-9" class="drawer drawer_switch">

--- a/docs/src/content/packages/drawer.mdx
+++ b/docs/src/content/packages/drawer.mdx
@@ -2,7 +2,7 @@
 title: Drawer
 description: "A container component that slides in from the left or right. Typically containing menus, search or other content."
 package: "@vrembem/drawer"
-state: "circle"
+status: "circle"
 ---
 
 import CodeExample from "../../components/CodeExample.astro";

--- a/docs/src/content/packages/grid.mdx
+++ b/docs/src/content/packages/grid.mdx
@@ -2,29 +2,25 @@
 title: Grid
 description: "A flexbox based grid system component."
 package: "@vrembem/grid"
+status: "loader"
 ---
+
+import CodeExample from '../../components/CodeExample.astro';
+import DocBlock from '../../components/DocBlock.astro';
 
 # Grid
 
 A flexbox based grid system component.
 
-[![npm version](https://img.shields.io/npm/v/%40vrembem%2Fgrid.svg)](https://www.npmjs.com/package/%40vrembem%2Fgrid)
-
-[Documentation](https://vrembem.com/packages/grid)
-
-## Installation
-
 ```sh
 npm install @vrembem/grid
 ```
-
-### Styles
 
 ```scss
 @use "@vrembem/grid";
 ```
 
-### Markup
+## Basic usage
 
 The most basic implementation of the grid component consists of two elements. By default, `grid__item`'s split the available space within the `grid` parent evenly:
 

--- a/docs/src/content/packages/grid.mdx
+++ b/docs/src/content/packages/grid.mdx
@@ -37,7 +37,7 @@ The most basic implementation of the grid component consists of two elements. By
 
 > Grid is a flex based layout component. That means you can use the [`@vremben/utility`](https://github.com/sebnitu/vrembem/tree/main/packages/utility) package—specifically [`flex`](https://github.com/sebnitu/vrembem/tree/main/packages/utility#flex) and [`span`](https://github.com/sebnitu/vrembem/tree/main/packages/utility#span) modules—to further customize your layout.
 
-#### `grid__clear`
+### grid__clear
 
 The clear element allows you to start a new row at any point in a column set.
 
@@ -50,9 +50,7 @@ The clear element allows you to start a new row at any point in a column set.
 </div>
 ```
 
-## Modifiers
-
-### `grid_auto`
+## grid_auto
 
 Gives grid items a basis of auto so their content dictates their width.
 
@@ -72,7 +70,7 @@ Set an individual grid item to auto using `grid__item_auto` element modifier.
 </div>
 ```
 
-### `grid_fill`
+## grid_fill
 
 The fill modifier stretches grid item’s contents to fill the height of it’s container.
 
@@ -92,7 +90,7 @@ Set an individual grid item to fill using the `grid__item_fill` element modifier
 </div>
 ```
 
-### `grid_gap_[key]`
+## grid_gap_[key]
 
 Modifiers that adjust the gutter spacing between `grid__item` elements. Gap key output is based on the values in [`$gap-map`](#gap-scale) variable map.
 
@@ -103,7 +101,7 @@ Modifiers that adjust the gutter spacing between `grid__item` elements. Gap key 
 </div>
 ```
 
-#### Available Variations
+**Available Variants**
 
 - `grid_gap_none`
 - `grid_gap_xs`
@@ -112,7 +110,7 @@ Modifiers that adjust the gutter spacing between `grid__item` elements. Gap key 
 - `grid_gap_lg`
 - `grid_gap_xl`
 
-### `grid_gap-x_[key]`
+## grid_gap-x_[key]
 
 Adjusts the horizontal gap spacing based on the provided key. Gap key output is based on the values in [`$gap-map`](#gap-scale) variable map.
 
@@ -123,7 +121,7 @@ Adjusts the horizontal gap spacing based on the provided key. Gap key output is 
 </div>
 ```
 
-#### Available Variations
+**Available Variants**
 
 - `grid_gap-x_none`
 - `grid_gap-x_xs`
@@ -132,7 +130,7 @@ Adjusts the horizontal gap spacing based on the provided key. Gap key output is 
 - `grid_gap-x_lg`
 - `grid_gap-x_xl`
 
-### `grid_gap-y_[key]`
+## grid_gap-y_[key]
 
 Adjusts the vertical gap spacing based on the provided key. Gap key output is based on the values in [`$gap-map`](#gap-scale) variable map.
 
@@ -143,7 +141,7 @@ Adjusts the vertical gap spacing based on the provided key. Gap key output is ba
 </div>
 ```
 
-#### Available Variations
+**Available Variants**
 
 - `grid_gap-y_none`
 - `grid_gap-y_xs`
@@ -152,7 +150,7 @@ Adjusts the vertical gap spacing based on the provided key. Gap key output is ba
 - `grid_gap-y_lg`
 - `grid_gap-y_xl`
 
-### `grid_stack_[key]`
+## grid_stack_[key]
 
 Adds a breakpoint for when grid items should be stacked vertically. Values and class keys are generated using the [`$breakpoints`](#breakpoints) map. Omitting the key value from the modifier (e.g. `grid_stack`) will stack items under all conditions.
 
@@ -163,7 +161,7 @@ Adds a breakpoint for when grid items should be stacked vertically. Values and c
 </div>
 ```
 
-#### Available Variations
+**Available Variants**
 
 - `grid_stack`
 - `grid_stack_xs`
@@ -172,7 +170,7 @@ Adds a breakpoint for when grid items should be stacked vertically. Values and c
 - `grid_stack_lg`
 - `grid_stack_xl`
 
-### `span`
+## span
 
 Set the flex-basis, width and max-width on an element using the `span` module. Span column widths are built from the `$span-columns` variable. Breakpoint keys are built from the [`$breakpoints`](#breakpoints) variable map. These are the available variants:
 
@@ -187,7 +185,7 @@ Set the flex-basis, width and max-width on an element using the `span` module. S
 | `$prefix-span`  | `null`   | String to prefix the span module with.                |
 | `$span-columns` | `12`     | The columns value to use when building span variants. |
 
-#### `span-[col]-[key]`
+### span-[col]-[key]
 
 Sets the number of columns an element should span with an optional breakpoint condition. The total number of columns is set in the `$span-columns` variable. Breakpoint keys are built from the [`$breakpoints`](#breakpoints) variable map.
 
@@ -213,7 +211,7 @@ Here's an example of using the optional breakpoint variants. Breakpoints variant
 </div>
 ```
 
-#### `span-auto-[key]`
+### span-auto-[key]
 
 Sets an elements width to `auto` with an optional breakpoint condition.
 
@@ -225,7 +223,7 @@ Sets an elements width to `auto` with an optional breakpoint condition.
 </div>
 ```
 
-#### `span-full-[key]`
+### span-full-[key]
 
 Sets an elements width to `100%` with an optional breakpoint condition.
 
@@ -239,44 +237,18 @@ Sets an elements width to `100%` with an optional breakpoint condition.
 
 ## Customization
 
-### Sass Variables
+Grids are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable via the `core` module.
 
-| Variable                 | Default                                        | Description                                                                   |
-| ------------------------ | ---------------------------------------------- | ----------------------------------------------------------------------------- |
-| `$prefix-block`          | `null`                                         | String to prefix blocks with.                                                 |
-| `$prefix-element`        | `"__"`                                         | String to prefix elements with.                                               |
-| `$prefix-modifier`       | `"_"`                                          | String to prefix modifiers with.                                              |
-| `$prefix-modifier-value` | `"_"`                                          | String to prefix modifier values with.                                        |
-| `$breakpoints`           | [`core.$breakpoints` Ref &darr;](#breakpoints) | The breakpoints map the `grid_stack_[key]` modifier uses to build its styles. |
-| `$gap`                   | `2em`                                          | The default gap spacing for the grid component.                               |
-| `$gap-map`               | [`Sass Map` Ref &darr;](#gap-scale)            | Used to output gap modifiers.                                                 |
+<DocBlock name="CSS Variables" type="file" src="grid/src/_root.scss">
 
-#### `$breakpoints`
+  ```scss
+  // TBD
+  ```
+</DocBlock>
 
-The breakpoints map the `grid_stack_[key]` modifier uses to build its styles.
+<DocBlock name="SCSS Variables" type="file" src="grid/src/_variables.scss">
 
-```scss
-// Inherited from: core.$breakpoints
-$breakpoints: (
-  "xs": 480px,
-  "sm": 620px,
-  "md": 760px,
-  "lg": 990px,
-  "xl": 1380px
-) !default;
-```
-
-#### `$gap-map`
-
-Used to output gap modifiers.
-
-```scss
-$gap-map: (
-  "none": 0,
-  "xs": 0.5em,
-  "sm": 1em,
-  "md": 2em,
-  "lg": 3em,
-  "xl": 4em
-) !default;
-```
+  ```scss
+  // TBD
+  ```
+</DocBlock>

--- a/docs/src/content/packages/grid.mdx
+++ b/docs/src/content/packages/grid.mdx
@@ -37,7 +37,7 @@ The most basic implementation of the grid component consists of two elements. By
 </div>
 ```
 
-> Grid is a flex based layout component. That means you can use the [`@vremben/utility`](https://github.com/sebnitu/vrembem/tree/main/packages/utility) package—specifically [`flex`](https://github.com/sebnitu/vrembem/tree/main/packages/utility#flex) and [`span`](https://github.com/sebnitu/vrembem/tree/main/packages/utility#span) modules—to further customize your layout.
+> Grid is a flex based layout component. Use flex utilities from [`@vremben/utility`](/packages/utility) to further customize your layout. 
 
 ### grid__clear
 

--- a/docs/src/content/packages/grid.mdx
+++ b/docs/src/content/packages/grid.mdx
@@ -312,51 +312,91 @@ Set the flex-basis, width and max-width on an element using the `span` module. S
 
 Sets the number of columns an element should span with an optional breakpoint condition. The total number of columns is set in the `$span-columns` variable. Breakpoint keys are built from the [`$breakpoints`](#scss-variables-file) variable map.
 
-```html
-<div class="grid">
-  <div class="grid__item span-6">...</div>
-  <div class="grid__item span-6">...</div>
-  <div class="grid__break"></div>
-  <div class="grid__item span-6">...</div>
-  <div class="grid__item span-3">...</div>
-  <div class="grid__item span-3">...</div>
-</div>
-```
+<CodeExample>
+  <Fragment slot="output">
+    <div class="grid">
+      <div class="grid__item span-6"><div class="box">...</div></div>
+      <div class="grid__item span-6"><div class="box">...</div></div>
+      <div class="grid__clear"></div>
+      <div class="grid__item span-6"><div class="box">...</div></div>
+      <div class="grid__item span-3"><div class="box">...</div></div>
+      <div class="grid__item span-3"><div class="box">...</div></div>
+    </div>
+  </Fragment>
+  ```html
+  <div class="grid">
+    <div class="grid__item span-6">...</div>
+    <div class="grid__item span-6">...</div>
+    <div class="grid__clear"></div>
+    <div class="grid__item span-6">...</div>
+    <div class="grid__item span-3">...</div>
+    <div class="grid__item span-3">...</div>
+  </div>
+  ```
+</CodeExample>
 
 Here's an example of using the optional breakpoint variants. Breakpoints variants should be added with a mobile-first approach.
 
-```html
-<div class="grid">
-  <div class="grid__item span-12 span-6-xs span-8-sm span-4-md span-3-lg">...</div>
-  <div class="grid__item span-12 span-6-xs span-4-sm span-4-md span-3-lg">...</div>
-  <div class="grid__item span-12 span-6-xs span-4-sm span-4-md span-3-lg">...</div>
-  <div class="grid__item span-12 span-6-xs span-8-sm span-12-md span-3-lg">...</div>
-</div>
-```
+<CodeExample>
+  <Fragment slot="output">
+    <div class="grid">
+      <div class="grid__item span-12 span-6-xs span-8-sm span-4-md span-3-lg"><div class="box">...</div></div>
+      <div class="grid__item span-12 span-6-xs span-4-sm span-4-md span-3-lg"><div class="box">...</div></div>
+      <div class="grid__item span-12 span-6-xs span-4-sm span-4-md span-3-lg"><div class="box">...</div></div>
+      <div class="grid__item span-12 span-6-xs span-8-sm span-12-md span-3-lg"><div class="box">...</div></div>
+    </div>
+  </Fragment>
+  ```html
+  <div class="grid">
+    <div class="grid__item span-12 span-6-xs span-8-sm span-4-md span-3-lg">...</div>
+    <div class="grid__item span-12 span-6-xs span-4-sm span-4-md span-3-lg">...</div>
+    <div class="grid__item span-12 span-6-xs span-4-sm span-4-md span-3-lg">...</div>
+    <div class="grid__item span-12 span-6-xs span-8-sm span-12-md span-3-lg">...</div>
+  </div>
+  ```
+</CodeExample>
 
 ### span-auto-[key]
 
 Sets an elements width to `auto` with an optional breakpoint condition.
 
-```html
-<div class="grid">
-  <div class="grid__item span-auto">...</div>
-  <div class="grid__item">...</div>
-  <div class="grid__item">...</div>
-</div>
-```
+<CodeExample>
+  <Fragment slot="output">
+    <div class="grid">
+      <div class="grid__item span-auto"><div class="box">...</div></div>
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__item"><div class="box">...</div></div>
+    </div>
+  </Fragment>
+  ```html
+  <div class="grid">
+    <div class="grid__item span-auto">...</div>
+    <div class="grid__item">...</div>
+    <div class="grid__item">...</div>
+  </div>
+  ```
+</CodeExample>
 
 ### span-full-[key]
 
 Sets an elements width to `100%` with an optional breakpoint condition.
 
-```html
-<div class="grid">
-  <div class="grid__item span-full">...</div>
-  <div class="grid__item">...</div>
-  <div class="grid__item">...</div>
-</div>
-```
+<CodeExample>
+  <Fragment slot="output">
+    <div class="grid">
+      <div class="grid__item span-full"><div class="box">...</div></div>
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__item"><div class="box">...</div></div>
+    </div>
+  </Fragment>
+  ```html
+  <div class="grid">
+    <div class="grid__item span-full">...</div>
+    <div class="grid__item">...</div>
+    <div class="grid__item">...</div>
+  </div>
+  ```
+</CodeExample>
 
 ## Customization
 

--- a/docs/src/content/packages/grid.mdx
+++ b/docs/src/content/packages/grid.mdx
@@ -405,13 +405,35 @@ Grids are primarily customized using CSS variables but can also be modified usin
 <DocBlock name="CSS Variables" type="file" src="grid/src/_root.scss">
 
   ```scss
-  // TBD
+  @use "@vrembem/core";
+  @use "@vrembem/core/theme";
+  @use "./variables" as var;
+
+  #{theme.$root-selector} {
+    @include core.css("grid-gap", var.$gap);
+    @include core.css("grid-gap-x", core.css("grid-gap"));
+    @include core.css("grid-gap-y", core.css("grid-gap"));
+  }
   ```
 </DocBlock>
 
 <DocBlock name="SCSS Variables" type="file" src="grid/src/_variables.scss">
 
   ```scss
-  // TBD
+  @use "@vrembem/core";
+
+  $breakpoints: core.$breakpoints !default;
+  $gap: 2em !default;
+  $gap-map: (
+    "none": 0,
+    "xs": 0.5em,
+    "sm": 1em,
+    "md": 2em,
+    "lg": 3em,
+    "xl": 4em
+  ) !default;
+
+  $span: 12 !default;
+  $span-class: "span" !default;
   ```
 </DocBlock>

--- a/docs/src/content/packages/grid.mdx
+++ b/docs/src/content/packages/grid.mdx
@@ -32,15 +32,9 @@ The most basic implementation of the grid component consists of two elements. By
 <CodeExample>
   <Fragment slot="output">
     <div class="grid">
-      <div class="grid__item">
-        <div class="box">...</div>
-      </div>
-      <div class="grid__item">
-        <div class="box">...</div>
-      </div>
-      <div class="grid__item">
-        <div class="box">...</div>
-      </div>
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__item"><div class="box">...</div></div>
     </div>
   </Fragment>
   ```html
@@ -54,69 +48,136 @@ The most basic implementation of the grid component consists of two elements. By
 
 > Grid is a flex based layout component. Use flex utilities from [`@vremben/utility`](/packages/utility) to further customize your layout. 
 
-### grid__clear
+The `grid__clear` element allows you to start a new row at any point in a column set.
 
-The clear element allows you to start a new row at any point in a column set.
-
-```html
-<div class="grid">
-  <div class="grid__item">...</div>
-  <div class="grid__clear"></div>
-  <div class="grid__item">...</div>
-  <div class="grid__item">...</div>
-</div>
-```
+<CodeExample>
+  <Fragment slot="output">
+    <div class="grid">
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__clear"></div>
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__item"><div class="box">...</div></div>
+    </div>
+  </Fragment>
+  ```html
+  <div class="grid">
+    <div class="grid__item">...</div>
+    <div class="grid__clear"></div>
+    <div class="grid__item">...</div>
+    <div class="grid__item">...</div>
+  </div>
+  ```
+</CodeExample>
 
 ## grid_auto
 
 Gives grid items a basis of auto so their content dictates their width.
 
-```html
-<div class="grid grid_auto">
-  <div class="grid__item">...</div>
-  <div class="grid__item">...</div>
-</div>
-```
+<CodeExample>
+  <Fragment slot="output">
+    <div class="grid grid_auto">
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__item"><div class="box">...</div></div>
+    </div>
+  </Fragment>
+  ```html
+  <div class="grid grid_auto">
+    <div class="grid__item">...</div>
+    <div class="grid__item">...</div>
+    <div class="grid__item">...</div>
+  </div>
+  ```
+</CodeExample>
 
 Set an individual grid item to auto using `grid__item_auto` element modifier.
 
-```html
-<div class="grid">
-  <div class="grid__item grid__item_auto">...</div>
-  <div class="grid__item">...</div>
-</div>
-```
+<CodeExample>
+  <Fragment slot="output">
+    <div class="grid">
+      <div class="grid__item grid__item_auto"><div class="box">...</div></div>
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__item"><div class="box">...</div></div>
+    </div>
+  </Fragment>
+  ```html
+  <div class="grid">
+    <div class="grid__item grid__item_auto">...</div>
+    <div class="grid__item">...</div>
+    <div class="grid__item">...</div>
+  </div>
+  ```
+</CodeExample>
 
 ## grid_fill
 
 The fill modifier stretches grid item’s contents to fill the height of it’s container.
 
-```html
-<div class="grid grid_fill">
-  <div class="grid__item">...</div>
-  <div class="grid__item">...</div>
-</div>
-```
+<CodeExample>
+  <Fragment slot="output">
+    <div class="grid grid_fill">
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__item gap-y">
+        <div class="box">...</div>
+        <div class="box">...</div>
+      </div>
+      <div class="grid__item"><div class="box">...</div></div>
+    </div>
+  </Fragment>
+  ```html
+  <div class="grid grid_fill">
+    <div class="grid__item">...</div>
+    <div class="grid__item">...</div>
+    <div class="grid__item">...</div>
+  </div>
+  ```
+</CodeExample>
 
 Set an individual grid item to fill using the `grid__item_fill` element modifier.
 
-```html
-<div class="grid">
-  <div class="grid__item grid__item_fill">...</div>
-  <div class="grid__item">...</div>
-</div>
-```
+<CodeExample>
+  <Fragment slot="output">
+    <div class="grid">
+      <div class="grid__item grid__item_fill"><div class="box">...</div></div>
+      <div class="grid__item gap-y">
+        <div class="box">...</div>
+        <div class="box">...</div>
+      </div>
+      <div class="grid__item"><div class="box">...</div></div>
+    </div>
+  </Fragment>
+  ```html
+  <div class="grid">
+    <div class="grid__item grid__item_fill">...</div>
+    <div class="grid__item">...</div>
+    <div class="grid__item">...</div>
+  </div>
+  ```
+</CodeExample>
 
 ## grid_gap_[key]
 
-Modifiers that adjust the gutter spacing between `grid__item` elements. Gap key output is based on the values in [`$gap-map`](#gap-scale) variable map.
+Modifiers that adjust the gutter spacing between `grid__item` elements. Gap key output is based on the values in [`$gap-map`](#scss-variables-file) variable map.
 
-```html
-<div class="grid grid_gap_sm">
-  <div class="grid__item">...</div>
-  <div class="grid__item">...</div>
-</div>
-```
+<CodeExample>
+  <Fragment slot="output">
+    <div class="grid grid_gap_xs">
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__clear"></div>
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__item"><div class="box">...</div></div>
+    </div>
+  </Fragment>
+  ```html
+  <div class="grid grid_gap_xs">
+    <div class="grid__item">...</div>
+    <div class="grid__item">...</div>
+    ...
+  </div>
+  ```
+</CodeExample>
 
 **Available Variants**
 
@@ -129,14 +190,27 @@ Modifiers that adjust the gutter spacing between `grid__item` elements. Gap key 
 
 ## grid_gap-x_[key]
 
-Adjusts the horizontal gap spacing based on the provided key. Gap key output is based on the values in [`$gap-map`](#gap-scale) variable map.
+Adjusts the horizontal gap spacing based on the provided key. Gap key output is based on the values in [`$gap-map`](#scss-variables-file) variable map.
 
-```html
-<div class="grid grid_gap-x_xs">
-  <div class="grid__item">...</div>
-  <div class="grid__item">...</div>
-</div>
-```
+<CodeExample>
+  <Fragment slot="output">
+    <div class="grid grid_gap-x_xs">
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__clear"></div>
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__item"><div class="box">...</div></div>
+    </div>
+  </Fragment>
+  ```html
+  <div class="grid grid_gap-x_xs">
+    <div class="grid__item">...</div>
+    <div class="grid__item">...</div>
+    ...
+  </div>
+  ```
+</CodeExample>
 
 **Available Variants**
 
@@ -149,14 +223,27 @@ Adjusts the horizontal gap spacing based on the provided key. Gap key output is 
 
 ## grid_gap-y_[key]
 
-Adjusts the vertical gap spacing based on the provided key. Gap key output is based on the values in [`$gap-map`](#gap-scale) variable map.
+Adjusts the vertical gap spacing based on the provided key. Gap key output is based on the values in [`$gap-map`](#scss-variables-file) variable map.
 
-```html
-<div class="grid grid_gap-y_xl">
-  <div class="grid__item">...</div>
-  <div class="grid__item">...</div>
-</div>
-```
+<CodeExample>
+  <Fragment slot="output">
+    <div class="grid grid_gap-y_xs">
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__clear"></div>
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__item"><div class="box">...</div></div>
+    </div>
+  </Fragment>
+  ```html
+  <div class="grid grid_gap-y_xl">
+    <div class="grid__item">...</div>
+    <div class="grid__item">...</div>
+    ...
+  </div>
+  ```
+</CodeExample>
 
 **Available Variants**
 
@@ -169,14 +256,40 @@ Adjusts the vertical gap spacing based on the provided key. Gap key output is ba
 
 ## grid_stack_[key]
 
-Adds a breakpoint for when grid items should be stacked vertically. Values and class keys are generated using the [`$breakpoints`](#breakpoints) map. Omitting the key value from the modifier (e.g. `grid_stack`) will stack items under all conditions.
+Adds a breakpoint for when grid items should be stacked vertically. Values and class keys are generated using the [`$breakpoints`](#scss-variables-file) map. Omitting the key value from the modifier (e.g. `grid_stack`) will stack items under all conditions.
 
-```html
-<div class="grid grid_stack_md">
-  <div class="grid__item">...</div>
-  <div class="grid__item">...</div>
-</div>
-```
+<CodeExample>
+  <div slot="output" class="gap-y">
+    <p>Current view-port width: <code data-vp-width>...</code></p>
+    <div class="grid grid_gap_sm grid_stack_md">
+      <div class="grid__item span-full">
+        Grid will stack below the <code>md (760px)</code> breakpoint.
+      </div>
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__item"><div class="box">...</div></div>
+    </div>
+    <div class="grid grid_gap_sm grid_stack_lg">
+      <div class="grid__item span-full">
+        Grid will stack below the <code>lg (990px)</code> breakpoint.
+      </div>
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__item"><div class="box">...</div></div>
+      <div class="grid__item"><div class="box">...</div></div>
+    </div>
+  </div>
+  ```html
+  <div class="grid grid_stack_md">
+    <div class="grid__item">...</div>
+    <div class="grid__item">...</div>
+  </div>
+
+  <div class="grid grid_stack_lg">
+    <div class="grid__item">...</div>
+    <div class="grid__item">...</div>
+    <div class="grid__item">...</div>
+  </div>
+  ```
+</CodeExample>
 
 **Available Variants**
 
@@ -189,22 +302,15 @@ Adds a breakpoint for when grid items should be stacked vertically. Values and c
 
 ## span
 
-Set the flex-basis, width and max-width on an element using the `span` module. Span column widths are built from the `$span-columns` variable. Breakpoint keys are built from the [`$breakpoints`](#breakpoints) variable map. These are the available variants:
+Set the flex-basis, width and max-width on an element using the `span` module. Span column widths are built from the `$span-columns` variable. Breakpoint keys are built from the [`$breakpoints`](#scss-variables-file) variable map. These are the available variants:
 
 - `span-[col]-[key]` - Sets the number of columns an element should span with an optional breakpoint condition.
 - `span-auto-[key]` - Sets an elements width to `auto` with an optional breakpoint condition.
 - `span-full-[key]` - Sets an elements width to `100%` with an optional breakpoint condition.
 
-| Variable        | Default  | Description                                           |
-| --------------- | -------- | ----------------------------------------------------- |
-| `$output-span`  | `true`   | Toggles the output of this module.                    |
-| `$class-span`   | `"span"` | String to use for the class name of the span module.  |
-| `$prefix-span`  | `null`   | String to prefix the span module with.                |
-| `$span-columns` | `12`     | The columns value to use when building span variants. |
-
 ### span-[col]-[key]
 
-Sets the number of columns an element should span with an optional breakpoint condition. The total number of columns is set in the `$span-columns` variable. Breakpoint keys are built from the [`$breakpoints`](#breakpoints) variable map.
+Sets the number of columns an element should span with an optional breakpoint condition. The total number of columns is set in the `$span-columns` variable. Breakpoint keys are built from the [`$breakpoints`](#scss-variables-file) variable map.
 
 ```html
 <div class="grid">

--- a/docs/src/content/packages/grid.mdx
+++ b/docs/src/content/packages/grid.mdx
@@ -29,13 +29,28 @@ The most basic implementation of the grid component consists of two elements. By
 - `grid`
 - `grid__item`
 
-```html
-<div class="grid">
-  <div class="grid__item">...</div>
-  <div class="grid__item">...</div>
-  <div class="grid__item">...</div>
-</div>
-```
+<CodeExample>
+  <Fragment slot="output">
+    <div class="grid">
+      <div class="grid__item">
+        <div class="box">...</div>
+      </div>
+      <div class="grid__item">
+        <div class="box">...</div>
+      </div>
+      <div class="grid__item">
+        <div class="box">...</div>
+      </div>
+    </div>
+  </Fragment>
+  ```html
+  <div class="grid">
+    <div class="grid__item">...</div>
+    <div class="grid__item">...</div>
+    <div class="grid__item">...</div>
+  </div>
+  ```
+</CodeExample>
 
 > Grid is a flex based layout component. Use flex utilities from [`@vremben/utility`](/packages/utility) to further customize your layout. 
 

--- a/docs/src/content/packages/grid.mdx
+++ b/docs/src/content/packages/grid.mdx
@@ -16,9 +16,11 @@ A flexbox based grid system component.
 npm install @vrembem/grid
 ```
 
-```scss
-@use "@vrembem/grid";
-```
+<CodeExample lang="scss">
+  ```scss
+  @use "@vrembem/grid";
+  ```
+</CodeExample>
 
 ## Basic usage
 

--- a/docs/src/content/packages/modal.mdx
+++ b/docs/src/content/packages/modal.mdx
@@ -2,7 +2,7 @@
 title: Modal
 description: "A component for changing the mode of a page to complete a critical task. This is usually used in conjunction with the dialog component to make modal dialogs."
 package: "@vrembem/modal"
-state: "circle"
+status: "circle"
 ---
 
 import CodeExample from "../../components/CodeExample.astro";

--- a/docs/src/content/packages/modal.mdx
+++ b/docs/src/content/packages/modal.mdx
@@ -38,7 +38,7 @@ Modals are composed using classes and data attributes for their triggers. The ba
 - `data-modal-close`: Closes a modal. Will close the last opened modal if left value-less. Can also take a modal id to close a specific modal, or `"*"` to close all open modals.
 - `data-modal-replace`: Replaces currently opened modal(s) with the modal of the id provided.
 
-<CodeExample lang="html">
+<CodeExample>
   <Fragment slot="output">
     <button class="link" data-modal-open="modal-1">Open</button>
     <div id="modal-1" class="modal">
@@ -64,7 +64,7 @@ Modals are composed using classes and data attributes for their triggers. The ba
 
 The dialog element of a modal is defined using the `modal__dialog` class. Modal dialogs should also be given the `role` attribute with a value of either [`dialog`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) or [`alertdialog`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role) and the `aria-modal` attribute with a value of `true`. Authors should provide modal dialogs with [`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) and [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) attributes if applicable to further improve accessibility.
 
-<CodeExample lang="html">
+<CodeExample>
   <Fragment slot="output">
     <button class="link" data-modal-open="modal-2">Open</button>
     <div id="modal-2" class="modal">
@@ -107,7 +107,7 @@ The dialog element of a modal is defined using the `modal__dialog` class. Modal 
 
 Modal dialogs are given focus when opened as long as the `setTabindex` option is set to `true` or if the modal dialog has `tabindex="-1"` set manually. If focus on a specific element inside a modal is preferred, give that element the `data-focus` attribute. Focus is returned to the element that initially triggered the modal once closed.
 
-<CodeExample lang="html">
+<CodeExample>
   <Fragment slot="output">
     <ul class="list">
       <li>
@@ -166,7 +166,7 @@ While a modal is active, the contents obscured by the modal are made inaccessibl
 
 Required modals are modals that need an explicit action to be closed. That means clicking on the background or pressing the escape key to close a required modal is disabled. Required modals are set by giving a dialog the attribute `role` with a value of `alertdialog`.
 
-<CodeExample lang="html">
+<CodeExample>
   <Fragment slot="output">
     <button class="link" data-modal-open="modal-5">Open</button>
     <div id="modal-5" class="modal">
@@ -239,7 +239,7 @@ To return a modal to its original location, use the collection API method `telep
 
 Adds styles to a modal that make it fill the entire viewport when opened.
 
-<CodeExample lang="html">
+<CodeExample>
   <Fragment slot="output">
     <button class="link" data-modal-open="modal-6">Open</button>
     <div id="modal-6" class="modal modal_full">
@@ -267,7 +267,7 @@ Adds styles to a modal that make it fill the entire viewport when opened.
 
 The default position of modals is in the center of the viewport. The position modifier allows positioning a modal to the top, bottom, left and right side of the document viewport.
 
-<CodeExample lang="html">
+<CodeExample>
   <div slot="output" class="level">
     <button class="button" data-modal-open="modal-pos-top">
       <span>Top</span>
@@ -397,7 +397,7 @@ The default position of modals is in the center of the viewport. The position mo
 
 Adjusts the size of modals. This modifier provides five options that are output using the [`$size-scale`](#scss-variables-file) variable map.
 
-<CodeExample lang="html">
+<CodeExample>
   <Fragment slot="output">
     <ul class="list">
       <li>

--- a/docs/src/content/packages/popover.mdx
+++ b/docs/src/content/packages/popover.mdx
@@ -2,7 +2,7 @@
 title: Popover
 description: "A component that is initially hidden and revealed upon user interaction either through a click or hover event. Popover can contain lists of actions, links, or additional supplementary content."
 package: "@vrembem/popover"
-state: "circle"
+status: "circle"
 ---
 
 import CodeExample from "../../components/CodeExample.astro";

--- a/docs/src/content/packages/radio.mdx
+++ b/docs/src/content/packages/radio.mdx
@@ -2,7 +2,7 @@
 title: Radio
 description: "Radios allow the user to select a single option from a set."
 package: "@vrembem/radio"
-state: "check"
+status: "check"
 ---
 
 import CodeExample from '../../components/CodeExample.astro';

--- a/docs/src/content/packages/radio.mdx
+++ b/docs/src/content/packages/radio.mdx
@@ -26,7 +26,7 @@ npm install @vrembem/radio
 
 Radio buttons are composed using a set of `<span>` elements alongside the native `<input type="radio">` element which should be given the `radio__native` class and come before the remaining presentational `<span>` elements.
 
-<CodeExample lang="html">
+<CodeExample>
   <Fragment slot="output">
     <span class="radio">
       <input type="radio" class="radio__native" name="example-1" value="1" checked />
@@ -61,7 +61,7 @@ Radio buttons are composed using a set of `<span>` elements alongside the native
 
 For radio buttons with labels, just wrap the radio component along with label text using the `<label>` element.
 
-<CodeExample lang="html">
+<CodeExample>
   <Fragment slot="output">
     <label class="display-inline-flex flex-align-center flex-gap-xs">
       <span class="radio">
@@ -113,7 +113,7 @@ For radio buttons with labels, just wrap the radio component along with label te
 
 Adjust the size of a radio by increasing or decreasing its width and height. By default, the radio scale will provide a radio height of 30px (small `radio_size_sm`), 40px (default) and 50px (large `radio_size_lg`).
 
-<CodeExample lang="html">
+<CodeExample>
   <Fragment slot="output">
     <div class="level flex-gap-xl">
       <div>

--- a/docs/src/content/packages/section.mdx
+++ b/docs/src/content/packages/section.mdx
@@ -31,7 +31,7 @@ Sections are composed using the base wrapper (`section`) along with three option
   - `section__image`
   - `section__screen`
 
-<CodeExample lang="html" flush={true}>
+<CodeExample flush={true}>
   <Fragment slot="output">
     <section class="section">
       <div class="section__container gap-y text-align-center">
@@ -60,7 +60,7 @@ Sections are composed using the base wrapper (`section`) along with three option
 
 Section screens and backgrounds are displayed behind the section container. These can be paired with the `vb-theme-light` or `vb-theme-dark` theme classes to create a light or dark section theme.
 
-<CodeExample lang="html" flush={true}>
+<CodeExample flush={true}>
   <Fragment slot="output">
     <section class="section vb-theme-light">
       <div class="section__container gap-y text-align-center">
@@ -112,7 +112,7 @@ Section screens and backgrounds are displayed behind the section container. Thes
 
 Sections have a few size modifier options to help adjust the space that is used based on how prominent the section needs to be. These are optimized for all screen sizes to avoid oversized areas on mobile.
 
-<CodeExample lang="html" flush={true}>
+<CodeExample flush={true}>
   <Fragment slot="output">
     <section class="section section_size_xl">
       <div class="section__container gap-y text-align-center">

--- a/docs/src/content/packages/section.mdx
+++ b/docs/src/content/packages/section.mdx
@@ -2,7 +2,7 @@
 title: Section
 description: "A container component for wrapping distinct sections of a page."
 package: "@vrembem/section"
-state: "check"
+status: "check"
 ---
 
 import CodeExample from "../../components/CodeExample.astro";

--- a/docs/src/content/packages/switch.mdx
+++ b/docs/src/content/packages/switch.mdx
@@ -26,7 +26,7 @@ npm install @vrembem/switch
 
 Switch form controls are composed using a set of `<span>` elements alongside the native `<input type="checkbox">` element which should be given the `switch__native` class and come before the remaining presentational `<span>` elements.
 
-<CodeExample lang="html">
+<CodeExample>
   <Fragment slot="output">
     <span class="switch">
       <input type="checkbox" class="switch__native" checked />
@@ -61,7 +61,7 @@ Switch form controls are composed using a set of `<span>` elements alongside the
 
 For switch with labels, just wrap the switch component along with label text using the `<label>` element.
 
-<CodeExample lang="html">
+<CodeExample>
   <Fragment slot="output">
     <label class="display-inline-flex flex-align-center flex-gap-xs">
       <span class="switch">
@@ -113,7 +113,7 @@ For switch with labels, just wrap the switch component along with label text usi
 
 Adjust the size of a switch by increasing or decreasing its width and height. By default, the switch scale will provide a switch height of 30px (small `switch_size_sm`), 40px (default) and 50px (large `switch_size_lg`).
 
-<CodeExample lang="html">
+<CodeExample>
   <Fragment slot="output">
     <span class="switch switch_size_sm">
       <input type="checkbox" class="switch__native" />

--- a/docs/src/content/packages/switch.mdx
+++ b/docs/src/content/packages/switch.mdx
@@ -2,7 +2,7 @@
 title: Switch
 description: "Switches are a binary form element used to toggle between two options."
 package: "@vrembem/switch"
-state: "check"
+status: "check"
 ---
 
 import CodeExample from '../../components/CodeExample.astro';

--- a/docs/src/content/packages/table.mdx
+++ b/docs/src/content/packages/table.mdx
@@ -26,7 +26,7 @@ npm install @vrembem/table
 
 For basic table styles, only the `table` component class is required. Use [proper HTML table markup](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table) and styles should apply as expected.
 
-<CodeExample lang="html">
+<CodeExample>
   <Fragment slot="output">
     <table class="table">
       <caption>Example of a table caption.</caption>
@@ -109,7 +109,7 @@ For basic table styles, only the `table` component class is required. Use [prope
 
 For simple responsive table styles, wrap your tables in the [`scroll-box` base module](/packages/base#scroll-box) which provides horizontal scrolling when tables can't fit in their container.
 
-<CodeExample lang="html">
+<CodeExample>
   <Fragment slot="output">
     <div class="scroll-box">
       <table class="table" style="width: 64rem">
@@ -158,7 +158,7 @@ For simple responsive table styles, wrap your tables in the [`scroll-box` base m
 
 Switches a table layout to `fixed` and adds ellipsis overflow styles to table cells and headers.
 
-<CodeExample lang="html">
+<CodeExample>
   <Fragment slot="output">
     <table class="table table_ellipsis">
       <thead>
@@ -201,7 +201,7 @@ Switches a table layout to `fixed` and adds ellipsis overflow styles to table ce
 
 Space will be split equally between columns when `table_ellipsis` is applied. For more control over specific column widths, use the `<colgroup>` and `<col>` elements and set their desired widths as needed.
 
-<CodeExample lang="html">
+<CodeExample>
   <Fragment slot="output">
     <table class="table table_ellipsis">
       <colgroup>

--- a/docs/src/content/packages/table.mdx
+++ b/docs/src/content/packages/table.mdx
@@ -2,7 +2,7 @@
 title: Table
 description: "A table component for displaying HTML tables."
 package: "@vrembem/table"
-state: "check"
+status: "check"
 ---
 
 import CodeExample from '../../components/CodeExample.astro';

--- a/docs/src/content/packages/utility.mdx
+++ b/docs/src/content/packages/utility.mdx
@@ -25,7 +25,7 @@ npm install @vrembem/utility
 
 Once loaded, the utility component provides a number of classes that can be used independently or to supplement other loaded components.
 
-<CodeExample lang="html">
+<CodeExample>
   ```html
   <!-- Using utility classes independently -->
   <div class="padding background-shade border radius">

--- a/docs/src/content/packages/utility.mdx
+++ b/docs/src/content/packages/utility.mdx
@@ -2,7 +2,7 @@
 title: Utility
 description: "The utility component provides a set of atomic classes that specialize in a single function."
 package: "@vrembem/utility"
-state: "layers"
+status: "layers"
 ---
 
 import CodeExample from '../../components/CodeExample.astro';

--- a/docs/src/modules/currentViewport.js
+++ b/docs/src/modules/currentViewport.js
@@ -1,4 +1,4 @@
-const els = document.querySelectorAll(".vp-width");
+const els = document.querySelectorAll("[data-vp-width]");
 
 if (els.length) {
   update(els);
@@ -10,6 +10,6 @@ if (els.length) {
 function update(els) {
   const vpw = window.innerWidth;
   els.forEach((el) => {
-    el.innerText = vpw;
+    el.innerText = `${vpw}px`;
   });
 }

--- a/docs/src/modules/getPackages.js
+++ b/docs/src/modules/getPackages.js
@@ -1,7 +1,7 @@
 import { getCollection } from "astro:content";
 
 function packageOrder(a, b) {
-  return a.data.state == "settings" ? -1 : b.data.state == "settings" ? 1 : (a.data.state == "layers" ? -1 : b.data.state == "layers" ? 1 : 0);
+  return a.data.status == "settings" ? -1 : b.data.status == "settings" ? 1 : (a.data.status == "layers" ? -1 : b.data.status == "layers" ? 1 : 0);
 }
 
 export async function getPackages() {

--- a/docs/src/styles/_box.scss
+++ b/docs/src/styles/_box.scss
@@ -1,0 +1,7 @@
+@use "@vrembem/core/palette";
+
+.box {
+  padding: calc(0.75em - 2px) calc(1em - 2px);
+  border: 2px solid palette.get("primary", 50%, 50%);
+  background: palette.get("primary", 50%, 20%);
+}

--- a/docs/src/styles/global.scss
+++ b/docs/src/styles/global.scss
@@ -13,6 +13,7 @@
 
 @use "./animations";
 @use "./badge";
+@use "./box";
 @use "./code-block";
 @use "./code-example";
 @use "./doc-block";

--- a/packages/base/src/_mixins.scss
+++ b/packages/base/src/_mixins.scss
@@ -135,8 +135,8 @@
   text-underline-offset: var.$link-underline-offset;
 
   code {
-    color: var.$link-color;
     background-color: palette.get("primary", 50%, 10%);
+    color: var.$link-color;
   }
 
   &:hover {

--- a/packages/base/src/_mixins.scss
+++ b/packages/base/src/_mixins.scss
@@ -2,6 +2,7 @@
 @use "sass:map";
 @use "sass:meta";
 @use "@vrembem/core";
+@use "@vrembem/core/palette";
 @use "./variables" as var;
 
 // Arrow
@@ -133,9 +134,18 @@
   text-decoration-thickness: var.$link-decoration-thickness;
   text-underline-offset: var.$link-underline-offset;
 
+  code {
+    color: var.$link-color;
+    background-color: palette.get("primary", 50%, 10%);
+  }
+
   &:hover {
     color: var.$link-color-hover;
     text-decoration: var.$link-decoration-hover;
+
+    code {
+      color: var.$link-color-hover;
+    }
   }
 
   &:focus {
@@ -143,6 +153,10 @@
     outline-offset: var.$link-outline-focus-offset;
     color: var.$link-color-hover;
     text-decoration: var.$link-decoration-hover;
+
+    code {
+      color: var.$link-color-hover;
+    }
   }
 }
 

--- a/packages/core/src/scss/_functions.scss
+++ b/packages/core/src/scss/_functions.scss
@@ -30,6 +30,7 @@
 /// Output a CSS variable using the core variable prefix.
 /// @param {String} $name - The custom property name.
 /// @return {CSS var} - The var() CSS function with the value of the custom property.
+/// TODO: Add the ability to set a variable fallback; e.g. core.css("grid-gap-x", "grid-gap").
 @function css($name) {
   @return var(--#{prefix.$variable}#{$name});
 }

--- a/packages/core/src/scss/_mixins.scss
+++ b/packages/core/src/scss/_mixins.scss
@@ -97,46 +97,6 @@
   }
 }
 
-/// A gap mixin that creates spacing between an elements children comparable to
-/// the gap property for flexbox. Optionally pass a direction string for
-/// column-gap ("x") and row-gaps ("y") output.
-/// @param {Number} $val - Number unit to apply.
-/// @param {String} $dir ["xy"] - Direction to apply flex-gap ("x", "y" or "xy" for both).
-/// @param {Boolean} $imp [null] - Whether or not to add `!important` flag.
-/// @param {String} $prop ["margin"] - Property to apply gap with ("margin" | "padding").
-@mixin flex-gap($val, $dir: "xy", $imp: false, $prop: "margin") {
-  @if ($imp) {
-    $imp: "!important";
-  }
-  @else if ($imp == false) {
-    $imp: null;
-  }
-
-  @if ($dir == "x") {
-    margin-left: ($val * -1) #{$imp};
-
-    > * {
-      #{$prop}-left: $val #{$imp};
-    }
-  }
-  @else if ($dir == "y") {
-    margin-top: ($val * -1) #{$imp};
-
-    > * {
-      #{$prop}-top: $val #{$imp};
-    }
-  }
-  @else {
-    margin-top: ($val * -1) #{$imp};
-    margin-left: ($val * -1) #{$imp};
-
-    > * {
-      #{$prop}-top: $val #{$imp};
-      #{$prop}-left: $val #{$imp};
-    }
-  }
-}
-
 /// A gap mixin that creates spacing between inline or block level elements.
 /// Spacing is added using the `> * + *` selector and can either be applied
 /// horizontally or vertically by passing $dir "x" or "y" respectively.

--- a/packages/grid/index.scss
+++ b/packages/grid/index.scss
@@ -1,4 +1,5 @@
 @forward "./src/variables";
+@forward "./src/root";
 @forward "./src/grid";
 @forward "./src/grid_auto";
 @forward "./src/grid_fill";

--- a/packages/grid/src/_grid.scss
+++ b/packages/grid/src/_grid.scss
@@ -4,12 +4,12 @@
 #{core.bem("grid")} {
   display: flex;
   flex-wrap: wrap;
-  margin-top: calc(core.css("grid-gap") * -1);
-  margin-left: calc(core.css("grid-gap") * -1);
+  margin-top: calc(core.css("grid-gap-y") * -1);
+  margin-left: calc(core.css("grid-gap-x") * -1);
 
   > * {
-    padding-top: core.css("grid-gap");
-    padding-left: core.css("grid-gap");
+    padding-top: core.css("grid-gap-y");
+    padding-left: core.css("grid-gap-x");
   }
 
   & + & {

--- a/packages/grid/src/_grid.scss
+++ b/packages/grid/src/_grid.scss
@@ -2,9 +2,15 @@
 @use "./variables" as var;
 
 #{core.bem("grid")} {
-  @include core.flex-gap(var.$gap, $prop: "padding");
   display: flex;
   flex-wrap: wrap;
+  margin-top: calc(core.css("grid-gap") * -1);
+  margin-left: calc(core.css("grid-gap") * -1);
+
+  > * {
+    padding-top: core.css("grid-gap");
+    padding-left: core.css("grid-gap");
+  }
 
   & + & {
     margin-top: 0;

--- a/packages/grid/src/_grid.scss
+++ b/packages/grid/src/_grid.scss
@@ -1,10 +1,7 @@
 @use "@vrembem/core";
 @use "./variables" as var;
 
-$_b: var.$prefix-block;
-$_e: var.$prefix-element;
-
-.#{$_b}grid {
+#{core.bem("grid")} {
   @include core.flex-gap(var.$gap, $prop: "padding");
   display: flex;
   flex-wrap: wrap;
@@ -14,12 +11,12 @@ $_e: var.$prefix-element;
   }
 }
 
-.#{$_b}grid#{$_e}item {
+#{core.bem("grid", "item")} {
   flex: 1 1 0;
   max-width: 100%;
 }
 
-.#{$_b}grid#{$_e}clear {
+#{core.bem("grid", "clear")} {
   flex: 1 0 100%;
   margin: 0 !important;
   padding: 0 !important;

--- a/packages/grid/src/_grid_auto.scss
+++ b/packages/grid/src/_grid_auto.scss
@@ -1,10 +1,6 @@
-@use "./variables" as var;
+@use "@vrembem/core";
 
-$_b: var.$prefix-block;
-$_e: var.$prefix-element;
-$_m: var.$prefix-modifier;
-
-.#{$_b}grid#{$_m}auto > .#{$_b}grid#{$_e}item,
-.#{$_b}grid#{$_e}item#{$_m}auto {
+#{core.bem("grid", null, "auto")} > #{core.bem("grid", "item")},
+#{core.bem("grid", "item", "auto")} {
   flex: 0 0 auto;
 }

--- a/packages/grid/src/_grid_fill.scss
+++ b/packages/grid/src/_grid_fill.scss
@@ -1,11 +1,7 @@
-@use "./variables" as var;
+@use "@vrembem/core";
 
-$_b: var.$prefix-block;
-$_e: var.$prefix-element;
-$_m: var.$prefix-modifier;
-
-.#{$_b}grid#{$_m}fill > .#{$_b}grid#{$_e}item,
-.#{$_b}grid#{$_e}item#{$_m}fill {
+#{core.bem("grid", null, "fill")} > #{core.bem("grid", "item")},
+#{core.bem("grid", "item", "fill")} {
   display: flex;
   flex-direction: column;
 

--- a/packages/grid/src/_grid_gap.scss
+++ b/packages/grid/src/_grid_gap.scss
@@ -3,7 +3,7 @@
 
 @each $key, $value in var.$gap-map {
   #{core.bem("grid", null, "gap", $key)} {
-    @include core.flex-gap($value, $prop: "padding");
+    @include core.css("grid-gap", $value);
   }
 }
 

--- a/packages/grid/src/_grid_gap.scss
+++ b/packages/grid/src/_grid_gap.scss
@@ -1,23 +1,18 @@
 @use "@vrembem/core";
 @use "./variables" as var;
 
-$_b: var.$prefix-block;
-$_e: var.$prefix-element;
-$_m: var.$prefix-modifier;
-$_v: var.$prefix-modifier-value;
-
 @each $key, $value in var.$gap-map {
-  .#{$_b}grid#{$_m}gap#{$_v}#{$key} {
+  #{core.bem("grid", null, "gap", $key)} {
     @include core.flex-gap($value, $prop: "padding");
   }
 }
 
 @each $key, $value in var.$gap-map {
-  .#{$_b}grid#{$_m}gap-x#{$_v}#{$key} {
+  #{core.bem("grid", null, "gap-x", $key)} {
     @include core.flex-gap($value, "x", $prop: "padding");
   }
 
-  .#{$_b}grid#{$_m}gap-y#{$_v}#{$key} {
+  #{core.bem("grid", null, "gap-y", $key)} {
     @include core.flex-gap($value, "y", $prop: "padding");
   }
 }

--- a/packages/grid/src/_grid_gap.scss
+++ b/packages/grid/src/_grid_gap.scss
@@ -9,10 +9,10 @@
 
 @each $key, $value in var.$gap-map {
   #{core.bem("grid", null, "gap-x", $key)} {
-    @include core.flex-gap($value, "x", $prop: "padding");
+    @include core.css("grid-gap-x", $value);
   }
 
   #{core.bem("grid", null, "gap-y", $key)} {
-    @include core.flex-gap($value, "y", $prop: "padding");
+    @include core.css("grid-gap-y", $value);
   }
 }

--- a/packages/grid/src/_grid_gap.scss
+++ b/packages/grid/src/_grid_gap.scss
@@ -3,7 +3,8 @@
 
 @each $key, $value in var.$gap-map {
   #{core.bem("grid", null, "gap", $key)} {
-    @include core.css("grid-gap", $value);
+    @include core.css("grid-gap-x", $value);
+    @include core.css("grid-gap-y", $value);
   }
 }
 

--- a/packages/grid/src/_grid_stack.scss
+++ b/packages/grid/src/_grid_stack.scss
@@ -1,33 +1,28 @@
 @use "@vrembem/core";
 @use "./variables" as var;
 
-$_b: var.$prefix-block;
-$_e: var.$prefix-element;
-$_m: var.$prefix-modifier;
-$_v: var.$prefix-modifier-value;
-
-.#{$_b}grid#{$_m}stack {
+#{core.bem("grid", null, "stack")} {
   flex-direction: column;
 
-  > .#{$_b}grid#{$_e}item {
+  > #{core.bem("grid", "item")} {
     flex: none;
     width: 100%;
   }
 }
 
 @each $key, $value in var.$breakpoints {
-  .#{$_b}grid#{$_m}stack#{$_v}#{$key} {
+  #{core.bem("grid", null, "stack", $key)} {
     flex-direction: column;
   }
 
   @include core.media-min($value) {
-    .#{$_b}grid#{$_m}stack#{$_v}#{$key} {
+    #{core.bem("grid", null, "stack", $key)} {
       flex-direction: row;
     }
   }
 
   @include core.media-max($value) {
-    .#{$_b}grid#{$_m}stack#{$_v}#{$key} > .#{$_b}grid#{$_e}item {
+    #{core.bem("grid", null, "stack", $key)} > #{core.bem("grid", "item")} {
       flex: none;
       width: 100%;
     }

--- a/packages/grid/src/_root.scss
+++ b/packages/grid/src/_root.scss
@@ -1,0 +1,7 @@
+@use "@vrembem/core";
+@use "@vrembem/core/theme";
+@use "./variables" as var;
+
+#{theme.$root-selector} {
+  @include core.css("grid-gap", var.$gap);
+}

--- a/packages/grid/src/_root.scss
+++ b/packages/grid/src/_root.scss
@@ -4,4 +4,6 @@
 
 #{theme.$root-selector} {
   @include core.css("grid-gap", var.$gap);
+  @include core.css("grid-gap-x", core.css("grid-gap"));
+  @include core.css("grid-gap-y", core.css("grid-gap"));
 }

--- a/packages/grid/src/_span.scss
+++ b/packages/grid/src/_span.scss
@@ -2,39 +2,36 @@
 @use "@vrembem/core";
 @use "./variables" as var;
 
-$_p: var.$prefix-span;
-$_c: var.$class-span;
-
-@if (var.$output-span) {
-  .#{$_p}#{$_c}-auto {
+@if (var.$span and var.$span != 0) {
+  .#{var.$span-class}-auto {
     flex: 0 0 auto;
   }
 
-  @for $i from 1 through var.$span-columns {
-    $_s: ".#{$_p}#{$_c}-#{$i}";
-    @if ($i == var.$span-columns) {
-      $_s: "#{$_s}, .#{$_p}#{$_c}-full";
+  @for $i from 1 through var.$span {
+    $_s: ".#{var.$span-class}-#{$i}";
+    @if ($i == var.$span) {
+      $_s: "#{$_s}, .#{var.$span-class}-full";
     }
     #{$_s} {
       flex: none;
-      width: (100% * (math.div($i, var.$span-columns)));
+      width: (100% * (math.div($i, var.$span)));
     }
   }
 
   @each $key, $value in var.$breakpoints {
     @include core.media-min($value) {
-      .#{$_p}#{$_c}-auto-#{$key} {
+      .#{var.$span-class}-auto-#{$key} {
         flex: 0 0 auto;
       }
 
-      @for $i from 1 through var.$span-columns {
-        $_s: ".#{$_p}#{$_c}-#{$i}-#{$key}";
-        @if ($i == var.$span-columns) {
-          $_s: "#{$_s}, .#{$_p}#{$_c}-full-#{$key}";
+      @for $i from 1 through var.$span {
+        $_s: ".#{var.$span-class}-#{$i}-#{$key}";
+        @if ($i == var.$span) {
+          $_s: "#{$_s}, .#{var.$span-class}-full-#{$key}";
         }
         #{$_s} {
           flex: none;
-          width: (100% * (math.div($i, var.$span-columns)));
+          width: (100% * (math.div($i, var.$span)));
         }
       }
     }

--- a/packages/grid/src/_variables.scss
+++ b/packages/grid/src/_variables.scss
@@ -11,7 +11,5 @@ $gap-map: (
   "xl": 4em
 ) !default;
 
-$output-span: true !default;
-$class-span: "span" !default;
-$prefix-span: null !default;
-$span-columns: 12 !default;
+$span: 12 !default;
+$span-class: "span" !default;

--- a/packages/grid/src/_variables.scss
+++ b/packages/grid/src/_variables.scss
@@ -1,10 +1,5 @@
 @use "@vrembem/core";
 
-$prefix-block: core.$prefix-block !default;
-$prefix-element: core.$prefix-element !default;
-$prefix-modifier: core.$prefix-modifier !default;
-$prefix-modifier-value: core.$prefix-modifier-value !default;
-
 $breakpoints: core.$breakpoints !default;
 $gap: 2em !default;
 $gap-map: (

--- a/packages/modal/src/js/register.js
+++ b/packages/modal/src/js/register.js
@@ -15,7 +15,7 @@ export async function register(el, config = {}) {
   // Setup the modal object.
   const entry = {
     id: el.id,
-    state: "closed",
+    status: "closed",
     el: el,
     dialog: null,
     get required() {

--- a/packages/modal/src/js/register.js
+++ b/packages/modal/src/js/register.js
@@ -15,7 +15,7 @@ export async function register(el, config = {}) {
   // Setup the modal object.
   const entry = {
     id: el.id,
-    status: "closed",
+    state: "closed",
     el: el,
     dialog: null,
     get required() {

--- a/packages/popover/src/js/register.js
+++ b/packages/popover/src/js/register.js
@@ -16,7 +16,7 @@ export async function register(el, trigger) {
   // Setup the popover object.
   const entry = {
     id: el.id,
-    state: "closed",
+    status: "closed",
     el: el,
     trigger: trigger,
     popper: createPopper(trigger, el),

--- a/packages/popover/src/js/register.js
+++ b/packages/popover/src/js/register.js
@@ -16,7 +16,7 @@ export async function register(el, trigger) {
   // Setup the popover object.
   const entry = {
     id: el.id,
-    status: "closed",
+    state: "closed",
     el: el,
     trigger: trigger,
     popper: createPopper(trigger, el),


### PR DESCRIPTION
## What changed?

This PR refactors the grid component to properly use the new custom property methodology and also updates the documentation to reflect those changes. This PR also includes the following changes:

- Code link styles have also been added to the link mixin to properly style code elements inside links.
- Updates the collection front-matter data from "state" to "status". 
- Removed `lang="html"` from `CodeExample` calls since it's already the default language used.