### PR TITLE
Allow passing maps to config.set mixin

### DIFF
--- a/packages/core/src/scss/modules/_config.scss
+++ b/packages/core/src/scss/modules/_config.scss
@@ -1,4 +1,6 @@
 @use "sass:map";
+@use "sass:meta";
+
 @use "../utilities/debug-map" as *;
 
 /// Stores all library wide configuration options.
@@ -23,11 +25,49 @@ $_options: (
 
 /// Set an option in the configuration map.
 /// @param {string} $key
-///   The key in the map to set.
-/// @param {any} $value
-///   The value to be stored.
-@mixin set($key, $value) {
-  $_options: map.set($_options, $key, $value) !global;
+///   The key in the map to set. Can be passed a map of key/value pairs. E.g:
+///   - ("key": "value"), null
+///   - ("key": ("key": "value")), null
+/// @param {any} $value [null]
+///   The value to be stored. Can be passed a map of key/value pairs where key
+///   will be prefixed with the provided value keys. E.g:
+///   - "key", "value"
+///   - "key", ("key": "value")
+@mixin set($key, $value: null) {
+  // Initialize the options map to our result.
+  $result: $_options;
+
+  @if (meta.type-of($key) == "map") {
+    @each $keyKey, $keyValue in $key {
+
+      // Scenario: ("key": ("key": "value")), null
+      @if (meta.type-of($keyValue) == "map") {
+        @each $key, $value in $keyValue {
+          $result: map.set($result, "#{$keyKey}-#{$key}", $value);
+        }
+      }
+
+      // Scenario: ("key": "value"), null
+      @else {
+        $result: map.set($result, $keyKey, $keyValue);
+      }
+    }
+  }
+
+  // Scenario: "key", ("key": "value")
+  @else if (meta.type-of($value) == "map") {
+    @each $valueKey, $value in $value {
+      $result: map.set($result, "#{$key}-#{$valueKey}", $value);
+    }
+  }
+
+  // Scenario: "key", "value"
+  @else {
+    $result: map.set($result, $key, $value);
+  }
+
+  // Save our updated map.
+  $_options: $result !global;
 }
 
 /// Remove an option from the configuration map.

--- a/packages/core/src/scss/modules/_css.scss
+++ b/packages/core/src/scss/modules/_css.scss
@@ -212,10 +212,15 @@ $_variables: (
 ///
 @mixin set($module, $prop, $value: null, $args...) {
   @if (meta.type-of($prop) == "map") {
+    
+    // Add value to args if one exists.
     @if ($value) {
       $args: list.append($args, $value);
     }
+
     @each $propKey, $propValue in $prop {
+
+      // Scenario: ("prop": ("prop": "value"))
       @if (meta.type-of($propValue) == "map") {
         @each $key, $value in $propValue {
           @if (list.length($args) > 0) {
@@ -223,7 +228,10 @@ $_variables: (
           }
           $_variables: map.set($_variables, $module, "#{$propKey}-#{$key}", $value) !global;
         }
-      } @else {
+      }
+
+      // Scenario: ("prop": "value")
+      @else {
         @if (list.length($args) > 0) {
           @include usage.set($module, $propKey, $args...);
         }
@@ -232,6 +240,7 @@ $_variables: (
     }
   }
 
+  // Scenario: "prop", ("prop": "value")
   @else if (meta.type-of($value) == "map") {
     @each $key, $value in $value {
       @if (list.length($args) > 0) {
@@ -241,6 +250,7 @@ $_variables: (
     }
   }
 
+  // Scenario: "prop", "value"
   @else {
     @if (list.length($args) > 0) {
       @include usage.set($module, $prop, $args...);


### PR DESCRIPTION
## What changed?

This PR updates the logic in `config.set` to now allow passing maps for more easily updating the config options map. This behavior is mirrored to how `css.set` works where the following parameter type are valid:
- `"key", "value"`
- `"key", ("key": "value")`
- `("key": "value"), null`
- `("key": ("key": "value")), null`

In cases where nested maps are provided, the root key is prefixed to subsequent keys. This allows the following:

```
@include config.set("asdf", (
  "one": 1,
  "two": 2
));

// Resulting options map:
$_options: (
  "asdf-one": 1,
  "asdf-two": 2
);
```