### PR TITLE
Migrate the icon component to custom property methods

### DIFF
--- a/docs/src/components/CodeBlock.astro
+++ b/docs/src/components/CodeBlock.astro
@@ -20,8 +20,8 @@ const { inline = false } = Astro.props;
     )
   }
   <Popover
-    triggerClass="code-block__copy-button"
-    targetClass="popover_tooltip"
+    buttonClass="code-block__copy-button"
+    popoverClass="popover_tooltip"
     aria-label="Copy code example"
     arrow
   >

--- a/docs/src/components/CodeBlock.astro
+++ b/docs/src/components/CodeBlock.astro
@@ -13,7 +13,7 @@ const { inline = false } = Astro.props;
 <div class={`code-block ${inline ? "code-block_inline" : ""}`.trim()}>
   {
     inline ? (
-      <Icon name="chevron-right" iconClass="code-block__prompt icon_size_sm foreground-lighter" />
+      <Icon name="chevron-right" classes="code-block__prompt icon_size_sm foreground-lighter" />
       <pre tabindex="0" class="pre"><code><slot /></code></pre>
     ) : (
       <pre tabindex="0" class="pre"><slot /></pre>
@@ -26,8 +26,8 @@ const { inline = false } = Astro.props;
     arrow
   >
     <Fragment slot="trigger">
-      <Icon name="copy" iconClass="icon_size_sm" />
-      <Icon name="check" iconClass="icon_size_sm foreground-primary-50 display-none" />
+      <Icon name="copy" classes="icon_size_sm" />
+      <Icon name="check" classes="icon_size_sm foreground-primary-50 display-none" />
     </Fragment>
     Copied!
   </Popover>

--- a/docs/src/components/CollectionNavi.astro
+++ b/docs/src/components/CollectionNavi.astro
@@ -39,7 +39,7 @@ const cp = currentPage(new URL(Astro.request.url).pathname, {
             <span class="flex-grow-1">{entry.data.title}</span>
             {
               entry.data.status && (
-                <Icon name={entry.data.status} iconClass="icon_size_sm foreground-primary" />
+                <Icon name={entry.data.status} classes="icon_size_sm foreground-primary" />
               )
             }
           </a>

--- a/docs/src/components/DocBlock.astro
+++ b/docs/src/components/DocBlock.astro
@@ -31,7 +31,7 @@ const isFile = (type === "file");
           aria-expanded={open ? "true" : "false"}
           class="toggle-trigger button button_icon button_size_sm"
         >
-          <Icon name="chevron-right" iconClass="icon_size_sm" />
+          <Icon name="chevron-right" classes="icon_size_sm" />
         </button>
       </div>
       <div class="media__body flex flex-align-center flex-gap-x flex-wrap">
@@ -49,7 +49,7 @@ const isFile = (type === "file");
           Source
           <Icon
             name="arrow-up-right"
-            iconClass="icon_external"
+            classes="icon_external"
           />
         </a>
       </div>

--- a/docs/src/components/DocBlock.astro
+++ b/docs/src/components/DocBlock.astro
@@ -12,7 +12,7 @@ interface Props {
   open?: boolean;
 }
 
-const { name, type, returns, src, line, args, open = false } = Astro.props;
+const { name, type = "file", returns, src, line, args, open = false } = Astro.props;
 const id = makeSafeForCSS(`${name}-${type}`);
 const isFile = (type === "file");
 

--- a/docs/src/components/Icon.astro
+++ b/docs/src/components/Icon.astro
@@ -9,7 +9,8 @@ interface Props {
 const { name, iconClass = "" } = Astro.props;
 
 const svg = feather.icons[name].toSvg({
-  class: `icon ${iconClass}`.trim()
+  class: `icon ${iconClass}`.trim(),
+  role: "img"
 });
 
 ---

--- a/docs/src/components/Icon.astro
+++ b/docs/src/components/Icon.astro
@@ -3,13 +3,13 @@ import feather from "feather-icons";
 
 interface Props {
   name?: string;
-  iconClass?: string;
+  classes?: string;
 }
 
-const { name, iconClass = "" } = Astro.props;
+const { name, classes = "" } = Astro.props;
 
 const svg = feather.icons[name].toSvg({
-  class: `icon ${iconClass}`.trim(),
+  class: `icon ${classes}`.trim(),
   role: "img"
 });
 

--- a/docs/src/components/LinkEditPage.astro
+++ b/docs/src/components/LinkEditPage.astro
@@ -25,6 +25,6 @@ const url = `${ghPath}${dir}${Astro.url.pathname}${filename}${ext}`;
   target="_blank"
   class="link flex-inline flex-align-center gap-x-sm"
 >
-  <Icon name="edit" iconClass="icon_size_sm" />
+  <Icon name="edit" classes="icon_size_sm" />
   <span>Suggest changes to this page</span>
 </a>

--- a/docs/src/components/Modal.astro
+++ b/docs/src/components/Modal.astro
@@ -2,15 +2,15 @@
 interface Props {
   id?: string;
   classes?: string;
-  dialogClasses?: string;
+  dialogClass?: string;
 }
 
-const { id, classes, dialogClasses = "dialog" } = Astro.props;
+const { id, classes, dialogClass = "dialog" } = Astro.props;
 
 ---
 
 <div id={id} class={`modal ${classes}`.trim()}>
-  <div class={`modal__dialog ${dialogClasses}`.trim()} role="dialog" aria-modal="true">
+  <div class={`modal__dialog ${dialogClass}`.trim()} role="dialog" aria-modal="true">
     <slot />
   </div>
 </div>

--- a/docs/src/components/Modal.astro
+++ b/docs/src/components/Modal.astro
@@ -2,15 +2,15 @@
 interface Props {
   id?: string;
   classes?: string;
-  dialogClass?: string;
+  dialogClasses?: string;
 }
 
-const { id, classes, dialogClass = "dialog" } = Astro.props;
+const { id, classes, dialogClasses = "dialog" } = Astro.props;
 
 ---
 
 <div id={id} class={`modal ${classes}`.trim()}>
-  <div class={`modal__dialog ${dialogClass}`.trim()} role="dialog" aria-modal="true">
+  <div class={`modal__dialog ${dialogClasses}`.trim()} role="dialog" aria-modal="true">
     <slot />
   </div>
 </div>

--- a/docs/src/components/Modal.astro
+++ b/docs/src/components/Modal.astro
@@ -1,15 +1,15 @@
 ---
 interface Props {
   id?: string;
-  modalClass?: string;
+  classes?: string;
   dialogClass?: string;
 }
 
-const { id, modalClass, dialogClass = "dialog" } = Astro.props;
+const { id, classes, dialogClass = "dialog" } = Astro.props;
 
 ---
 
-<div id={id} class={`modal ${modalClass}`.trim()}>
+<div id={id} class={`modal ${classes}`.trim()}>
   <div class={`modal__dialog ${dialogClass}`.trim()} role="dialog" aria-modal="true">
     <slot />
   </div>

--- a/docs/src/components/Navi.astro
+++ b/docs/src/components/Navi.astro
@@ -37,7 +37,7 @@ const cp = currentPage(new URL(Astro.request.url).pathname, {
       GitHub
       <Icon
         name="arrow-up-right"
-        iconClass="icon_external"
+        classes="icon_external"
       />
     </a>
   </li>
@@ -46,7 +46,7 @@ const cp = currentPage(new URL(Astro.request.url).pathname, {
       Sponsor
       <Icon
         name="arrow-up-right"
-        iconClass="icon_external"
+        classes="icon_external"
       />
     </a>
   </li>

--- a/docs/src/components/Navi.astro
+++ b/docs/src/components/Navi.astro
@@ -5,11 +5,11 @@ import ThemeSwitcherMenu from "../components/ThemeSwitcherMenu.astro";
 import Icon from "./Icon.astro";
 
 interface Props {
-  menuClass?: string;
+  classes?: string;
   inline?: boolean;
 }
 
-const { menuClass, inline = false } = Astro.props;
+const { classes, inline = false } = Astro.props;
 
 const cp = currentPage(new URL(Astro.request.url).pathname, {
   classBase: "menu__action",
@@ -19,7 +19,7 @@ const cp = currentPage(new URL(Astro.request.url).pathname, {
 
 ---
 
-<ul class={`menu ${inline ? "menu_inline" : ""} ${menuClass}`.trim()}>
+<ul class={`menu ${inline ? "menu_inline" : ""} ${classes}`.trim()}>
   <li class="menu__item">
     <a class={cp.classes("/getting-started")} href="/getting-started"
       >Get Started</a

--- a/docs/src/components/Navibar.astro
+++ b/docs/src/components/Navibar.astro
@@ -25,7 +25,7 @@ const { classes = "" } = Astro.props;
       </a>
     </div>
     <div class="navibar__menu">
-      <Navi menuClass="display-none display-flex-md" inline />
+      <Navi classes="display-none display-flex-md" inline />
       <button
         data-modal-open="modal-navi"
         class="button button_icon display-block display-none-md"

--- a/docs/src/components/Navibar.astro
+++ b/docs/src/components/Navibar.astro
@@ -36,7 +36,7 @@ const { classes = "" } = Astro.props;
   </div>
 </header>
 
-<Modal id="modal-navi" modalClass="modal_pos_top">
+<Modal id="modal-navi" classes="modal_pos_top">
   <div class="dialog__header">
     <h2 class="dialog__title">Menu</h2>
     <button data-modal-close class="button button_icon dialog__close">

--- a/docs/src/components/Popover.astro
+++ b/docs/src/components/Popover.astro
@@ -3,8 +3,8 @@ interface Props {
   id?: string;
   arrow?: boolean;
   ariaLabel?: string;
-  triggerClass?: string;
-  targetClass?: string;
+  buttonClass?: string;
+  popoverClass?: string;
   placement?: string;
 }
 
@@ -12,8 +12,8 @@ const {
   id, 
   arrow = false,
   ariaLabel, 
-  triggerClass = "link", 
-  targetClass = "",
+  buttonClass = "link", 
+  popoverClass = "",
   placement
 } = Astro.props;
 
@@ -31,14 +31,14 @@ if (placement) {
   data-popover-trigger={uid}
   aria-controls={uid}
   aria-label={ariaLabel}
-  class={triggerClass}>
+  class={buttonClass}>
   <slot name="trigger">Popover Trigger</slot>
 </button>
 
 <div
   id={uid}
   aria-labelledby={`${uid}-trigger`}
-  class={("popover " + targetClass).trim()}
+  class={("popover " + popoverClass).trim()}
   style={css}>
   <slot>Popover Content</slot>
   { 

--- a/docs/src/components/ThemeSwitcherPopover.astro
+++ b/docs/src/components/ThemeSwitcherPopover.astro
@@ -14,8 +14,8 @@ import ThemeSwitcherMenu from "./ThemeSwitcherMenu.astro";
     <svg class="icon icon_style_fill theme-icon theme-icon_root" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path fill-rule="evenodd" clip-rule="evenodd" d="M21 12C21 7.36745 17.5 3.55237 13 3.05493L13 20.9451C17.4999 20.4476 21 16.6326 21 12ZM12 1C18.0751 1 23 5.92487 23 12C23 18.0751 18.0751 23 12 23C5.92487 23 0.999999 18.0751 1 12C1 5.92487 5.92487 0.999999 12 1Z" fill="currentColor" />
     </svg>
-    <Icon name="sun" iconClass="theme-icon theme-icon_light" />
-    <Icon name="moon" iconClass="theme-icon theme-icon_dark" />
+    <Icon name="sun" classes="theme-icon theme-icon_light" />
+    <Icon name="moon" classes="theme-icon theme-icon_dark" />
   </Fragment>
   <ThemeSwitcherMenu />
 </Popover>

--- a/docs/src/components/ThemeSwitcherPopover.astro
+++ b/docs/src/components/ThemeSwitcherPopover.astro
@@ -7,8 +7,8 @@ import ThemeSwitcherMenu from "./ThemeSwitcherMenu.astro";
 <Popover
   id="theme-switcher"
   ariaLabel="Switch selected theme"
-  triggerClass="button button_icon overflow-hidden"
-  targetClass="popover_size_auto vb-theme-light"
+  buttonClass="button button_icon overflow-hidden"
+  popoverClass="popover_size_auto vb-theme-light"
   placement="bottom-end">
   <Fragment slot="trigger">
     <svg class="icon icon_style_fill theme-icon theme-icon_root" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/src/content/packages/button.mdx
+++ b/docs/src/content/packages/button.mdx
@@ -286,10 +286,10 @@ Buttons are primarily customized using CSS variables but can also be modified us
   ["$foreground", "Color", "A color for the foreground of the button."],
   ["$background", "String", "The color key for the background of the button (should exist in palette map)."]
 ]}>
-  <p>Creates a button variant using CSS variables and the palette module.</p>
+  Creates a button variant using CSS variables and the palette module.
 
   <div slot="example">
-
+  
     ```scss
     .button-custom {
       @include button-variant(white, "secondary");

--- a/docs/src/content/packages/button.mdx
+++ b/docs/src/content/packages/button.mdx
@@ -181,7 +181,7 @@ Adjust the size of a button by increasing or decreasing its padding and font-siz
 
 Buttons are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable via the `core` module.
 
-<DocBlock name="CSS Variables" type="file" src="button/src/_root.scss">
+<DocBlock name="CSS Variables" src="button/src/_root.scss">
 
   ```scss
   @use "@vrembem/core";
@@ -220,7 +220,7 @@ Buttons are primarily customized using CSS variables but can also be modified us
   ```
 </DocBlock>
 
-<DocBlock name="SCSS Variables" type="file" src="button/src/_variables.scss">
+<DocBlock name="SCSS Variables" src="button/src/_variables.scss">
 
   ```scss
   @use "sass:list";
@@ -289,7 +289,7 @@ Buttons are primarily customized using CSS variables but can also be modified us
   Creates a button variant using CSS variables and the palette module.
 
   <div slot="example">
-  
+
     ```scss
     .button-custom {
       @include button-variant(white, "secondary");

--- a/docs/src/content/packages/button.mdx
+++ b/docs/src/content/packages/button.mdx
@@ -49,7 +49,7 @@ Elements within a button are centered vertically and spaced accordingly using th
 <CodeExample>
   <div slot="output">
     <button class="button">
-      <Icon name="anchor" iconClass="icon_size_sm" />
+      <Icon name="anchor" classes="icon_size_sm" />
       <span>Button</span>
       <span class="arrow"></span>
     </button>

--- a/docs/src/content/packages/card.mdx
+++ b/docs/src/content/packages/card.mdx
@@ -155,7 +155,7 @@ When creating a card using the `<a>` element, additional styles are applied to m
 
 Cards are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable via the `core` module.
 
-<DocBlock name="CSS Variables" type="file" src="card/src/_root.scss">
+<DocBlock name="CSS Variables" src="card/src/_root.scss">
 
   ```scss
   @use "@vrembem/core";
@@ -188,7 +188,7 @@ Cards are primarily customized using CSS variables but can also be modified usin
   ```
 </DocBlock>
 
-<DocBlock name="SCSS Variables" type="file" src="card/src/_variables.scss">
+<DocBlock name="SCSS Variables" src="card/src/_variables.scss">
 
   ```scss
   @use "@vrembem/core";

--- a/docs/src/content/packages/checkbox.mdx
+++ b/docs/src/content/packages/checkbox.mdx
@@ -184,7 +184,7 @@ Adjust the size of a checkbox by increasing or decreasing its width and height. 
 
 Checkboxes are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable via the `core` module.
 
-<DocBlock name="CSS Variables" type="file" src="checkbox/src/_root.scss">
+<DocBlock name="CSS Variables" src="checkbox/src/_root.scss">
 
   ```scss
   @use "@vrembem/core";
@@ -215,7 +215,7 @@ Checkboxes are primarily customized using CSS variables but can also be modified
   ```
 </DocBlock>
 
-<DocBlock name="SCSS Variables" type="file" src="checkbox/src/_variables.scss">
+<DocBlock name="SCSS Variables" src="checkbox/src/_variables.scss">
 
   ```scss
   @use "@vrembem/core";

--- a/docs/src/content/packages/dialog.mdx
+++ b/docs/src/content/packages/dialog.mdx
@@ -93,7 +93,7 @@ The dialog component comes with a variety of elements to help fit a wide range o
 
 Dialogs are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable via the `core` module.
 
-<DocBlock name="CSS Variables" type="file" src="dialog/src/_root.scss">
+<DocBlock name="CSS Variables" src="dialog/src/_root.scss">
 
   ```scss
   @use "@vrembem/core";
@@ -118,7 +118,7 @@ Dialogs are primarily customized using CSS variables but can also be modified us
   ```
 </DocBlock>
 
-<DocBlock name="SCSS Variables" type="file" src="dialog/src/_variables.scss">
+<DocBlock name="SCSS Variables" src="dialog/src/_variables.scss">
 
   ```scss
   @use "@vrembem/core/theme";

--- a/docs/src/content/packages/dialog.mdx
+++ b/docs/src/content/packages/dialog.mdx
@@ -54,7 +54,7 @@ The dialog component comes with a variety of elements to help fit a wide range o
       <div class="dialog__header">
         <h2 class="dialog__title">Dialog example</h2>
         <button class="button button_icon button_size_sm">
-          <Icon name="x" iconClass="icon_size_sm" />
+          <Icon name="x" classes="icon_size_sm" />
         </button>
       </div>
       <div class="dialog__body">

--- a/docs/src/content/packages/drawer.mdx
+++ b/docs/src/content/packages/drawer.mdx
@@ -403,7 +403,7 @@ Drawers slide in from the left by default. To create a right side drawer, use th
 
 Drawers are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable via the `core` module.
 
-<DocBlock name="CSS Variables" type="file" src="drawer/src/scss/_root.scss">
+<DocBlock name="CSS Variables" src="drawer/src/scss/_root.scss">
 
   ```scss
   @use "./variables" as var;
@@ -417,7 +417,7 @@ Drawers are primarily customized using CSS variables but can also be modified us
   ```
 </DocBlock>
 
-<DocBlock name="SCSS Variables" type="file" src="drawer/src/scss/_variables.scss">
+<DocBlock name="SCSS Variables" src="drawer/src/scss/_variables.scss">
 
   ```scss
   @use "@vrembem/core";
@@ -457,7 +457,7 @@ Drawers are primarily customized using CSS variables but can also be modified us
   ```
 </DocBlock>
 
-<DocBlock name="JS Config" type="file" src="drawer/src/js/defaults.js">
+<DocBlock name="JS Config" src="drawer/src/js/defaults.js">
 
   ```js
   export default {

--- a/docs/src/content/packages/grid.mdx
+++ b/docs/src/content/packages/grid.mdx
@@ -402,7 +402,7 @@ Sets an elements width to `100%` with an optional breakpoint condition.
 
 Grids are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable via the `core` module.
 
-<DocBlock name="CSS Variables" type="file" src="grid/src/_root.scss">
+<DocBlock name="CSS Variables" src="grid/src/_root.scss">
 
   ```scss
   @use "@vrembem/core";
@@ -415,7 +415,7 @@ Grids are primarily customized using CSS variables but can also be modified usin
   ```
 </DocBlock>
 
-<DocBlock name="SCSS Variables" type="file" src="grid/src/_variables.scss">
+<DocBlock name="SCSS Variables" src="grid/src/_variables.scss">
 
   ```scss
   @use "@vrembem/core";

--- a/docs/src/content/packages/icon.mdx
+++ b/docs/src/content/packages/icon.mdx
@@ -2,122 +2,126 @@
 title: Icon
 description: "The icon component provides a consistent way to style icons."
 package: "@vrembem/icon"
+status: "loader"
 ---
+
+import CodeExample from '../../components/CodeExample.astro';
+import DocBlock from '../../components/DocBlock.astro';
+import Icon from '../../components/Icon.astro';
 
 # Icon
 
 The icon component provides a consistent way to style icons.
 
-[![npm version](https://img.shields.io/npm/v/%40vrembem%2Ficon.svg)](https://www.npmjs.com/package/%40vrembem%2Ficon)
-
-[Documentation](https://vrembem.com/packages/icon)
-
-## Installation
-
 ```sh
 npm install @vrembem/icon
 ```
 
-### Styles
+<CodeExample lang="scss">
+  ```scss
+  @use "@vrembem/icon";
+  ```
+</CodeExample>
 
-```scss
-@use "@vrembem/icon";
-```
-
-### Markup
+## Basic usage
 
 The most basic implementation of the icon component consists of the `icon` class applied to an svg element.
 
-```html
-<svg class="icon" role="img">
-  <use xlink:href="#icon-anchor"></use>
-</svg>
-```
+<CodeExample>
+  <div slot="output" class="level level_gap_xl">
+    <Icon name="anchor" />
+    <Icon name="arrow-left" />
+    <Icon name="arrow-right" />
+    <Icon name="arrow-up" />
+    <Icon name="arrow-down" />
+    <Icon name="clipboard" />
+    <Icon name="clock" />
+    <Icon name="download-cloud" />
+  </div>
+  ```html
+  <svg class="icon" role="img">...</svg>
+  ```
+</CodeExample>
 
-## Modifiers
-
-### `icon_size_[value]`
+## icon_size_[value]
 
 Add a size modifier to adjust the size of your icons. Icon sizes are controlled using the font-size attribute and optionally a stroke width.
 
-```html
-<svg class="icon icon_size_sm" role="img">
-  <use xlink:href="#icon-anchor"></use>
-</svg>
-```
+<CodeExample>
+  <div slot="output" class="level level_gap_xl">
+    <Icon name="anchor" iconClass="icon_size_xs" />
+    <Icon name="anchor" iconClass="icon_size_sm" />
+    <Icon name="anchor" />
+    <Icon name="anchor" iconClass="icon_size_lg" />
+    <Icon name="anchor" iconClass="icon_size_xl" />
+  </div>
+  ```html
+  <svg class="icon icon_size_sm" role="img">...</svg>
+  ```
+</CodeExample>
 
-#### Available Variations
+**Available Variants**
 
 - `icon_size_xs`
 - `icon_size_sm`
 - `icon_size_lg`
 - `icon_size_xl`
 
-### `icon_style_[value]`
+## icon_style_[value]
 
 The default icon style is set using the `$icon-style` variable. You can also explicitly style an icon using the style modifier.
 
-```html
-<svg class="icon icon_style_stroke" role="img">
-  <use xlink:href="#icon-heart"></use>
-</svg>
+<CodeExample>
+  <div slot="output" class="level level_gap_xl">
+    <Icon name="heart" iconClass="icon_style_stroke" />
+    <Icon name="heart" iconClass="icon_style_fill" />
+  </div>
+  ```html
+  <svg class="icon icon_style_stroke" role="img">...</svg>
+  <svg class="icon icon_style_fill" role="img">...</svg>
+  ```
+</CodeExample>
 
-<svg class="icon icon_style_fill" role="img">
-  <use xlink:href="#icon-heart"></use>
-</svg>
-```
-
-#### Available Variations
+**Available Variants**
 
 - `icon_style_stroke`
 - `icon_style_fill`
 
-#### `@mixin icon-style($style)`
-
-Output unique styles for an icons based on their style type.
-
-**Arguments**
-
-| Variable | Type     | Description                                                                                         |
-| -------- | -------- | --------------------------------------------------------------------------------------------------- |
-| `$style` | `string` | The icon styles to output. Current options include `"stroke"` and `"fill"`, defaults to `"stroke"`. |
-
-**Example**
-
-```scss
-.icon-selector {
-  @include icon-style("fill");
-}
-
-// CSS Output
-.icon-selector {
-  stroke: none;
-  stroke-width: 0;
-  fill: currentColor;
-}
-```
-
 ## Customization
 
-### Sass Variables
+Icons are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable via the `core` module.
 
-| Variable                 | Default    | Description                                                                         |
-| ------------------------ | ---------- | ----------------------------------------------------------------------------------- |
-| `$prefix-block`          | `null`     | String to prefix blocks with.                                                       |
-| `$prefix-element`        | `"__"`     | String to prefix elements with.                                                     |
-| `$prefix-modifier`       | `"_"`      | String to prefix modifiers with.                                                    |
-| `$prefix-modifier-value` | `"_"`      | String to prefix modifier values with.                                              |
-| `$style`                 | `"stroke"` | The default icon styles to output. Current options include `"stroke"` and `"fill"`. |
-| `$size`                  | `1.25em`   | The base size of icons. This is applied using the `font-size` property.             |
-| `$stroke-width`          | `2xp`      | Sets the stroke-width property of icons.                                            |
-| `$stroke-linecap`        | `round`    | Sets the stroke-linecap property of icons.                                          |
-| `$stroke-linejoin`       | `round`    | Sets the stroke-linejoin property of icons.                                         |
-| `$vertical-align`        | `top`      | Sets the vertical-align property of icons.                                          |
-| `$size-xs`               | `0.75em`   | Sets the font-size property of icons with the `icon_size_xs` modifier.              |
-| `$size-xs-stroke-width`  | `null`     | Sets the stroke-width property of icons with the `icon_size_xs` modifier.           |
-| `$size-sm`               | `1em`      | Sets the font-size property of icons with the `icon_size_sm` modifier.              |
-| `$size-sm-stroke-width`  | `null`     | Sets the stroke-width property of icons with the `icon_size_sm` modifier.           |
-| `$size-lg`               | `1.75em`   | Sets the font-size property of icons with the `icon_size_lg` modifier.              |
-| `$size-lg-stroke-width`  | `null`     | Sets the stroke-width property of icons with the `icon_size_lg` modifier.           |
-| `$size-xl`               | `2.75em`   | Sets the font-size property of icons with the `icon_size_xl` modifier.              |
-| `$size-xl-stroke-width`  | `null`     | Sets the stroke-width property of icons with the `icon_size_xl` modifier.           |
+<DocBlock name="CSS Variables" type="file" src="icon/src/_root.scss">
+
+  ```scss
+  TBD
+  ```
+</DocBlock>
+
+<DocBlock name="SCSS Variables" type="file" src="icon/src/_variables.scss">
+
+  ```scss
+  TBD
+  ```
+</DocBlock>
+
+<DocBlock name="icon-style" type="mixin" src="icon/src/_mixins.scss" args={[
+  ["$style", "String", "The icon styles to output. Current options include \"stroke\" and \"fill\", defaults to \"stroke\"."]
+]}>
+  Output unique styles for an icons based on their style type.
+
+  <div slot="example">
+    ```scss
+    .icon-selector {
+      @include icon-style("fill");
+    }
+
+    // CSS Output
+    .icon-selector {
+      stroke: none;
+      stroke-width: 0;
+      fill: currentColor;
+    }
+    ```
+  </div>
+</DocBlock>

--- a/docs/src/content/packages/icon.mdx
+++ b/docs/src/content/packages/icon.mdx
@@ -91,14 +91,14 @@ The default icon style is set using the `$icon-style` variable. You can also exp
 
 Icons are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable via the `core` module.
 
-<DocBlock name="CSS Variables" type="file" src="icon/src/_root.scss">
+<DocBlock name="CSS Variables" src="icon/src/_root.scss">
 
   ```scss
   TBD
   ```
 </DocBlock>
 
-<DocBlock name="SCSS Variables" type="file" src="icon/src/_variables.scss">
+<DocBlock name="SCSS Variables" src="icon/src/_variables.scss">
 
   ```scss
   TBD

--- a/docs/src/content/packages/icon.mdx
+++ b/docs/src/content/packages/icon.mdx
@@ -2,7 +2,7 @@
 title: Icon
 description: "The icon component provides a consistent way to style icons."
 package: "@vrembem/icon"
-status: "loader"
+status: "check"
 ---
 
 import CodeExample from '../../components/CodeExample.astro';

--- a/docs/src/content/packages/icon.mdx
+++ b/docs/src/content/packages/icon.mdx
@@ -75,10 +75,15 @@ The default icon style is set using the `$icon-style` variable. You can also exp
   <div slot="output" class="level level_gap_xl">
     <Icon name="heart" classes="icon_style_stroke" />
     <Icon name="heart" classes="icon_style_fill" />
+    <Icon name="heart" classes="icon_style_both" />
+    <Icon name="sun" classes="icon_style_stroke" />
+    <Icon name="sun" classes="icon_style_fill" />
+    <Icon name="sun" classes="icon_style_both" />
   </div>
   ```html
   <svg class="icon icon_style_stroke" role="img">...</svg>
   <svg class="icon icon_style_fill" role="img">...</svg>
+  <svg class="icon icon_style_both" role="img">...</svg>
   ```
 </CodeExample>
 
@@ -86,6 +91,7 @@ The default icon style is set using the `$icon-style` variable. You can also exp
 
 - `icon_style_stroke`
 - `icon_style_fill`
+- `icon_style_both`
 
 ## Customization
 

--- a/docs/src/content/packages/icon.mdx
+++ b/docs/src/content/packages/icon.mdx
@@ -49,11 +49,11 @@ Add a size modifier to adjust the size of your icons. Icon sizes are controlled 
 
 <CodeExample>
   <div slot="output" class="level level_gap_xl">
-    <Icon name="anchor" iconClass="icon_size_xs" />
-    <Icon name="anchor" iconClass="icon_size_sm" />
+    <Icon name="anchor" classes="icon_size_xs" />
+    <Icon name="anchor" classes="icon_size_sm" />
     <Icon name="anchor" />
-    <Icon name="anchor" iconClass="icon_size_lg" />
-    <Icon name="anchor" iconClass="icon_size_xl" />
+    <Icon name="anchor" classes="icon_size_lg" />
+    <Icon name="anchor" classes="icon_size_xl" />
   </div>
   ```html
   <svg class="icon icon_size_sm" role="img">...</svg>
@@ -73,8 +73,8 @@ The default icon style is set using the `$icon-style` variable. You can also exp
 
 <CodeExample>
   <div slot="output" class="level level_gap_xl">
-    <Icon name="heart" iconClass="icon_style_stroke" />
-    <Icon name="heart" iconClass="icon_style_fill" />
+    <Icon name="heart" classes="icon_style_stroke" />
+    <Icon name="heart" classes="icon_style_fill" />
   </div>
   ```html
   <svg class="icon icon_style_stroke" role="img">...</svg>

--- a/docs/src/content/packages/icon.mdx
+++ b/docs/src/content/packages/icon.mdx
@@ -69,7 +69,7 @@ Add a size modifier to adjust the size of your icons. Icon sizes are controlled 
 
 ## icon_style_[value]
 
-The default icon style is set using the `$icon-style` variable. You can also explicitly style an icon using the style modifier.
+The default icon style is set using the `$icon-style` variable. You can also use the `icon_style_[value]` modifier to style individual icons.
 
 <CodeExample>
   <div slot="output" class="level level_gap_xl">
@@ -100,19 +100,44 @@ Icons are primarily customized using CSS variables but can also be modified usin
 <DocBlock name="CSS Variables" src="icon/src/_root.scss">
 
   ```scss
-  TBD
+  @use "@vrembem/core";
+  @use "@vrembem/core/theme";
+  @use "./variables" as var;
+
+  #{theme.$root-selector} {
+    @include core.css("icon-size", var.$size);
+    @include core.css("icon-stroke-width", var.$stroke-width);
+    @include core.css("icon-color", var.$color);
+  }
   ```
 </DocBlock>
 
 <DocBlock name="SCSS Variables" src="icon/src/_variables.scss">
 
   ```scss
-  TBD
+  @use "@vrembem/core";
+
+  $style: "stroke" !default;
+  $size: 1.5em !default;
+  $stroke-width: 2 !default;
+  $color: currentColor !default;
+
+  $size-xs: 0.75em !default;
+  $size-xs-stroke-width: 3.5 !default;
+
+  $size-sm: 1.125em !default;
+  $size-sm-stroke-width: 2.5 !default;
+
+  $size-lg: 2em !default;
+  $size-lg-stroke-width: 1.75 !default;
+
+  $size-xl: 3em !default;
+  $size-xl-stroke-width: 1.3 !default;
   ```
 </DocBlock>
 
 <DocBlock name="icon-style" type="mixin" src="icon/src/_mixins.scss" args={[
-  ["$style", "String", "The icon styles to output. Current options include \"stroke\" and \"fill\", defaults to \"stroke\"."]
+  ["$style", "String", "The icon styles to output. Current options include \"stroke\", \"fill\" and \"both\". Defaults to \"stroke\"."]
 ]}>
   Output unique styles for an icons based on their style type.
 

--- a/docs/src/content/packages/modal.mdx
+++ b/docs/src/content/packages/modal.mdx
@@ -498,7 +498,7 @@ Adjusts the size of modals. This modifier provides five options that are output 
 
 Modals are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable via the `core` module.
 
-<DocBlock name="CSS Variables" type="file" src="modal/src/scss/_root.scss">
+<DocBlock name="CSS Variables" src="modal/src/scss/_root.scss">
 
   ```scss
   @use "./variables" as var;
@@ -512,7 +512,7 @@ Modals are primarily customized using CSS variables but can also be modified usi
   ```
 </DocBlock>
 
-<DocBlock name="SCSS Variables" type="file" src="modal/src/scss/_variables.scss">
+<DocBlock name="SCSS Variables" src="modal/src/scss/_variables.scss">
 
   ```scss
   @use "@vrembem/core";
@@ -555,7 +555,7 @@ Modals are primarily customized using CSS variables but can also be modified usi
   ```
 </DocBlock>
 
-<DocBlock name="JS Config" type="file" src="modal/src/js/defaults.js">
+<DocBlock name="JS Config" src="modal/src/js/defaults.js">
 
   ```js
   export default {

--- a/docs/src/content/packages/notice.mdx
+++ b/docs/src/content/packages/notice.mdx
@@ -108,7 +108,7 @@ It's a common pattern to allow users to dismiss notices. This can be accomplishe
       <div class="flex flex-justify-between flex-align-center">
         <p>This is an example notice with a dismiss button.</p>
         <button class="button button_icon button_size_sm" aria-label="Dismiss this notice" data-dismiss=".notice">
-          <Icon name="x" iconClass="icon_size_sm" />
+          <Icon name="x" classes="icon_size_sm" />
         </button>
       </div>
     </div>

--- a/docs/src/content/packages/notice.mdx
+++ b/docs/src/content/packages/notice.mdx
@@ -186,7 +186,7 @@ Adds styles for changing the look and feel to better reflect the urgency or stat
 
 Notices are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable via the `core` module.
 
-<DocBlock name="CSS Variables" type="file" src="notice/src/_root.scss">
+<DocBlock name="CSS Variables" src="notice/src/_root.scss">
 
   ```scss
   @use "@vrembem/core";
@@ -210,7 +210,7 @@ Notices are primarily customized using CSS variables but can also be modified us
   ```
 </DocBlock>
 
-<DocBlock name="SCSS Variables" type="file" src="notice/src/_variables.scss">
+<DocBlock name="SCSS Variables" src="notice/src/_variables.scss">
 
   ```scss
   @use "@vrembem/core";

--- a/docs/src/content/packages/popover.mdx
+++ b/docs/src/content/packages/popover.mdx
@@ -264,7 +264,7 @@ Applies styles to create a popover tooltip. The default placement of a tooltip i
 
 Popovers are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable via the `core` module.
 
-<DocBlock name="CSS Variables" type="file" src="popover/src/scss/_root.scss">
+<DocBlock name="CSS Variables" src="popover/src/scss/_root.scss">
 
   ```scss
   @use "./variables" as var;
@@ -287,7 +287,7 @@ Popovers are primarily customized using CSS variables but can also be modified u
   ```
 </DocBlock>
 
-<DocBlock name="SCSS Variables" type="file" src="popover/src/scss/_variables.scss">
+<DocBlock name="SCSS Variables" src="popover/src/scss/_variables.scss">
 
   ```scss
   @use "@vrembem/core/theme";
@@ -327,7 +327,7 @@ Popovers are primarily customized using CSS variables but can also be modified u
   ```
 </DocBlock>
 
-<DocBlock name="JS Config" type="file" src="popover/src/js/defaults.js">
+<DocBlock name="JS Config" src="popover/src/js/defaults.js">
 
   ```js
   export default {

--- a/docs/src/content/packages/radio.mdx
+++ b/docs/src/content/packages/radio.mdx
@@ -192,7 +192,7 @@ Adjust the size of a radio by increasing or decreasing its width and height. By 
 
 Radios are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable via the `core` module.
 
-<DocBlock name="CSS Variables" type="file" src="radio/src/_root.scss">
+<DocBlock name="CSS Variables" src="radio/src/_root.scss">
 
   ```scss
   @use "@vrembem/core";
@@ -221,7 +221,7 @@ Radios are primarily customized using CSS variables but can also be modified usi
   ```
 </DocBlock>
 
-<DocBlock name="SCSS Variables" type="file" src="radio/src/_variables.scss">
+<DocBlock name="SCSS Variables" src="radio/src/_variables.scss">
 
   ```scss
   @use "@vrembem/core";

--- a/docs/src/content/packages/section.mdx
+++ b/docs/src/content/packages/section.mdx
@@ -146,7 +146,7 @@ Sections have a few size modifier options to help adjust the space that is used 
 
 Sections are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable via the `core` module.
 
-<DocBlock name="CSS Variables" type="file" src="section/src/_root.scss">
+<DocBlock name="CSS Variables" src="section/src/_root.scss">
 
   ```scss
   @use "@vrembem/core";
@@ -167,7 +167,7 @@ Sections are primarily customized using CSS variables but can also be modified u
   ```
 </DocBlock>
 
-<DocBlock name="SCSS Variables" type="file" src="section/src/_variables.scss">
+<DocBlock name="SCSS Variables" src="section/src/_variables.scss">
 
   ```scss
   @use "@vrembem/core";

--- a/docs/src/content/packages/switch.mdx
+++ b/docs/src/content/packages/switch.mdx
@@ -160,7 +160,7 @@ Adjust the size of a switch by increasing or decreasing its width and height. By
 
 Switches are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable via the `core` module.
 
-<DocBlock name="CSS Variables" type="file" src="switch/src/_root.scss">
+<DocBlock name="CSS Variables" src="switch/src/_root.scss">
 
   ```scss
   @use "@vrembem/core";
@@ -189,7 +189,7 @@ Switches are primarily customized using CSS variables but can also be modified u
   ```
 </DocBlock>
 
-<DocBlock name="SCSS Variables" type="file" src="switch/src/_variables.scss">
+<DocBlock name="SCSS Variables" src="switch/src/_variables.scss">
 
   ```scss
   @use "@vrembem/core";

--- a/docs/src/content/packages/table.mdx
+++ b/docs/src/content/packages/table.mdx
@@ -582,7 +582,7 @@ Adds zebra styled rows to a table to help increase its readability. This is done
 
 Tables are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable via the `core` module.
 
-<DocBlock name="CSS Variables" type="file" src="table/src/_root.scss">
+<DocBlock name="CSS Variables" src="table/src/_root.scss">
 
   ```scss
   @use "@vrembem/core";
@@ -608,7 +608,7 @@ Tables are primarily customized using CSS variables but can also be modified usi
   ```
 </DocBlock>
 
-<DocBlock name="SCSS Variables" type="file" src="table/src/_variables.scss">
+<DocBlock name="SCSS Variables" src="table/src/_variables.scss">
 
   ```scss
   @use "@vrembem/core";

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -40,7 +40,7 @@ import Icon from "../components/Icon.astro";
       <div class="grid">
         <div class="grid__item span-12 span-6-sm span-4-lg">
           <div class="background radius-lg padding-xl gap-y-sm">
-            <Icon name="database" iconClass="icon_size_lg foreground-primary" />
+            <Icon name="database" classes="icon_size_lg foreground-primary" />
             <h2 class="font-size-lg">BEM Methodoloy</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent
@@ -50,7 +50,7 @@ import Icon from "../components/Icon.astro";
         </div>
         <div class="grid__item span-12 span-6-sm span-4-lg">
           <div class="background radius-lg padding-xl gap-y-sm">
-            <Icon name="box" iconClass="icon_size_lg foreground-primary" />
+            <Icon name="box" classes="icon_size_lg foreground-primary" />
             <h2 class="font-size-lg">CSS Variables</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent
@@ -60,7 +60,7 @@ import Icon from "../components/Icon.astro";
         </div>
         <div class="grid__item span-12 span-6-sm span-4-lg">
           <div class="background radius-lg padding-xl gap-y-sm">
-            <Icon name="zap" iconClass="icon_size_lg foreground-primary" />
+            <Icon name="zap" classes="icon_size_lg foreground-primary" />
             <h2 class="font-size-lg">Theming System</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent
@@ -70,7 +70,7 @@ import Icon from "../components/Icon.astro";
         </div>
         <div class="grid__item span-12 span-6-sm span-4-lg">
           <div class="background radius-lg padding-xl gap-y-sm">
-            <Icon name="award" iconClass="icon_size_lg foreground-primary" />
+            <Icon name="award" classes="icon_size_lg foreground-primary" />
             <h2 class="font-size-lg">Accessible</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent
@@ -80,7 +80,7 @@ import Icon from "../components/Icon.astro";
         </div>
         <div class="grid__item span-12 span-6-sm span-4-lg">
           <div class="background radius-lg padding-xl gap-y-sm">
-            <Icon name="command" iconClass="icon_size_lg foreground-primary" />
+            <Icon name="command" classes="icon_size_lg foreground-primary" />
             <h2 class="font-size-lg">Modular</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent
@@ -90,7 +90,7 @@ import Icon from "../components/Icon.astro";
         </div>
         <div class="grid__item span-12 span-6-sm span-4-lg">
           <div class="background radius-lg padding-xl gap-y-sm">
-            <Icon name="search" iconClass="icon_size_lg foreground-primary" />
+            <Icon name="search" classes="icon_size_lg foreground-primary" />
             <h2 class="font-size-lg">Customizable</h2>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent

--- a/packages/icon/index.scss
+++ b/packages/icon/index.scss
@@ -1,5 +1,6 @@
 @forward "./src/variables";
 @forward "./src/mixins";
+@forward "./src/root";
 @forward "./src/icon";
 @forward "./src/icon_size";
 @forward "./src/icon_style";

--- a/packages/icon/src/_icon.scss
+++ b/packages/icon/src/_icon.scss
@@ -9,6 +9,6 @@
   flex-shrink: 0;
   width: 1em;
   height: 1em;
-  font-size: var.$size;
+  font-size: core.css("icon-size");
   vertical-align: top;
 }

--- a/packages/icon/src/_icon.scss
+++ b/packages/icon/src/_icon.scss
@@ -9,8 +9,6 @@
   flex-shrink: 0;
   width: 1em;
   height: 1em;
-  stroke-linecap: var.$stroke-linecap;
-  stroke-linejoin: var.$stroke-linejoin;
   font-size: var.$size;
-  vertical-align: var.$vertical-align;
+  vertical-align: top;
 }

--- a/packages/icon/src/_icon.scss
+++ b/packages/icon/src/_icon.scss
@@ -1,7 +1,8 @@
+@use "@vrembem/core";
 @use "./variables" as var;
 @use "./mixins" as mix;
 
-.#{var.$prefix-block}icon {
+#{core.bem("icon")} {
   @include mix.icon-style(var.$style);
   display: inline-block;
   box-sizing: content-box;

--- a/packages/icon/src/_icon_size.scss
+++ b/packages/icon/src/_icon_size.scss
@@ -2,21 +2,21 @@
 @use "./variables" as var;
 
 #{core.bem("icon", null, "size", "xs")} {
-  stroke-width: var.$size-xs-stroke-width;
-  font-size: var.$size-xs;
+  @include core.css("icon-size", var.$size-xs);
+  @include core.css("icon-stroke-width", var.$size-xs-stroke-width);
 }
 
 #{core.bem("icon", null, "size", "sm")} {
-  stroke-width: var.$size-sm-stroke-width;
-  font-size: var.$size-sm;
+  @include core.css("icon-size", var.$size-sm);
+  @include core.css("icon-stroke-width", var.$size-sm-stroke-width);
 }
 
 #{core.bem("icon", null, "size", "lg")} {
-  stroke-width: var.$size-lg-stroke-width;
-  font-size: var.$size-lg;
+  @include core.css("icon-size", var.$size-lg);
+  @include core.css("icon-stroke-width", var.$size-lg-stroke-width);
 }
 
 #{core.bem("icon", null, "size", "xl")} {
-  stroke-width: var.$size-xl-stroke-width;
-  font-size: var.$size-xl;
+  @include core.css("icon-size", var.$size-xl);
+  @include core.css("icon-stroke-width", var.$size-xl-stroke-width);
 }

--- a/packages/icon/src/_icon_size.scss
+++ b/packages/icon/src/_icon_size.scss
@@ -1,25 +1,22 @@
+@use "@vrembem/core";
 @use "./variables" as var;
 
-$_b: #{var.$prefix-block};
-$_m: #{var.$prefix-modifier};
-$_v: #{var.$prefix-modifier-value};
-
-.#{$_b}icon#{$_m}size#{$_v}xs {
+#{core.bem("icon", null, "size", "xs")} {
   stroke-width: var.$size-xs-stroke-width;
   font-size: var.$size-xs;
 }
 
-.#{$_b}icon#{$_m}size#{$_v}sm {
+#{core.bem("icon", null, "size", "sm")} {
   stroke-width: var.$size-sm-stroke-width;
   font-size: var.$size-sm;
 }
 
-.#{$_b}icon#{$_m}size#{$_v}lg {
+#{core.bem("icon", null, "size", "lg")} {
   stroke-width: var.$size-lg-stroke-width;
   font-size: var.$size-lg;
 }
 
-.#{$_b}icon#{$_m}size#{$_v}xl {
+#{core.bem("icon", null, "size", "xl")} {
   stroke-width: var.$size-xl-stroke-width;
   font-size: var.$size-xl;
 }

--- a/packages/icon/src/_icon_style.scss
+++ b/packages/icon/src/_icon_style.scss
@@ -8,3 +8,7 @@
 #{core.bem("icon", null, "style", "fill")} {
   @include mix.icon-style("fill");
 }
+
+#{core.bem("icon", null, "style", "both")} {
+  @include mix.icon-style("both");
+}

--- a/packages/icon/src/_icon_style.scss
+++ b/packages/icon/src/_icon_style.scss
@@ -1,14 +1,10 @@
-@use "./variables" as var;
+@use "@vrembem/core";
 @use "./mixins" as mix;
 
-$_b: #{var.$prefix-block};
-$_m: #{var.$prefix-modifier};
-$_v: #{var.$prefix-modifier-value};
-
-.#{$_b}icon#{$_m}style#{$_v}stroke {
+#{core.bem("icon", null, "style", "stroke")} {
   @include mix.icon-style("stroke");
 }
 
-.#{$_b}icon#{$_m}style#{$_v}fill {
+#{core.bem("icon", null, "style", "fill")} {
   @include mix.icon-style("fill");
 }

--- a/packages/icon/src/_mixins.scss
+++ b/packages/icon/src/_mixins.scss
@@ -1,21 +1,21 @@
-@use "./variables" as var;
+@use "@vrembem/core";
 
 @mixin icon-style($style) {
   @if ($style == "stroke") {
-    stroke: currentcolor;
-    stroke-width: var.$stroke-width;
+    stroke: core.css("icon-color");
+    stroke-width: core.css("icon-stroke-width");
     fill: none;
   }
 
   @else if ($style == "fill") {
     stroke: none;
     stroke-width: 0;
-    fill: currentcolor;
+    fill: core.css("icon-color");
   }
 
   @else {
-    stroke: currentcolor;
-    stroke-width: var.$stroke-width;
-    fill: currentcolor;
+    stroke: core.css("icon-color");
+    stroke-width: core.css("icon-stroke-width");
+    fill: core.css("icon-color");
   }
 }

--- a/packages/icon/src/_mixins.scss
+++ b/packages/icon/src/_mixins.scss
@@ -6,9 +6,16 @@
     stroke-width: var.$stroke-width;
     fill: none;
   }
+
   @else if ($style == "fill") {
     stroke: none;
     stroke-width: 0;
+    fill: currentcolor;
+  }
+
+  @else {
+    stroke: currentcolor;
+    stroke-width: var.$stroke-width;
     fill: currentcolor;
   }
 }

--- a/packages/icon/src/_root.scss
+++ b/packages/icon/src/_root.scss
@@ -1,0 +1,9 @@
+@use "@vrembem/core";
+@use "@vrembem/core/theme";
+@use "./variables" as var;
+
+#{theme.$root-selector} {
+  @include core.css("icon-size", var.$size);
+  @include core.css("icon-stroke-width", var.$stroke-width);
+  @include core.css("icon-color", var.$color);
+}

--- a/packages/icon/src/_variables.scss
+++ b/packages/icon/src/_variables.scss
@@ -3,6 +3,7 @@
 $style: "stroke" !default;
 $size: 1.5em !default;
 $stroke-width: 2 !default;
+$color: currentColor !default;
 
 $size-xs: 0.75em !default;
 $size-xs-stroke-width: 3.5 !default;

--- a/packages/icon/src/_variables.scss
+++ b/packages/icon/src/_variables.scss
@@ -3,7 +3,7 @@
 $style: "stroke" !default;
 $size: 1.5em !default;
 $stroke-width: 2 !default;
-$color: currentColor !default;
+$color: currentcolor !default;
 
 $size-xs: 0.75em !default;
 $size-xs-stroke-width: 3.5 !default;

--- a/packages/icon/src/_variables.scss
+++ b/packages/icon/src/_variables.scss
@@ -1,10 +1,5 @@
 @use "@vrembem/core";
 
-$prefix-block: core.$prefix-block !default;
-$prefix-element: core.$prefix-element !default;
-$prefix-modifier: core.$prefix-modifier !default;
-$prefix-modifier-value: core.$prefix-modifier-value !default;
-
 $style: "stroke" !default;
 $size: 1.5em !default;
 $stroke-width: 2 !default;

--- a/packages/icon/src/_variables.scss
+++ b/packages/icon/src/_variables.scss
@@ -3,9 +3,6 @@
 $style: "stroke" !default;
 $size: 1.5em !default;
 $stroke-width: 2 !default;
-$stroke-linecap: round !default;
-$stroke-linejoin: round !default;
-$vertical-align: top !default;
 
 $size-xs: 0.75em !default;
 $size-xs-stroke-width: 3.5 !default;


### PR DESCRIPTION
## What changed?

This PR migrates the icon component to the new custom property (CSS variables) methodology. This applies new custom properties and properly applies the new BEM and CSS mixins/functions. The docs have also been updated to reflect these changes.