### PR TITLE
Improve package exports for better entry paths

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -10,15 +10,16 @@
     "base"
   ],
   "exports": {
-    ".": "./index.scss",
-    "./css": "./dist/index.css",
-    "./scss": "./index.scss",
+    ".": {
+      "sass": "./index.scss",
+      "style": "./dist/index.css"
+    },
     "./dev": "./dev/index.css",
     "./dist": "./dist/index.css",
+    "./dev/*": "./dev/*",
+    "./dist/*": "./dist/*",
     "./*": "./src/*"
   },
-  "sass": "index.scss",
-  "style": "dist/index.css",
   "scripts": {
     "serve": "vite",
     "build": "npm-run-all clean styles",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -14,8 +14,6 @@
       "sass": "./index.scss",
       "style": "./dist/index.css"
     },
-    "./dev": "./dev/index.css",
-    "./dist": "./dist/index.css",
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",
     "./*": "./src/*"

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -10,15 +10,16 @@
     "button"
   ],
   "exports": {
-    ".": "./index.scss",
-    "./css": "./dist/index.css",
-    "./scss": "./index.scss",
+    ".": {
+      "sass": "./index.scss",
+      "style": "./dist/index.css"
+    },
     "./dev": "./dev/index.css",
     "./dist": "./dist/index.css",
+    "./dev/*": "./dev/*",
+    "./dist/*": "./dist/*",
     "./*": "./src/*"
   },
-  "sass": "index.scss",
-  "style": "dist/index.css",
   "scripts": {
     "serve": "vite",
     "build": "npm-run-all clean styles",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -14,8 +14,6 @@
       "sass": "./index.scss",
       "style": "./dist/index.css"
     },
-    "./dev": "./dev/index.css",
-    "./dist": "./dist/index.css",
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",
     "./*": "./src/*"

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -10,15 +10,16 @@
     "card"
   ],
   "exports": {
-    ".": "./index.scss",
-    "./css": "./dist/index.css",
-    "./scss": "./index.scss",
+    ".": {
+      "sass": "./index.scss",
+      "style": "./dist/index.css"
+    },
     "./dev": "./dev/index.css",
     "./dist": "./dist/index.css",
+    "./dev/*": "./dev/*",
+    "./dist/*": "./dist/*",
     "./*": "./src/*"
   },
-  "sass": "index.scss",
-  "style": "dist/index.css",
   "scripts": {
     "serve": "vite",
     "build": "npm-run-all clean styles",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -14,8 +14,6 @@
       "sass": "./index.scss",
       "style": "./dist/index.css"
     },
-    "./dev": "./dev/index.css",
-    "./dist": "./dist/index.css",
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",
     "./*": "./src/*"

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -10,15 +10,16 @@
     "checkbox"
   ],
   "exports": {
-    ".": "./index.scss",
-    "./css": "./dist/index.css",
-    "./scss": "./index.scss",
+    ".": {
+      "sass": "./index.scss",
+      "style": "./dist/index.css"
+    },
     "./dev": "./dev/index.css",
     "./dist": "./dist/index.css",
+    "./dev/*": "./dev/*",
+    "./dist/*": "./dist/*",
     "./*": "./src/*"
   },
-  "sass": "index.scss",
-  "style": "dist/index.css",
   "scripts": {
     "serve": "vite",
     "build": "npm-run-all clean styles",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -14,8 +14,6 @@
       "sass": "./index.scss",
       "style": "./dist/index.css"
     },
-    "./dev": "./dev/index.css",
-    "./dist": "./dist/index.css",
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",
     "./*": "./src/*"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,10 +10,9 @@
     "component",
     "core"
   ],
-  "main": "./dist/index.js",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
+      "import": "./index.js",
       "require": "./dist/index.umd.cjs",
       "sass": "./index.scss",
       "style": "./dist/index.css"
@@ -28,9 +27,8 @@
     "./css": "./src/scss/modules/css.scss",
     "./palette": "./src/scss/modules/palette.scss",
     "./theme": "./src/scss/modules/theme.scss",
-    "./*": "./src/scss/*"
+    "./*": "./src/*"
   },
-  "unpkg": "dist/index.umd.cjs",
   "sass": "index.scss",
   "style": "dist/index.css",
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,8 +17,6 @@
       "sass": "./index.scss",
       "style": "./dist/index.css"
     },
-    "./dev": "./dev/index.css",
-    "./dist": "./dist/index.css",
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",
     "./root": "./root.scss",
@@ -29,8 +27,6 @@
     "./theme": "./src/scss/modules/theme.scss",
     "./*": "./src/*"
   },
-  "sass": "index.scss",
-  "style": "dist/index.css",
   "files": [
     "dev",
     "dist",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -10,15 +10,16 @@
     "dialog"
   ],
   "exports": {
-    ".": "./index.scss",
-    "./css": "./dist/index.css",
-    "./scss": "./index.scss",
+    ".": {
+      "sass": "./index.scss",
+      "style": "./dist/index.css"
+    },
     "./dev": "./dev/index.css",
     "./dist": "./dist/index.css",
+    "./dev/*": "./dev/*",
+    "./dist/*": "./dist/*",
     "./*": "./src/*"
   },
-  "sass": "index.scss",
-  "style": "dist/index.css",
   "scripts": {
     "serve": "vite",
     "build": "npm-run-all clean styles",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -14,8 +14,6 @@
       "sass": "./index.scss",
       "style": "./dist/index.css"
     },
-    "./dev": "./dev/index.css",
-    "./dist": "./dist/index.css",
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",
     "./*": "./src/*"

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -17,8 +17,6 @@
       "sass": "./index.scss",
       "style": "./dist/index.css"
     },
-    "./dev": "./dev/index.css",
-    "./dist": "./dist/index.css",
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",
     "./*": "./src/*"

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -10,21 +10,19 @@
     "component",
     "drawer"
   ],
-  "main": "./dist/index.js",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.umd.cjs"
+      "import": "./index.js",
+      "require": "./dist/index.umd.cjs",
+      "sass": "./index.scss",
+      "style": "./dist/index.css"
     },
-    "./css": "./dist/index.css",
-    "./scss": "./index.scss",
     "./dev": "./dev/index.css",
     "./dist": "./dist/index.css",
-    "./*": "./src/scss/*"
+    "./dev/*": "./dev/*",
+    "./dist/*": "./dist/*",
+    "./*": "./src/*"
   },
-  "unpkg": "dist/index.umd.cjs",
-  "sass": "index.scss",
-  "style": "dist/index.css",
   "files": [
     "dev",
     "dist",

--- a/packages/flex/package.json
+++ b/packages/flex/package.json
@@ -10,15 +10,16 @@
     "flex"
   ],
   "exports": {
-    ".": "./index.scss",
-    "./css": "./dist/index.css",
-    "./scss": "./index.scss",
+    ".": {
+      "sass": "./index.scss",
+      "style": "./dist/index.css"
+    },
     "./dev": "./dev/index.css",
     "./dist": "./dist/index.css",
+    "./dev/*": "./dev/*",
+    "./dist/*": "./dist/*",
     "./*": "./src/*"
   },
-  "sass": "index.scss",
-  "style": "dist/index.css",
   "scripts": {
     "serve": "vite",
     "build": "npm-run-all clean styles",

--- a/packages/flex/package.json
+++ b/packages/flex/package.json
@@ -14,8 +14,6 @@
       "sass": "./index.scss",
       "style": "./dist/index.css"
     },
-    "./dev": "./dev/index.css",
-    "./dist": "./dist/index.css",
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",
     "./*": "./src/*"

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -14,8 +14,6 @@
       "sass": "./index.scss",
       "style": "./dist/index.css"
     },
-    "./dev": "./dev/index.css",
-    "./dist": "./dist/index.css",
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",
     "./*": "./src/*"

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -10,15 +10,16 @@
     "grid"
   ],
   "exports": {
-    ".": "./index.scss",
-    "./css": "./dist/index.css",
-    "./scss": "./index.scss",
+    ".": {
+      "sass": "./index.scss",
+      "style": "./dist/index.css"
+    },
     "./dev": "./dev/index.css",
     "./dist": "./dist/index.css",
+    "./dev/*": "./dev/*",
+    "./dist/*": "./dist/*",
     "./*": "./src/*"
   },
-  "sass": "index.scss",
-  "style": "dist/index.css",
   "scripts": {
     "serve": "vite",
     "build": "npm-run-all clean styles",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -10,15 +10,16 @@
     "icon"
   ],
   "exports": {
-    ".": "./index.scss",
-    "./css": "./dist/index.css",
-    "./scss": "./index.scss",
+    ".": {
+      "sass": "./index.scss",
+      "style": "./dist/index.css"
+    },
     "./dev": "./dev/index.css",
     "./dist": "./dist/index.css",
+    "./dev/*": "./dev/*",
+    "./dist/*": "./dist/*",
     "./*": "./src/*"
   },
-  "sass": "index.scss",
-  "style": "dist/index.css",
   "scripts": {
     "serve": "vite",
     "build": "npm-run-all clean styles",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -14,8 +14,6 @@
       "sass": "./index.scss",
       "style": "./dist/index.css"
     },
-    "./dev": "./dev/index.css",
-    "./dist": "./dist/index.css",
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",
     "./*": "./src/*"

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -10,15 +10,16 @@
     "input"
   ],
   "exports": {
-    ".": "./index.scss",
-    "./css": "./dist/index.css",
-    "./scss": "./index.scss",
+    ".": {
+      "sass": "./index.scss",
+      "style": "./dist/index.css"
+    },
     "./dev": "./dev/index.css",
     "./dist": "./dist/index.css",
+    "./dev/*": "./dev/*",
+    "./dist/*": "./dist/*",
     "./*": "./src/*"
   },
-  "sass": "index.scss",
-  "style": "dist/index.css",
   "scripts": {
     "serve": "vite",
     "build": "npm-run-all clean styles",

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -14,8 +14,6 @@
       "sass": "./index.scss",
       "style": "./dist/index.css"
     },
-    "./dev": "./dev/index.css",
-    "./dist": "./dist/index.css",
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",
     "./*": "./src/*"

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -10,15 +10,16 @@
     "menu"
   ],
   "exports": {
-    ".": "./index.scss",
-    "./css": "./dist/index.css",
-    "./scss": "./index.scss",
+    ".": {
+      "sass": "./index.scss",
+      "style": "./dist/index.css"
+    },
     "./dev": "./dev/index.css",
     "./dist": "./dist/index.css",
+    "./dev/*": "./dev/*",
+    "./dist/*": "./dist/*",
     "./*": "./src/*"
   },
-  "sass": "index.scss",
-  "style": "dist/index.css",
   "scripts": {
     "serve": "vite",
     "build": "npm-run-all clean styles",

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -14,8 +14,6 @@
       "sass": "./index.scss",
       "style": "./dist/index.css"
     },
-    "./dev": "./dev/index.css",
-    "./dist": "./dist/index.css",
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",
     "./*": "./src/*"

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -17,8 +17,6 @@
       "sass": "./index.scss",
       "style": "./dist/index.css"
     },
-    "./dev": "./dev/index.css",
-    "./dist": "./dist/index.css",
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",
     "./*": "./src/*"

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -10,21 +10,19 @@
     "component",
     "modal"
   ],
-  "main": "./dist/index.js",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.umd.cjs"
+      "import": "./index.js",
+      "require": "./dist/index.umd.cjs",
+      "sass": "./index.scss",
+      "style": "./dist/index.css"
     },
-    "./css": "./dist/index.css",
-    "./scss": "./index.scss",
     "./dev": "./dev/index.css",
     "./dist": "./dist/index.css",
-    "./*": "./src/scss/*"
+    "./dev/*": "./dev/*",
+    "./dist/*": "./dist/*",
+    "./*": "./src/*"
   },
-  "unpkg": "dist/index.umd.cjs",
-  "sass": "index.scss",
-  "style": "dist/index.css",
   "files": [
     "dev",
     "dist",

--- a/packages/notice/package.json
+++ b/packages/notice/package.json
@@ -10,15 +10,16 @@
     "notice"
   ],
   "exports": {
-    ".": "./index.scss",
-    "./css": "./dist/index.css",
-    "./scss": "./index.scss",
+    ".": {
+      "sass": "./index.scss",
+      "style": "./dist/index.css"
+    },
     "./dev": "./dev/index.css",
     "./dist": "./dist/index.css",
+    "./dev/*": "./dev/*",
+    "./dist/*": "./dist/*",
     "./*": "./src/*"
   },
-  "sass": "index.scss",
-  "style": "dist/index.css",
   "scripts": {
     "serve": "vite",
     "build": "npm-run-all clean styles",

--- a/packages/notice/package.json
+++ b/packages/notice/package.json
@@ -14,8 +14,6 @@
       "sass": "./index.scss",
       "style": "./dist/index.css"
     },
-    "./dev": "./dev/index.css",
-    "./dist": "./dist/index.css",
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",
     "./*": "./src/*"

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -17,8 +17,6 @@
       "sass": "./index.scss",
       "style": "./dist/index.css"
     },
-    "./dev": "./dev/index.css",
-    "./dist": "./dist/index.css",
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",
     "./*": "./src/*"

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -10,21 +10,19 @@
     "component",
     "popover"
   ],
-  "main": "./dist/index.js",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.umd.cjs"
+      "import": "./index.js",
+      "require": "./dist/index.umd.cjs",
+      "sass": "./index.scss",
+      "style": "./dist/index.css"
     },
-    "./css": "./dist/index.css",
-    "./scss": "./index.scss",
     "./dev": "./dev/index.css",
     "./dist": "./dist/index.css",
-    "./*": "./src/scss/*"
+    "./dev/*": "./dev/*",
+    "./dist/*": "./dist/*",
+    "./*": "./src/*"
   },
-  "unpkg": "dist/index.umd.cjs",
-  "sass": "index.scss",
-  "style": "dist/index.css",
   "files": [
     "dev",
     "dist",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -10,15 +10,16 @@
     "radio"
   ],
   "exports": {
-    ".": "./index.scss",
-    "./css": "./dist/index.css",
-    "./scss": "./index.scss",
+    ".": {
+      "sass": "./index.scss",
+      "style": "./dist/index.css"
+    },
     "./dev": "./dev/index.css",
     "./dist": "./dist/index.css",
+    "./dev/*": "./dev/*",
+    "./dist/*": "./dist/*",
     "./*": "./src/*"
   },
-  "sass": "index.scss",
-  "style": "dist/index.css",
   "scripts": {
     "serve": "vite",
     "build": "npm-run-all clean styles",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -14,8 +14,6 @@
       "sass": "./index.scss",
       "style": "./dist/index.css"
     },
-    "./dev": "./dev/index.css",
-    "./dist": "./dist/index.css",
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",
     "./*": "./src/*"

--- a/packages/section/package.json
+++ b/packages/section/package.json
@@ -10,15 +10,16 @@
     "section"
   ],
   "exports": {
-    ".": "./index.scss",
-    "./css": "./dist/index.css",
-    "./scss": "./index.scss",
+    ".": {
+      "sass": "./index.scss",
+      "style": "./dist/index.css"
+    },
     "./dev": "./dev/index.css",
     "./dist": "./dist/index.css",
+    "./dev/*": "./dev/*",
+    "./dist/*": "./dist/*",
     "./*": "./src/*"
   },
-  "sass": "index.scss",
-  "style": "dist/index.css",
   "scripts": {
     "serve": "vite",
     "build": "npm-run-all clean styles",

--- a/packages/section/package.json
+++ b/packages/section/package.json
@@ -14,8 +14,6 @@
       "sass": "./index.scss",
       "style": "./dist/index.css"
     },
-    "./dev": "./dev/index.css",
-    "./dist": "./dist/index.css",
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",
     "./*": "./src/*"

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -14,8 +14,6 @@
       "sass": "./index.scss",
       "style": "./dist/index.css"
     },
-    "./dev": "./dev/index.css",
-    "./dist": "./dist/index.css",
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",
     "./*": "./src/*"

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -10,15 +10,16 @@
     "switch"
   ],
   "exports": {
-    ".": "./index.scss",
-    "./css": "./dist/index.css",
-    "./scss": "./index.scss",
+    ".": {
+      "sass": "./index.scss",
+      "style": "./dist/index.css"
+    },
     "./dev": "./dev/index.css",
     "./dist": "./dist/index.css",
+    "./dev/*": "./dev/*",
+    "./dist/*": "./dist/*",
     "./*": "./src/*"
   },
-  "sass": "index.scss",
-  "style": "dist/index.css",
   "scripts": {
     "serve": "vite",
     "build": "npm-run-all clean styles",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -10,15 +10,16 @@
     "table"
   ],
   "exports": {
-    ".": "./index.scss",
-    "./css": "./dist/index.css",
-    "./scss": "./index.scss",
+    ".": {
+      "sass": "./index.scss",
+      "style": "./dist/index.css"
+    },
     "./dev": "./dev/index.css",
     "./dist": "./dist/index.css",
+    "./dev/*": "./dev/*",
+    "./dist/*": "./dist/*",
     "./*": "./src/*"
   },
-  "sass": "index.scss",
-  "style": "dist/index.css",
   "scripts": {
     "serve": "vite",
     "build": "npm-run-all clean styles",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -14,8 +14,6 @@
       "sass": "./index.scss",
       "style": "./dist/index.css"
     },
-    "./dev": "./dev/index.css",
-    "./dist": "./dist/index.css",
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",
     "./*": "./src/*"

--- a/packages/utility/package.json
+++ b/packages/utility/package.json
@@ -14,8 +14,6 @@
       "sass": "./index.scss",
       "style": "./dist/index.css"
     },
-    "./dev": "./dev/index.css",
-    "./dist": "./dist/index.css",
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",
     "./*": "./src/*"

--- a/packages/utility/package.json
+++ b/packages/utility/package.json
@@ -10,15 +10,16 @@
     "utility"
   ],
   "exports": {
-    ".": "./index.scss",
-    "./css": "./dist/index.css",
-    "./scss": "./index.scss",
+    ".": {
+      "sass": "./index.scss",
+      "style": "./dist/index.css"
+    },
     "./dev": "./dev/index.css",
     "./dist": "./dist/index.css",
+    "./dev/*": "./dev/*",
+    "./dist/*": "./dist/*",
     "./*": "./src/*"
   },
-  "sass": "index.scss",
-  "style": "dist/index.css",
   "scripts": {
     "serve": "vite",
     "build": "npm-run-all clean styles",

--- a/packages/vrembem/package.json
+++ b/packages/vrembem/package.json
@@ -17,8 +17,6 @@
       "sass": "./index.scss",
       "style": "./dist/index.css"
     },
-    "./dev": "./dev/index.css",
-    "./dist": "./dist/index.css",
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",
     "./root": "./root.scss"


### PR DESCRIPTION
## What changed?

This PR improves the entry packs by creating better values in `package.exports`. There are two primary ways to consume a Vrembem component and two unique exceptions. A component that only offers CSS and SCSS modules, exports are now set as follows:

```js
"exports": {
  ".": {
    "sass": "./index.scss",
    "style": "./dist/index.css"
  },
  "./dev/*": "./dev/*",
  "./dist/*": "./dist/*",
  "./*": "./src/*"
},
```

Modules that also include JavaScript entries such as `drawer`, `modal` and `popover` now look like this:

```js
"exports": {
  ".": {
    "import": "./index.js",
    "require": "./dist/index.umd.cjs",
    "sass": "./index.scss",
    "style": "./dist/index.css"
  },
  "./dev/*": "./dev/*",
  "./dist/*": "./dist/*",
  "./*": "./src/*"
},
```

The only two exceptions to these patterns are `core` and the `vrembem` package. In `vrembem`, we also include a `root` export to include all custom properties output. In `core`, we also include entires to all available core SCSS modules as well as a root import:

```js
"exports": {
    ".": {
      "import": "./index.js",
      "require": "./dist/index.umd.cjs",
      "sass": "./index.scss",
      "style": "./dist/index.css"
    },
    "./dev/*": "./dev/*",
    "./dist/*": "./dist/*",
    "./root": "./root.scss",
    "./config": "./src/scss/modules/config.scss",
    "./usage": "./src/scss/modules/usage.scss",
    "./css": "./src/scss/modules/css.scss",
    "./palette": "./src/scss/modules/palette.scss",
    "./theme": "./src/scss/modules/theme.scss",
    "./*": "./src/*"
  },
```

Because of these changes, the following package properties have been removed as they are either not standard or are superseded by the exports property:

- `"main"`: Replaced with `"." > "import"` and `"." > "require"`
- `"sass"`: Replaced with `"." > "sass"`
- `"style"`: Replaced with `"." > "style"`
