### PR TITLE
Create better build entries into the Vrembem package

### DIFF
--- a/packages/vrembem/build/components.scss
+++ b/packages/vrembem/build/components.scss
@@ -1,0 +1,1 @@
+@forward "../index.scss";

--- a/packages/vrembem/build/index.scss
+++ b/packages/vrembem/build/index.scss
@@ -1,0 +1,2 @@
+@forward "../index.scss";
+@forward "../root.scss";

--- a/packages/vrembem/build/root.scss
+++ b/packages/vrembem/build/root.scss
@@ -1,0 +1,1 @@
+@forward "../root.scss";

--- a/packages/vrembem/package.json
+++ b/packages/vrembem/package.json
@@ -13,7 +13,7 @@
   "main": "./dist/index.js",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
+      "import": "./index.js",
       "require": "./dist/index.umd.cjs"
     },
     "./css": "./dist/index.css",
@@ -34,21 +34,17 @@
   ],
   "scripts": {
     "serve": "vite",
-    "build": "npm-run-all clean styles root scripts",
+    "build": "npm-run-all clean styles scripts",
     "clean": "del dev && del dist",
     "scripts": "npm-run-all scripts:dev scripts:dist",
     "scripts:dev": "vite build --outDir dev --minify false",
     "scripts:dist": "vite build --outDir dist",
     "styles": "npm-run-all styles:dev styles:dist",
-    "styles:dev": "sass index.scss dev/index.css --load-path=../../node_modules",
-    "styles:dist": "sass index.scss dist/index.css --load-path=../../node_modules --style=compressed",
-    "root": "npm-run-all root:dev root:dist",
-    "root:dev": "sass root.scss dev/root.css --load-path=../../node_modules",
-    "root:dist": "sass root.scss dist/root.css --load-path=../../node_modules --style=compressed",
-    "watch": "concurrently --kill-others 'npm run watch:scripts' 'npm run watch:styles' 'npm run watch:root'",
+    "styles:dev": "sass build:dev --load-path=../../node_modules",
+    "styles:dist": "sass build:dist --load-path=../../node_modules --style=compressed",
+    "watch": "concurrently --kill-others 'npm run watch:scripts' 'npm run watch:styles'",
     "watch:scripts": "concurrently 'npm run scripts:dev -- --watch' 'npm run scripts:dist -- --watch'",
-    "watch:styles": "concurrently 'npm run styles:dev -- --watch' 'npm run styles:dist -- --watch'",
-    "watch:root": "concurrently 'npm run root:dev -- --watch' 'npm run root:dist -- --watch'"
+    "watch:styles": "concurrently 'npm run styles:dev -- --watch' 'npm run styles:dist -- --watch'"
   },
   "repository": {
     "type": "git",

--- a/packages/vrembem/package.json
+++ b/packages/vrembem/package.json
@@ -10,21 +10,19 @@
     "component",
     "library"
   ],
-  "main": "./dist/index.js",
   "exports": {
     ".": {
       "import": "./index.js",
-      "require": "./dist/index.umd.cjs"
+      "require": "./dist/index.umd.cjs",
+      "sass": "./index.scss",
+      "style": "./dist/index.css"
     },
-    "./css": "./dist/index.css",
-    "./scss": "./index.scss",
     "./dev": "./dev/index.css",
     "./dist": "./dist/index.css",
+    "./dev/*": "./dev/*",
+    "./dist/*": "./dist/*",
     "./root": "./root.scss"
   },
-  "unpkg": "dist/index.umd.cjs",
-  "sass": "index.scss",
-  "style": "dist/index.css",
   "files": [
     "dev",
     "dist",


### PR DESCRIPTION
## What changed?

There's a need to create two distinct ways of consuming Vrembem packages; either via Sass or compiled CSS files. This PR tries to address these needs by creating a `build` directory which handles tailoring the output CSS files and leaving the root `scss` imports to be more tailored to using Vrembem in a Sass workflow.