### PR TITLE
Add css function fallback parameter

### DIFF
--- a/docs/src/content/packages/grid.mdx
+++ b/docs/src/content/packages/grid.mdx
@@ -411,8 +411,6 @@ Grids are primarily customized using CSS variables but can also be modified usin
 
   #{theme.$root-selector} {
     @include core.css("grid-gap", var.$gap);
-    @include core.css("grid-gap-x", core.css("grid-gap"));
-    @include core.css("grid-gap-y", core.css("grid-gap"));
   }
   ```
 </DocBlock>

--- a/packages/core/src/scss/_functions.scss
+++ b/packages/core/src/scss/_functions.scss
@@ -29,10 +29,14 @@
 
 /// Output a CSS variable using the core variable prefix.
 /// @param {String} $name - The custom property name.
+/// @param {String} $fallback [null] - The custom property name of a fallback.
 /// @return {CSS var} - The var() CSS function with the value of the custom property.
-/// TODO: Add the ability to set a variable fallback; e.g. core.css("grid-gap-x", "grid-gap").
-@function css($name) {
-  @return var(--#{prefix.$variable}#{$name});
+@function css($name, $fallback: null) {
+  @if ($fallback) {
+    @return var(--#{prefix.$variable}#{$name}, var(--#{prefix.$variable}#{$fallback}));
+  } @else {
+    @return var(--#{prefix.$variable}#{$name});
+  }
 }
 
 /// Encodes a color for use in data-uri

--- a/packages/grid/src/_grid.scss
+++ b/packages/grid/src/_grid.scss
@@ -4,12 +4,12 @@
 #{core.bem("grid")} {
   display: flex;
   flex-wrap: wrap;
-  margin-top: calc(core.css("grid-gap-y") * -1);
-  margin-left: calc(core.css("grid-gap-x") * -1);
+  margin-top: calc(core.css("grid-gap-y", "grid-gap") * -1);
+  margin-left: calc(core.css("grid-gap-x", "grid-gap") * -1);
 
   > * {
-    padding-top: core.css("grid-gap-y");
-    padding-left: core.css("grid-gap-x");
+    padding-top: core.css("grid-gap-y", "grid-gap");
+    padding-left: core.css("grid-gap-x", "grid-gap");
   }
 
   & + & {

--- a/packages/grid/src/_grid_gap.scss
+++ b/packages/grid/src/_grid_gap.scss
@@ -3,8 +3,7 @@
 
 @each $key, $value in var.$gap-map {
   #{core.bem("grid", null, "gap", $key)} {
-    @include core.css("grid-gap-x", $value);
-    @include core.css("grid-gap-y", $value);
+    @include core.css("grid-gap", $value);
   }
 }
 

--- a/packages/grid/src/_root.scss
+++ b/packages/grid/src/_root.scss
@@ -4,6 +4,4 @@
 
 #{theme.$root-selector} {
   @include core.css("grid-gap", var.$gap);
-  @include core.css("grid-gap-x", core.css("grid-gap"));
-  @include core.css("grid-gap-y", core.css("grid-gap"));
 }


### PR DESCRIPTION
## What changed?

This PR adds a new parameter option to the `core.css` function which allows setting a fallback CSS custom property. This is then applied to the grid component and the custom gap properties. This allows setting either a `grid-gap` value or a more specific `grid-gap-x`/`grid-gap-y` property instead of always having to set both the `-x` and `-y` variants.
