### PR TITLE
Add the ability to reset code examples

### DIFF
--- a/docs/src/components/CodeBlock.astro
+++ b/docs/src/components/CodeBlock.astro
@@ -22,8 +22,9 @@ const { inline = false } = Astro.props;
   <Popover
     triggerClass="code-block__copy-button"
     targetClass="popover_tooltip"
-    arrow={true}
-    aria-label="Copy code example">
+    aria-label="Copy code example"
+    arrow
+  >
     <Fragment slot="trigger">
       <Icon name="copy" iconClass="icon_size_sm" />
       <Icon name="check" iconClass="icon_size_sm foreground-primary-50 display-none" />

--- a/docs/src/components/CodeExample.astro
+++ b/docs/src/components/CodeExample.astro
@@ -3,9 +3,16 @@ interface Props {
   lang?: string;
   tabs?: boolean;
   flush?: boolean;
+  resettable?: boolean;
 }
 
-const { lang = "html", tabs = false, flush = false } = Astro.props;
+const { 
+  lang = "html",
+  tabs = false,
+  flush = false,
+  resettable = false
+} = Astro.props;
+
 const uid = JSON.stringify(Math.floor(Math.random() * Date.now()));
 
 ---
@@ -13,7 +20,10 @@ const uid = JSON.stringify(Math.floor(Math.random() * Date.now()));
 <div class="code-example">
   {
     Astro.slots.has("output") && (
-      <div class={`code-example__output ${flush ? 'padding-none' : ''}`.trim()}>
+      <div 
+        id={`code-example-output-${uid}`}
+        class={`code-example__output ${flush ? 'padding-none' : ''}`.trim()}
+      >
         <slot name="output" />
       </div>
     )
@@ -26,39 +36,49 @@ const uid = JSON.stringify(Math.floor(Math.random() * Date.now()));
         <slot />
       </div>
     ) : (
-      <div 
-        class="code-example__toolbar" 
-        role="tablist" 
-        aria-label="Code examples">
-        {
-          Astro.slots.has("tab-html") && (
-          <button 
-            class="tab"
-            id={`tab-html-${uid}`}
-            role="tab"
-            aria-controls={`tabpanel-html-${uid}`}
-            aria-selected="false">HTML</button>
+      <div class="code-example__toolbar">
+        <div role="tablist" aria-label="Code examples">
+          {
+            Astro.slots.has("tab-html") && (
+            <button 
+              class="tab"
+              id={`tab-html-${uid}`}
+              role="tab"
+              aria-controls={`tabpanel-html-${uid}`}
+              aria-selected="false">HTML</button>
+              )
+          }
+          {
+            Astro.slots.has("tab-scss") && (
+            <button 
+              class="tab"
+              id={`tab-scss-${uid}`}
+              role="tab"
+              aria-controls={`tabpanel-scss-${uid}`}
+              aria-selected="false">SCSS</button>
+              )
+          }
+          {
+            Astro.slots.has("tab-js") && (
+            <button 
+              class="tab"
+              id={`tab-js-${uid}`}
+              role="tab"
+              aria-controls={`tabpanel-js-${uid}`}
+              aria-selected="false"
+              tabindex="-1">JS</button>
             )
-        }
+          }
+        </div>
         {
-          Astro.slots.has("tab-scss") && (
-          <button 
-            class="tab"
-            id={`tab-scss-${uid}`}
-            role="tab"
-            aria-controls={`tabpanel-scss-${uid}`}
-            aria-selected="false">SCSS</button>
-            )
-        }
-        {
-          Astro.slots.has("tab-js") && (
-          <button 
-            class="tab"
-            id={`tab-js-${uid}`}
-            role="tab"
-            aria-controls={`tabpanel-js-${uid}`}
-            aria-selected="false"
-            tabindex="-1">JS</button>
+          resettable && (
+            <button
+              type="button"
+              class="button button_size_sm button_color_secondary"
+              data-reset={`code-example-output-${uid}`}
+            >
+              Reset <span class="sr-only">example</span>
+            </button>
           )
         }
       </div>

--- a/docs/src/components/Navibar.astro
+++ b/docs/src/components/Navibar.astro
@@ -25,7 +25,7 @@ const { classes = "" } = Astro.props;
       </a>
     </div>
     <div class="navibar__menu">
-      <Navi menuClass="display-none display-flex-md" inline={true} />
+      <Navi menuClass="display-none display-flex-md" inline />
       <button
         data-modal-open="modal-navi"
         class="button button_icon display-block display-none-md"

--- a/docs/src/content/packages/checkbox.mdx
+++ b/docs/src/content/packages/checkbox.mdx
@@ -26,7 +26,7 @@ npm install @vrembem/checkbox
 
 Checkboxes are composed using a set of `<span>` elements alongside the native `<input type="checkbox">` element which should be given the `checkbox__native` class and come before the remaining presentational `<span>` elements.
 
-<CodeExample tabs={true}>
+<CodeExample tabs>
   <Fragment slot="output">
     <span class="checkbox">
       <input class="checkbox__native" type="checkbox" checked />

--- a/docs/src/content/packages/drawer.mdx
+++ b/docs/src/content/packages/drawer.mdx
@@ -36,7 +36,7 @@ Drawers are composed using classes and data attributes for their triggers. The b
 - `drawer-frame`: Applied to the parent element wrapping all drawers and the main content.
 - `drawer-main`: Applied to the element containing the main content. This should be the last child of the `drawer-frame` element.
 
-<CodeExample flush={true}>
+<CodeExample flush>
   <Fragment slot="output">
     <div class="drawer-frame">
       <aside id="drawer-1" class="drawer">
@@ -91,7 +91,7 @@ Drawer triggers are defined using three data attributes:
 
 The dialog element of a drawer is defined using the `drawer__dialog` class. Along with a role attribute (e.g. `role="dialog"`), authors should provide drawer dialogs with [`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) and [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) attributes if applicable to further improve accessibility. The `aria-modal` attribute is applied automatically based on if the drawer is currently in modal mode.
 
-<CodeExample flush={true}>
+<CodeExample flush>
   <Fragment slot="output">
     <div class="drawer-frame" style="min-height: 16rem;">
       <aside id="drawer-2" class="drawer">
@@ -140,7 +140,7 @@ The dialog element of a drawer is defined using the `drawer__dialog` class. Alon
 
 There are multiple ways a modal drawer can be created. The simplest being applying the [`drawer_modal`](#drawer_modal) modifier class to the `drawer` element before its been registered. To change a drawer's mode after its been registered, change the `mode` property of the drawer entry from `'inline'` to `'modal'` (or vice versa) in JavaScript.
 
-<CodeExample tabs={true} flush={true}>
+<CodeExample tabs flush>
   <Fragment slot="output">
     <div class="drawer-frame" style="min-height: 8rem;">
       <aside id="drawer-3" class="drawer drawer_modal" data-drawer-config="{ 'selectorInert': null, 'selectorOverflow': null }">
@@ -176,7 +176,7 @@ There are multiple ways a modal drawer can be created. The simplest being applyi
 
 In cases where you'd like a drawer to switch modes based on a specific viewport width, use the `data-drawer-breakpoint` data attribute with either a width value or a breakpoint key.
 
-<CodeExample flush={true}>
+<CodeExample flush>
   <Fragment slot="output">
     <div class="drawer-frame">
       <aside id="drawer-4" class="drawer" data-drawer-breakpoint="1200px" data-drawer-config="{ 'selectorInert': null, 'selectorOverflow': null }">
@@ -257,7 +257,7 @@ While a modal drawer is active, the contents obscured by the modal are made inac
 
 Drawer dialogs are given focus when opened as long as the `setTabindex` option is set to `true` or if the drawer dialog has `tabindex="-1"` set manually. If focus on a specific element inside a drawer is preferred, give that element the `data-focus` attribute. Focus is returned to the element that initially triggered the drawer once closed.
 
-<CodeExample flush={true}>
+<CodeExample flush>
   <Fragment slot="output">
     <div class="drawer-frame" style="min-height: 8rem;">
       <aside id="drawer-6" class="drawer">
@@ -349,7 +349,7 @@ Here's an example where we want the `drawer-main` content area to be inaccessibl
 
 Applies modal drawer styles to a drawer. This modifier should be applied before the drawer has been registered to properly setup the modal drawer. For more details on modal drawers and how to create them dynamically, please see the [modal drawer](#modal-drawers) documentation.
 
-<CodeExample flush={true}>
+<CodeExample flush>
   <Fragment slot="output">
     <div class="drawer-frame" style="min-height: 8rem;">
       <aside id="drawer-8" class="drawer drawer_modal" data-drawer-config="{ 'selectorInert': null, 'selectorOverflow': null }">
@@ -376,7 +376,7 @@ Applies modal drawer styles to a drawer. This modifier should be applied before 
 
 Drawers slide in from the left by default. To create a right side drawer, use the `drawer_switch` modifier.
 
-<CodeExample flush={true}>
+<CodeExample flush>
   <Fragment slot="output">
     <div class="drawer-frame" style="min-height: 8rem;">
       <aside id="drawer-9" class="drawer drawer_switch">

--- a/docs/src/content/packages/notice.mdx
+++ b/docs/src/content/packages/notice.mdx
@@ -102,7 +102,7 @@ For cases where a notice message should be displayed alongside an icon or image,
 
 It's a common pattern to allow users to dismiss notices. This can be accomplished using the button component along with some simple vanilla JavaScript.
 
-<CodeExample tabs={true}>
+<CodeExample tabs resettable>
   <Fragment slot="output">
     <div class="notice">
       <div class="flex flex-justify-between">
@@ -118,7 +118,11 @@ It's a common pattern to allow users to dismiss notices. This can be accomplishe
     <div class="notice">
       <div class="flex flex-justify-between">
         <p>...</p>
-        <button class="button button_icon button_size_sm" aria-label="Dismiss this notice" data-dismiss=".notice">
+        <button 
+          class="button button_icon button_size_sm" 
+          aria-label="Dismiss this notice" 
+          data-dismiss=".notice"
+        >
           ...
         </button>
       </div>

--- a/docs/src/content/packages/notice.mdx
+++ b/docs/src/content/packages/notice.mdx
@@ -105,7 +105,7 @@ It's a common pattern to allow users to dismiss notices. This can be accomplishe
 <CodeExample tabs resettable>
   <Fragment slot="output">
     <div class="notice">
-      <div class="flex flex-justify-between">
+      <div class="flex flex-justify-between flex-align-center">
         <p>This is an example notice with a dismiss button.</p>
         <button class="button button_icon button_size_sm" aria-label="Dismiss this notice" data-dismiss=".notice">
           <Icon name="x" iconClass="icon_size_sm" />

--- a/docs/src/content/packages/section.mdx
+++ b/docs/src/content/packages/section.mdx
@@ -31,7 +31,7 @@ Sections are composed using the base wrapper (`section`) along with three option
   - `section__image`
   - `section__screen`
 
-<CodeExample flush={true}>
+<CodeExample flush>
   <Fragment slot="output">
     <section class="section">
       <div class="section__container gap-y text-align-center">
@@ -60,7 +60,7 @@ Sections are composed using the base wrapper (`section`) along with three option
 
 Section screens and backgrounds are displayed behind the section container. These can be paired with the `vb-theme-light` or `vb-theme-dark` theme classes to create a light or dark section theme.
 
-<CodeExample flush={true}>
+<CodeExample flush>
   <Fragment slot="output">
     <section class="section vb-theme-light">
       <div class="section__container gap-y text-align-center">
@@ -112,7 +112,7 @@ Section screens and backgrounds are displayed behind the section container. Thes
 
 Sections have a few size modifier options to help adjust the space that is used based on how prominent the section needs to be. These are optimized for all screen sizes to avoid oversized areas on mobile.
 
-<CodeExample flush={true}>
+<CodeExample flush>
   <Fragment slot="output">
     <section class="section section_size_xl">
       <div class="section__container gap-y text-align-center">

--- a/docs/src/content/packages/utility.mdx
+++ b/docs/src/content/packages/utility.mdx
@@ -105,7 +105,7 @@ $gap-map: (
 
 Applies background color property. Most options include light, lighter, dark and darker variants.
 
-<CodeExample stack={true}>
+<CodeExample>
   <div slot="output" class="flex flex-wrap">
     <div class="swatch background"></div>
     <div class="swatch background-dark"></div>

--- a/docs/src/modules/dismissible.js
+++ b/docs/src/modules/dismissible.js
@@ -1,0 +1,8 @@
+document.addEventListener("click", (event) => {
+  const el = event.target.closest("[data-dismiss]");
+  if (el) {
+    const selector = el.getAttribute("data-dismiss");
+    const result = el.closest(selector);
+    if (result) result.classList.add("display-none");
+  }
+}, false);

--- a/docs/src/modules/resettable.js
+++ b/docs/src/modules/resettable.js
@@ -22,11 +22,13 @@ document.addEventListener("click", (event) => {
     const result = document.querySelector(`#${save.id}`);
     if (result) {
       el.disabled = true;
+      el.classList.add("is-loading");
       result.innerHTML = save.data;
       result.classList.add("updated");
       setTimeout(() => {
         result.classList.remove("updated");
         el.disabled = false;
+        el.classList.remove("is-loading");
       }, 600);
     }
   }

--- a/docs/src/modules/resettable.js
+++ b/docs/src/modules/resettable.js
@@ -1,0 +1,33 @@
+const saves = [];
+const btns = document.querySelectorAll("[data-reset]");
+
+// Build the saves array.
+btns.forEach((btn) => {
+  const value = btn.getAttribute("data-reset");
+  const result = document.getElementById(`${value}`);
+  if (result) {
+    const html = result.innerHTML;
+    saves.push({
+      id: result.id,
+      data: html
+    });
+  }
+});
+
+// Add event listener for reset button clicks.
+document.addEventListener("click", (event) => {
+  const el = event.target.closest("[data-reset]");
+  if (el) {
+    const save = saves.find((item) => item.id === el.getAttribute("data-reset"));
+    const result = document.querySelector(`#${save.id}`);
+    if (result) {
+      el.disabled = true;
+      result.innerHTML = save.data;
+      result.classList.add("updated");
+      setTimeout(() => {
+        result.classList.remove("updated");
+        el.disabled = false;
+      }, 600);
+    }
+  }
+}, false);

--- a/docs/src/pages/packages/[slug].astro
+++ b/docs/src/pages/packages/[slug].astro
@@ -53,6 +53,8 @@ const layout = {
   import { tabs } from "../../modules/tabs";
   import { toggle } from "../../modules/toggle";
   import "../../modules/currentViewport";
+  import "../../modules/dismissible";
+  import "../../modules/resettable";
 
   headerAnchor.mount();
   tabs.mount();
@@ -62,15 +64,5 @@ const layout = {
   const checkboxes = document.querySelectorAll(
     "input[type='checkbox'][aria-checked='mixed']"
   );
-  checkboxes.forEach((checkbox) => checkbox.indeterminate = true);
-
-  // Dismissible
-  const btns = document.querySelectorAll("[data-dismiss]");
-  btns.forEach((btn) => {
-    btn.addEventListener("click", (event) => {
-      const selector = btn.getAttribute("data-dismiss");
-      const result = event.target.closest(selector);
-      if (result) result.classList.add("display-none");
-    });
-  });
+  checkboxes.forEach((checkbox) => checkbox.indeterminate = true);  
 </script>

--- a/docs/src/styles/_code-example.scss
+++ b/docs/src/styles/_code-example.scss
@@ -84,6 +84,7 @@
   from {
     box-shadow: 0 0 0 3px palette.get("primary", 50%, 100%) inset;
   }
+
   to {
     box-shadow: 0 0 0 3px palette.get("primary", 50%, 0%) inset;
   }

--- a/docs/src/styles/_code-example.scss
+++ b/docs/src/styles/_code-example.scss
@@ -1,5 +1,6 @@
-@use "@vrembem/core/theme";
 @use "@vrembem/core";
+@use "@vrembem/core/theme";
+@use "@vrembem/core/palette";
 @use "./root";
 
 .code-example {
@@ -57,16 +58,33 @@
   .drawer-frame {
     height: 100%;
   }
+
+  &.updated {
+    animation: .6s linear updated;
+  }
 }
 
 .code-example__toolbar {
   display: flex;
   gap: 0.5rem;
-  padding: 0.5rem 1rem;
+  padding: 0.5rem 3.5rem 0.5rem 1rem;
   color: theme.get("foreground-lighter");
   text-transform: uppercase;
 
-  > * + * {
-    margin-left: 1rem;
+  [role="tablist"] {
+    flex-grow: 1;
+  }
+
+  [data-reset] {
+    margin: -2px 0;
+  }
+}
+
+@keyframes updated {
+  from {
+    background-color: palette.get("primary", 50%, 10%);
+  }
+  to {
+    background-color: palette.get("primary", 50%, 0%);
   }
 }

--- a/docs/src/styles/_code-example.scss
+++ b/docs/src/styles/_code-example.scss
@@ -82,9 +82,9 @@
 
 @keyframes updated {
   from {
-    background-color: palette.get("primary", 50%, 10%);
+    box-shadow: 0 0 0 3px palette.get("primary", 50%, 100%) inset;
   }
   to {
-    background-color: palette.get("primary", 50%, 0%);
+    box-shadow: 0 0 0 3px palette.get("primary", 50%, 0%) inset;
   }
 }


### PR DESCRIPTION
## What changed?

This PR introduces the `resettable` module to the documentation code examples. In cases where the code example output is demonstrating some JavaScript that changes the example state or HTML, we've added a "reset" button that restores the example to it's original state. This can be enabled as a `CodeExample` prop `resettable`. This update also:

- Removes the use of a value on boolean props.
- Puts `dismissible` JavaScript into its own module.
- Refactors `dismissible` to attach event listener to document instead of the HTML button.