### PR TITLE
Fix theme classes not overriding system preference

### DIFF
--- a/docs/src/components/ThemeSwitcherMenu.astro
+++ b/docs/src/components/ThemeSwitcherMenu.astro
@@ -4,7 +4,7 @@ import Icon from "./Icon.astro";
 
 <ul class="menu menu_themes">
   <li class="menu__item">
-    <button data-value="root" class="menu__action">
+    <button type="button" data-value="root" class="menu__action">
       <svg class="icon icon_style_fill" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path fill-rule="evenodd" clip-rule="evenodd" d="M21 12C21 7.36745 17.5 3.55237 13 3.05493L13 20.9451C17.4999 20.4476 21 16.6326 21 12ZM12 1C18.0751 1 23 5.92487 23 12C23 18.0751 18.0751 23 12 23C5.92487 23 0.999999 18.0751 1 12C1 5.92487 5.92487 0.999999 12 1Z" fill="currentColor" />
       </svg>
@@ -12,13 +12,13 @@ import Icon from "./Icon.astro";
     </button>
   </li>
   <li class="menu__item">
-    <button data-value="light" class="menu__action">
+    <button type="button" data-value="light" class="menu__action">
       <Icon name="sun" />
       <span>Light</span>
     </button>
   </li>
   <li class="menu__item">
-    <button data-value="dark" class="menu__action">
+    <button type="button" data-value="dark" class="menu__action">
       <Icon name="moon" />
       <span>Dark</span>
     </button>

--- a/docs/src/layouts/Root.astro
+++ b/docs/src/layouts/Root.astro
@@ -32,18 +32,16 @@ mainClasses += layout.hasAside ? " has-aside" : "";
       href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;600&display=swap"
       rel="stylesheet"
     />
+  </head>
+  <body class={bodyClass}>
     <script is:inline>
       (function () {
         // Make this script blocking to prevent flash of pre-themed content.
         const local = localStorage.getItem("VB:Profile");
         const store = local ? JSON.parse(local) : {};
-        document.documentElement.classList.add(
-          `vb-theme-${store.theme || "root"}`
-        );
+        document.body.classList.add(`vb-theme-${store.theme || "root"}`);
       })();
     </script>
-  </head>
-  <body class={bodyClass}>
     <main id="main" class={mainClasses} tabindex="-1">
       <slot />
     </main>

--- a/docs/src/modules/useThemeStore.js
+++ b/docs/src/modules/useThemeStore.js
@@ -18,8 +18,8 @@ if (typeof window !== "undefined") {
     if (themes.includes(value)) {
       store.theme = value;
       profile.set("theme", value);
-      document.documentElement.classList.remove(...classes);
-      document.documentElement.classList.add(`${prefix}${value}`);
+      document.body.classList.remove(...classes);
+      document.body.classList.add(`${prefix}${value}`);
     } else {
       console.error(`Not a valid theme: "${value}"`);
     }


### PR DESCRIPTION
## What changed?

This PR correctly sets theme classes to the `body` instead of the `html` element to properly override system preference.