### PR TITLE
Fix param parsing in css.set

### DIFF
--- a/packages/core/src/scss/modules/_css.scss
+++ b/packages/core/src/scss/modules/_css.scss
@@ -212,6 +212,9 @@ $_variables: (
 ///
 @mixin set($module, $prop, $value: null, $args...) {
   @if (meta.type-of($prop) == "map") {
+    @if ($value) {
+      $args: list.append($args, $value);
+    }
     @each $propKey, $propValue in $prop {
       @if (meta.type-of($propValue) == "map") {
         @each $key, $value in $propValue {


### PR DESCRIPTION
## What changed?

This PR fixes a bug with `css.set()` where passing a prop/value map as the second param didn't correctly reassign the third param as part of the meta arguments. This PR fixes this scenario by appending `$value` to `$args` if `$prop` is a map.