### PR TITLE
Improve creating and maintaining themes

### DIFF
--- a/docs/src/layouts/Root.astro
+++ b/docs/src/layouts/Root.astro
@@ -32,16 +32,16 @@ mainClasses += layout.hasAside ? " has-aside" : "";
       href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;600&display=swap"
       rel="stylesheet"
     />
-  </head>
-  <body class={bodyClass}>
     <script is:inline>
       (function () {
         // Make this script blocking to prevent flash of pre-themed content.
         const local = localStorage.getItem("VB:Profile");
         const store = local ? JSON.parse(local) : {};
-        document.body.classList.add(`vb-theme-${store.theme || "root"}`);
+        document.documentElement.classList.add(`vb-theme-${store.theme || "root"}`);
       })();
     </script>
+  </head>
+  <body class={bodyClass}>
     <main id="main" class={mainClasses} tabindex="-1">
       <slot />
     </main>

--- a/docs/src/modules/useThemeStore.js
+++ b/docs/src/modules/useThemeStore.js
@@ -18,8 +18,8 @@ if (typeof window !== "undefined") {
     if (themes.includes(value)) {
       store.theme = value;
       profile.set("theme", value);
-      document.body.classList.remove(...classes);
-      document.body.classList.add(`${prefix}${value}`);
+      document.documentElement.classList.remove(...classes);
+      document.documentElement.classList.add(`${prefix}${value}`);
     } else {
       console.error(`Not a valid theme: "${value}"`);
     }

--- a/docs/src/pages/packages/index.mdx
+++ b/docs/src/pages/packages/index.mdx
@@ -83,13 +83,14 @@ Packages and their use of the theme module will impact the flexibility of a comp
   <span class="test-3 vb-theme-dark">vb-theme-dark</span>
 </div>
 
-1. Using custom properties as values of new themes. Setting the default theme should allow all themes to inherit those styles unless explicitly set.
+4. Using custom properties as values of new themes. Setting the default theme should allow all themes to inherit those styles unless explicitly set.
 
-<div class="flex">
+<div class="flex align-items-center">
   <span class="test-4">Default</span>
   <span class="test-4 vb-theme-root">vb-theme-root</span>
   <span class="test-4 vb-theme-light">vb-theme-light</span>
   <span class="test-4 vb-theme-dark">vb-theme-dark</span>
+  <span class="test-4 vb-theme-pink">vb-theme-pink</span>
   <span class="test-4 vb-theme-matrix">vb-theme-matrix</span>
 </div>
 

--- a/docs/src/pages/packages/index.mdx
+++ b/docs/src/pages/packages/index.mdx
@@ -83,17 +83,6 @@ Packages and their use of the theme module will impact the flexibility of a comp
   <span class="test-3 vb-theme-dark">vb-theme-dark</span>
 </div>
 
-4. Using custom properties as values of new themes. Setting the default theme should allow all themes to inherit those styles unless explicitly set.
-
-<div class="flex align-items-center">
-  <span class="test-4">Default</span>
-  <span class="test-4 vb-theme-root">vb-theme-root</span>
-  <span class="test-4 vb-theme-light">vb-theme-light</span>
-  <span class="test-4 vb-theme-dark">vb-theme-dark</span>
-  <span class="test-4 vb-theme-pink">vb-theme-pink</span>
-  <span class="test-4 vb-theme-matrix">vb-theme-matrix</span>
-</div>
-
 ### CSS Theme Classes
 
 There are three themes that come from Vrembem by default though these can be expanded or removed as needed via the theme module. These themes include:

--- a/docs/src/pages/packages/index.mdx
+++ b/docs/src/pages/packages/index.mdx
@@ -83,6 +83,16 @@ Packages and their use of the theme module will impact the flexibility of a comp
   <span class="test-3 vb-theme-dark">vb-theme-dark</span>
 </div>
 
+1. Using custom properties as values of new themes. Setting the default theme should allow all themes to inherit those styles unless explicitly set.
+
+<div class="flex">
+  <span class="test-4">Default</span>
+  <span class="test-4 vb-theme-root">vb-theme-root</span>
+  <span class="test-4 vb-theme-light">vb-theme-light</span>
+  <span class="test-4 vb-theme-dark">vb-theme-dark</span>
+  <span class="test-4 vb-theme-matrix">vb-theme-matrix</span>
+</div>
+
 ### CSS Theme Classes
 
 There are three themes that come from Vrembem by default though these can be expanded or removed as needed via the theme module. These themes include:

--- a/docs/src/styles/_test.scss
+++ b/docs/src/styles/_test.scss
@@ -12,6 +12,7 @@
 }
 
 // TEST 1
+// ---
 // Using core theme properties directly.
 
 .test-1 {
@@ -21,6 +22,7 @@
 }
 
 // TEST 2
+// ---
 // Using core theme properties as values of new properties. These end up being
 // completely to the values set in :root of these custom property definitions
 // and do not change based on the presence of theme classes.
@@ -38,6 +40,7 @@
 }
 
 // TEST 3
+// ---
 // Using core theme properties as values of new themes.
 
 $theme-default: (
@@ -46,7 +49,7 @@ $theme-default: (
   "border-color": theme.get("border-color"),
 );
 
-@include theme.set("test-3", theme.$default, $theme-default);
+@include theme.set("test-3", "default", $theme-default);
 @include theme.set("test-3", "dark");
 
 .test-3 {
@@ -56,12 +59,13 @@ $theme-default: (
 }
 
 // TEST 4
+// ---
 // Using custom properties as values of new themes. Setting the default theme 
 // should allow all themes to inherit those styles unless explicitly set.
 
 // Create the default theme. All properties used in subsequent themes bust exist
 // in the default.
-@include theme.set("test-4", theme.$default, (
+@include theme.set("test-4", "default", (
   "background": theme.get("background"),
   "foreground": theme.get("foreground"),
   "border-color": theme.get("border-color"),

--- a/docs/src/styles/_test.scss
+++ b/docs/src/styles/_test.scss
@@ -24,16 +24,21 @@
  * Test 2
  */
 
-:root {
-  @include css.define("test-2", "background", theme.get("background"));
-  @include css.define("test-2", "foreground", theme.get("foreground"));
-  @include css.define("test-2", "border-color", theme.get("border-color"));
-}
+@include css.set("test-2", (
+  "background": theme.get("background"),
+  "foreground": theme.get("foreground"),
+  "border-color": theme.get("border-color")
+));
 
 .test-2 {
-  border-color: css.reference("test-2", "border-color");
-  background: css.reference("test-2", "background");
-  color: css.reference("test-2", "foreground");
+  border-color: css.get("test-2", "border-color");
+  background: css.get("test-2", "background");
+  color: css.get("test-2", "foreground");
+}
+
+:root {
+  // Output needs to come after the property has been referenced.
+  @include css.output("test-2");
 }
 
 /**
@@ -54,10 +59,12 @@ $theme-dark: (
 
 @include theme.set("test-3", "light", $theme-light);
 @include theme.set("test-3", "dark", $theme-dark);
-@include theme.output("test-3");
 
 .test-3 {
-  border-color: css.reference("test-3", "border-color");
-  background: css.reference("test-3", "background");
-  color: css.reference("test-3", "foreground");
+  border-color: theme.get("test-3", "border-color");
+  background: theme.get("test-3", "background");
+  color: theme.get("test-3", "foreground");
 }
+
+// Output needs to come after the property has been referenced.
+@include theme.output("test-3");

--- a/docs/src/styles/_test.scss
+++ b/docs/src/styles/_test.scss
@@ -4,8 +4,7 @@
 
 .test-1,
 .test-2,
-.test-3,
-.test-4 {
+.test-3 {
   padding: 0.5em 1em;
   border: 1px solid transparent;
   border-radius: 0.25em;
@@ -56,45 +55,4 @@ $theme-default: (
   border-color: theme.get("test-3", "border-color");
   background: theme.get("test-3", "background");
   color: theme.get("test-3", "foreground");
-}
-
-// TEST 4
-// ---
-// Using custom properties as values of new themes. Setting the default theme 
-// should allow all themes to inherit those styles unless explicitly set.
-
-// Create the default theme. All properties used in subsequent themes bust exist
-// in the default.
-@include theme.set("test-4", "default", (
-  "background": theme.get("background"),
-  "foreground": theme.get("foreground"),
-  "border-color": theme.get("border-color"),
-  "font-family": css.get("font-family"),
-  "font-size": css.get("font-size-lg")
-));
-
-// Create an empty theme class. This inherits everything from the default theme.
-@include theme.set("test-4", "dark");
-
-// Create a theme with only one property. All other properties are inherited
-// from the default theme.
-@include theme.set("test-4", "pink", (
-  "background": pink
-));
-
-// Create a theme with all unique properties. These are used as expected.
-@include theme.set("test-4", "matrix", (
-  "background": black,
-  "foreground": lime,
-  "border-color": black,
-  "font-family": css.get("font-family-mono"),
-  "font-size": css.get("font-size")
-));
-
-.test-4 {
-  border-color: theme.get("test-4", "border-color");
-  background: theme.get("test-4", "background");
-  color: theme.get("test-4", "foreground");
-  font-family: theme.get("test-4", "font-family");
-  font-size: theme.get("test-4", "font-size");
 }

--- a/docs/src/styles/_test.scss
+++ b/docs/src/styles/_test.scss
@@ -4,15 +4,15 @@
 
 .test-1,
 .test-2,
-.test-3 {
+.test-3,
+.test-4 {
   padding: 0.5em 1em;
   border: 1px solid transparent;
   border-radius: 0.25em;
 }
 
-/**
- * Test 1
- */
+// TEST 1
+// Using core theme properties directly.
 
 .test-1 {
   border-color: theme.get("border-color");
@@ -20,9 +20,8 @@
   color: theme.get("foreground");
 }
 
-/**
- * Test 2
- */
+// TEST 2
+// Using core theme properties as values of new properties.
 
 @include css.set("test-2", (
   "background": theme.get("background"),
@@ -36,14 +35,8 @@
   color: css.get("test-2", "foreground");
 }
 
-:root {
-  // Output needs to come after the property has been referenced.
-  @include css.output("test-2");
-}
-
-/**
- * Test 3
- */
+// TEST 3
+// Using core theme properties as values of new themes.
 
 $theme-light: (
   "background": theme.get("background"),
@@ -66,5 +59,33 @@ $theme-dark: (
   color: theme.get("test-3", "foreground");
 }
 
-// Output needs to come after the property has been referenced.
-@include theme.output("test-3");
+// TEST 4
+// Using custom properties as values of new themes. Setting the default theme 
+// should allow all themes to inherit those styles unless explicitly set.
+
+$theme-default: (
+  "background": theme.get("background"),
+  "foreground": theme.get("foreground"),
+  "border-color": theme.get("border-color"),
+  "font-family": css.get("font-family"),
+  "font-size": css.get("font-size-lg")
+);
+
+$theme-matrix: (
+  "background": black,
+  "foreground": lime,
+  "border-color": black,
+  "font-family": css.get("font-family-mono"),
+  "font-size": css.get("font-size")
+);
+
+@include theme.set("test-4", theme.$default, $theme-default);
+@include theme.set("test-4", "matrix", $theme-matrix);
+
+.test-4 {
+  border-color: theme.get("test-4", "border-color");
+  background: theme.get("test-4", "background");
+  color: theme.get("test-4", "foreground");
+  font-family: theme.get("test-4", "font-family");
+  font-size: theme.get("test-4", "font-size");
+}

--- a/docs/src/styles/_test.scss
+++ b/docs/src/styles/_test.scss
@@ -21,7 +21,9 @@
 }
 
 // TEST 2
-// Using core theme properties as values of new properties.
+// Using core theme properties as values of new properties. These end up being
+// completely to the values set in :root of these custom property definitions
+// and do not change based on the presence of theme classes.
 
 @include css.set("test-2", (
   "background": theme.get("background"),
@@ -38,20 +40,14 @@
 // TEST 3
 // Using core theme properties as values of new themes.
 
-$theme-light: (
+$theme-default: (
   "background": theme.get("background"),
   "foreground": theme.get("foreground"),
   "border-color": theme.get("border-color"),
 );
 
-$theme-dark: (
-  "background": theme.get("background"),
-  "foreground": theme.get("foreground"),
-  "border-color": theme.get("border-color"),
-);
-
-@include theme.set("test-3", "light", $theme-light);
-@include theme.set("test-3", "dark", $theme-dark);
+@include theme.set("test-3", theme.$default, $theme-default);
+@include theme.set("test-3", "dark");
 
 .test-3 {
   border-color: theme.get("test-3", "border-color");
@@ -63,24 +59,33 @@ $theme-dark: (
 // Using custom properties as values of new themes. Setting the default theme 
 // should allow all themes to inherit those styles unless explicitly set.
 
-$theme-default: (
+// Create the default theme. All properties used in subsequent themes bust exist
+// in the default.
+@include theme.set("test-4", theme.$default, (
   "background": theme.get("background"),
   "foreground": theme.get("foreground"),
   "border-color": theme.get("border-color"),
   "font-family": css.get("font-family"),
   "font-size": css.get("font-size-lg")
-);
+));
 
-$theme-matrix: (
+// Create an empty theme class. This inherits everything from the default theme.
+@include theme.set("test-4", "dark");
+
+// Create a theme with only one property. All other properties are inherited
+// from the default theme.
+@include theme.set("test-4", "pink", (
+  "background": pink
+));
+
+// Create a theme with all unique properties. These are used as expected.
+@include theme.set("test-4", "matrix", (
   "background": black,
   "foreground": lime,
   "border-color": black,
   "font-family": css.get("font-family-mono"),
   "font-size": css.get("font-size")
-);
-
-@include theme.set("test-4", theme.$default, $theme-default);
-@include theme.set("test-4", "matrix", $theme-matrix);
+));
 
 .test-4 {
   border-color: theme.get("test-4", "border-color");

--- a/packages/core/src/scss/modules/_config.scss
+++ b/packages/core/src/scss/modules/_config.scss
@@ -13,7 +13,8 @@ $_options: (
   "prefix-blocks": null,
   "prefix-elements": "__",
   "prefix-modifiers": "_",
-  "prefix-modifier-values": "_"
+  "prefix-modifier-values": "_",
+  "default-theme": "light"
 );
 
 /// Returns the value of an option in the configuration map.

--- a/packages/core/src/scss/modules/_css.scss
+++ b/packages/core/src/scss/modules/_css.scss
@@ -319,10 +319,11 @@ $_variables: (
   }
 }
 
-/// Output all the stored custom properties of a provided module. Provided 
-/// module must exist in the `$_variables` custom properties map.
-/// @param {string} $module ["core"]
-///   The module to output all stored custom properties from.
+/// Output all the stored custom properties of a provided module or of all 
+/// modules. Provided module must exist in the `$_variables` map.
+/// @param {string} $module ["*"]
+///   The module to output all custom properties from. If no module is passed or
+///   set to "*" or "all", will output all custom properties for all modules.
 /// @param {string} $strategy ["used"]
 ///   The output strategy to apply. Available options: "*", "all" or "used".
 ///   - "*" and "all" will output all stored custom properties.
@@ -350,15 +351,22 @@ $_variables: (
 ///     --vb-button-border: 1px solid #000;
 ///   }
 ///
-@mixin output($module: "core", $strategy: config.get("output-strategy")) {
-  @if not map.has-key($_variables, $module) {
-    @error "Module map has not been set: \"#{$module}\"";
+@mixin output($module: "*", $strategy: config.get("output-strategy")) {
+  @if ($module == "*") or ($module == "all") {
+    // Call output() for every module in $_variables.
+    @each $module in map.keys($_variables) {
+      @include output($module, $strategy);
+    }
+  } @else {
+    @if not map.has-key($_variables, $module) {
+      @error "Module map has not been set: \"#{$module}\"";
+    }
+    $moduleMap: map.get($_variables, $module);
+    // Output custom properties via usage output.
+    @include usage.output(
+      meta.get-mixin("define"), $module, $moduleMap, $strategy
+    );
   }
-  $moduleMap: map.get($_variables, $module);
-  // Output custom properties via usage output.
-  @include usage.output(
-    meta.get-mixin("define"), $module, $moduleMap, $strategy
-  );
 }
 
 /// Log to console either the entire `$_variables` custom properties map or a 

--- a/packages/core/src/scss/modules/_palette.scss
+++ b/packages/core/src/scss/modules/_palette.scss
@@ -139,12 +139,10 @@ $_palette: build();
 /// @param {map} $strategy
 ///   The output strategy to apply.
 @mixin output($strategy: config.get("output-strategy")) {
-  :root {
-    // Output custom properties via usage output.
-    @include usage.output(
-      meta.get-mixin("define", "css"), "palette", $_palette, $strategy
-    );
-  }
+  // Output custom properties via usage output.
+  @include usage.output(
+    meta.get-mixin("define", "css"), "palette", $_palette, $strategy
+  );
 }
 
 /// Log to console the entire `$_palette` map.

--- a/packages/core/src/scss/modules/_theme.scss
+++ b/packages/core/src/scss/modules/_theme.scss
@@ -9,23 +9,6 @@
 @use "./css";
 @use "./palette";
 
-/// Prefix for theme classes.
-/// @type string
-/// @alias config.get("prefix-themes")
-/// @access private
-$_t: config.get("prefix-themes");
-
-/// Set the default theme. Should match an existing theme in the $_themes map.
-/// @type string
-/// @alias config.get("prefix-themes")
-/// @access private
-/// TODO: Test that changing this in docs works as expected.
-$_default: config.get("default-theme") !default;
-
-/// CSS selector to use for outputting the root CSS custom properties.
-/// @type string
-$root-selector: ":root, .#{$_t}root" !default;
-
 /// Stores theme maps for individual modules. These are used to build theme 
 /// classes and CSS custom property output. Optionally set `color-scheme` 
 /// property for outputting the `color-scheme: (light | dark);` property.
@@ -127,8 +110,8 @@ $_themes: (
     @error "Module map has not been set: \"#{$module}\"";
   }
 
-  @if not map.has-key($_themes, $module, $_default, $prop) {
-    @error "Property does not exist in the default theme: \"#{$module}\" > \"#{$_default}\" > \"#{$prop}\"";
+  @if not map.has-key($_themes, $module, config.get("default-theme"), $prop) {
+    @error "Property does not exist in the default theme: \"#{$module}\" > \"#{config.get("default-theme")}\" > \"#{$prop}\"";
   }
 
   // Return the CSS custom property reference.
@@ -158,7 +141,7 @@ $_themes: (
 @mixin set($module, $theme, $prop: null, $value: null) {
   // Set theme to default if the value "default" is passed.
   @if ($theme == "default") {
-    $theme: $_default;
+    $theme: config.get("default-theme");
   }
 
   // Shift the values of arguments if module was not passed. Also sets module to
@@ -241,9 +224,9 @@ $_themes: (
   $color-scheme: map.get($moduleMap, "color-scheme");
   $moduleMap: map.remove($moduleMap, "color-scheme");
 
-  // Merge the values of `$_default` with all other themes.
-  @if ($theme != $_default) {
-    $moduleMap: map.merge(map.get($_themes, $module, $_default), $moduleMap);
+  // Merge the values of the default theme with all other themes.
+  @if ($theme != config.get("default-theme")) {
+    $moduleMap: map.merge(map.get($_themes, $module, config.get("default-theme")), $moduleMap);
   }
 
   // Output custom properties via usage output.
@@ -279,19 +262,19 @@ $_themes: (
   } @else {  
     // Output the default theme and system preference media query under the using
     // the root selector. This should come before the theme class output.
-    #{$root-selector} {
+    :root, .#{config.get("prefix-themes")}root {
       // Output the default theme.
-      @include output-theme($module, $_default, $strategy);
+      @include output-theme($module, config.get("default-theme"), $strategy);
 
       // If the default them is not light mode, output the prefers light media query.
-      @if $_default != "light" and map.has-key($_themes, $module, "light") {
+      @if config.get("default-theme") != "light" and map.has-key($_themes, $module, "light") {
         @media (prefers-color-scheme: light) {
           @include output-theme($module, "light", $strategy, "override");
         }
       }
 
       // If the default them is not dark mode, output the prefers dark media query.
-      @if $_default != "dark" and map.has-key($_themes, $module, "dark") {
+      @if config.get("default-theme") != "dark" and map.has-key($_themes, $module, "dark") {
         @media (prefers-color-scheme: dark) {
           @include output-theme($module, "dark", $strategy, "override");
         }
@@ -300,7 +283,7 @@ $_themes: (
 
     // This outputs all custom themes using their theme class.
     @each $key, $value in map.get($_themes, $module) {
-      .#{$_t}#{$key} {
+      .#{config.get("prefix-themes")}#{$key} {
         @include output-theme($module, $key, $strategy, "override");
       }
     }

--- a/packages/core/src/scss/modules/_theme.scss
+++ b/packages/core/src/scss/modules/_theme.scss
@@ -239,20 +239,19 @@ $_themes: (
 ///   @include theme.output("notice");
 ///
 @mixin output($module: "core", $strategy: config.get("output-strategy")) {
-  // Output the default theme using the root selector.
+  // Output the default theme and system preference media query under the using
+  // the root selector. This should come before the theme class output.
   #{$root-selector} {
+    // Output the default theme.
     @include output-theme($module, $default, $strategy);
-  }
 
-  // This outputs the theme for system preference.
-  #{$root-selector} {
     // If the default them is not light mode, output the prefers light media query.
     @if $default != "light" and map.has-key($_themes, $module, "light") {
       @media (prefers-color-scheme: light) {
         @include output-theme($module, "light", $strategy, "override");
       }
     }
-    
+
     // If the default them is not dark mode, output the prefers dark media query.
     @if $default != "dark" and map.has-key($_themes, $module, "dark") {
       @media (prefers-color-scheme: dark) {

--- a/packages/core/src/scss/modules/_theme.scss
+++ b/packages/core/src/scss/modules/_theme.scss
@@ -240,7 +240,7 @@ $_themes: (
 ///
 @mixin output($module: "core", $strategy: config.get("output-strategy")) {
   // Output the default theme in the root selector.
-  #{$root-selector}, .#{$_t}#{$default} {
+  #{$root-selector} {
     @include output-theme($module, $default, $strategy);
   }
 
@@ -262,10 +262,8 @@ $_themes: (
   
   // Run the output function on all module themes.
   @each $key, $value in map.get($_themes, $module) {
-    @if not ($key == $default) {
-      .#{$_t}#{$key} {
-        @include output-theme($module, $key, $strategy, "override");
-      }
+    .#{$_t}#{$key} {
+      @include output-theme($module, $key, $strategy, "override");
     }
   }
 }

--- a/packages/core/src/scss/modules/_theme.scss
+++ b/packages/core/src/scss/modules/_theme.scss
@@ -172,18 +172,42 @@ $_themes: (
 /// Remove a custom property from all themes of a provided module.
 /// @param {string} $module
 ///   The module name to search under.
-/// @param {string} $args...
-///   The keys path to search and remove.
+/// @param {string} $theme
+///   The module theme to search under or remove.
+/// @param {string} $prop [null]
+///   The property name to remove.
 /// 
 /// @example scss
-///   // Remove the border-color property from all component themes.
-///   @include theme.remove("button", "border-color");
+///   // Remove the dark theme from buttons module.
+///   @include theme.remove("button", "dark");
 ///
-/// TODO: Ensure that removing a theme works
-@mixin remove($module, $args...) {
-  @each $theme, $props in map.get($_themes, $module) {
-    @if usage.remove($module, $args...) {
-      $_themes: map.deep-remove($_themes, $module, $theme, $args...) !global;
+/// @example scss
+///   // Remove the border-color property from all button themes.
+///   @include theme.remove("button", "border-color");
+/// 
+/// @example scss
+///   // Remove the background property from the button light theme.
+///   @include theme.remove("button", "light", "border-color");
+///
+@mixin remove($module, $theme, $prop: null) {
+  // Check if no properties were passed and if the theme exists in the module
+  @if not ($prop) and (map.has-key($_themes, $module, $theme)) {
+    // Remove the theme entirely.
+    $_themes: map.deep-remove($_themes, $module, $theme) !global;
+  }
+
+  // Else, remove the property from all module themes.
+  @else {
+    // Shift the value of theme to prop.
+    @if not ($prop) {
+      $prop: $theme;
+    }
+
+    // Loop through module themes and remove property from usage and themes.
+    @each $theme in map.keys(map.get($_themes, $module)) {
+      @if usage.remove($module, $prop) {
+        $_themes: map.deep-remove($_themes, $module, $theme, $prop) !global;
+      }
     }
   }
 }

--- a/packages/core/src/scss/modules/_theme.scss
+++ b/packages/core/src/scss/modules/_theme.scss
@@ -19,6 +19,7 @@ $_t: config.get("prefix-themes");
 /// @type string
 /// @alias config.get("prefix-themes")
 /// @access private
+/// TODO: Test that changing this in docs works as expected.
 $_default: config.get("default-theme") !default;
 
 /// CSS selector to use for outputting the root CSS custom properties.
@@ -155,10 +156,13 @@ $_themes: (
 ///   @include theme.set("card", "dark");
 ///
 @mixin set($module, $theme, $prop: null, $value: null) {
-  // 
+  // Set theme to default if the value "default" is passed.
   @if ($theme == "default") {
     $theme: $_default;
   }
+
+  // Shift the values of arguments if module was not passed. Also sets module to
+  // "core" as the default.
   @if not ($value) and ($prop) and (meta.type-of($prop) != "map") {
     $value: $prop;
     $prop: $theme;
@@ -192,6 +196,7 @@ $_themes: (
 ///   // Remove the border-color property from all component themes.
 ///   @include theme.remove("button", "border-color");
 ///
+/// TODO: Ensure that removing a theme works
 @mixin remove($module, $args...) {
   @each $theme, $props in map.get($_themes, $module) {
     @if usage.remove($module, $args...) {

--- a/packages/core/src/scss/modules/_theme.scss
+++ b/packages/core/src/scss/modules/_theme.scss
@@ -1,7 +1,9 @@
+@use "sass:list";
 @use "sass:map";
 @use "sass:meta";
 
 @use "../utilities/debug-map" as *;
+@use "../utilities/empty-map" as *;
 @use "./config";
 @use "./usage";
 @use "./css";
@@ -135,7 +137,7 @@ $_themes: (
 ///   The module to set a property value for.
 /// @param {string} $theme
 ///   The theme to set a property value for.
-/// @param {string | map} $prop
+/// @param {string | map} $prop [null]
 ///   The property value to set for the respective module > theme. Can be a map
 ///   containing prop/value pairs.
 /// @param {any} $value [null]
@@ -144,9 +146,14 @@ $_themes: (
 /// @example scss
 ///   // Set the foreground custom property for the card dark theme.
 ///   @include theme.set("card", "dark", "foreground", blue);
+/// 
+/// @example scss
+///   // Create an empty theme by not passing a property or value. This will
+///   // take the properties of the default theme once output.
+///   @include theme.set("card", "dark");
 ///
-@mixin set($module, $theme, $prop, $value: null) {
-  @if not ($value) and (meta.type-of($prop) != "map") {
+@mixin set($module, $theme, $prop: null, $value: null) {
+  @if not ($value) and ($prop) and (meta.type-of($prop) != "map") {
     $value: $prop;
     $prop: $theme;
     $theme: $module;
@@ -156,6 +163,11 @@ $_themes: (
   // If the value is a map, apply it with deep-merge.
   @if (meta.type-of($prop) == "map") {
     $_themes: map.deep-merge($_themes, ($module: ($theme: $prop))) !global;
+  }
+
+  // If no property or value are provided, create a theme with an empty map.
+  @else if not ($prop) and not ($value) {
+    $_themes: map.set($_themes, $module, $theme, empty-map()) !global;
   }
   
   // Otherwise, just add the value using the $args list.
@@ -217,6 +229,11 @@ $_themes: (
   // Get a reference of the color scheme property and remove it from the map.
   $color-scheme: map.get($moduleMap, "color-scheme");
   $moduleMap: map.remove($moduleMap, "color-scheme");
+
+  // Merge the values of $default with all other themes.
+  @if ($theme != $default) {
+    $moduleMap: map.merge(map.get($_themes, $module, $default), $moduleMap);
+  }
 
   // Output custom properties via usage output.
   @include usage.output(

--- a/packages/core/src/scss/modules/_theme.scss
+++ b/packages/core/src/scss/modules/_theme.scss
@@ -92,12 +92,15 @@ $_themes: (
 ) !default;
 
 /// Function to return the CSS variable with fallback of an entry within the
-/// $_themes map. Requested property must exist in the default theme.
+/// $_themes map. Requested module must be set in the `$_themes` map and contain
+/// a value for the requested property in the default theme.
 /// @param {string} $module ["core"]
 ///   The module name to search for a prop in. Can be omitted for prop value if
 ///   the desired property is in the core module.
 /// @param {string} $prop [null]
 ///   The property value to return.
+/// @param {string} $fallback [null]
+///   The fallback value if initial property is not defined.
 /// @return {function}
 ///   The var() CSS function with the value of the requested custom property.
 /// 
@@ -109,22 +112,22 @@ $_themes: (
 ///   // Return the background CSS reference for the card module.
 ///   background: theme.get("card", "background");
 ///
-@function get($module, $prop: null) {
+@function get($module, $prop: null, $fallback: null) {
   @if not ($prop) {
     $prop: $module;
     $module: "core";
   }
 
-  @if not map.has-key($_themes, $module, $default) {
+  @if not map.has-key($_themes, $module) {
     @error "Module map has not been set: \"#{$module}\"";
   }
 
   @if not map.has-key($_themes, $module, $default, $prop) {
-    @error "Property does not exist in themes map: #{$module} > #{$default} > #{$prop}";
+    @error "Property does not exist in the default theme: \"#{$module}\" > \"#{$default}\" > \"#{$prop}\"";
   }
 
   // Return the CSS custom property reference.
-  @return css.reference($module, $prop);
+  @return css.reference($module, $prop, $fallback);
 }
 
 /// Set a new or modify an existing property value in the $_themes map.
@@ -229,8 +232,9 @@ $_themes: (
 /// Output all the themes for a specific module. Each theme will be wrapped in
 /// their own appropriate root selector and theme class. Themes named "light" or
 /// "dark" will have a `prefers-color-scheme` media query applied.
-/// @param {string} $module ["core"]
-///   The module to output all applied themes for.
+/// @param {string} $module ["*"]
+///   The module to output all applied themes. If no module is passed or set to 
+///   "*" or "all", will output all applied themes for all modules.
 /// @param {string} $strategy [config.get("output-strategy")]
 ///   The output strategy to apply.
 ///
@@ -238,32 +242,39 @@ $_themes: (
 ///   // Output all themes of the notice module.
 ///   @include theme.output("notice");
 ///
-@mixin output($module: "core", $strategy: config.get("output-strategy")) {
-  // Output the default theme and system preference media query under the using
-  // the root selector. This should come before the theme class output.
-  #{$root-selector} {
-    // Output the default theme.
-    @include output-theme($module, $default, $strategy);
+@mixin output($module: "*", $strategy: config.get("output-strategy")) {
+  @if ($module == "*") or ($module == "all") {
+    // Call output() for every module in $_themes.
+    @each $module in map.keys($_themes) {
+      @include output($module, $strategy);
+    }
+  } @else {  
+    // Output the default theme and system preference media query under the using
+    // the root selector. This should come before the theme class output.
+    #{$root-selector} {
+      // Output the default theme.
+      @include output-theme($module, $default, $strategy);
 
-    // If the default them is not light mode, output the prefers light media query.
-    @if $default != "light" and map.has-key($_themes, $module, "light") {
-      @media (prefers-color-scheme: light) {
-        @include output-theme($module, "light", $strategy, "override");
+      // If the default them is not light mode, output the prefers light media query.
+      @if $default != "light" and map.has-key($_themes, $module, "light") {
+        @media (prefers-color-scheme: light) {
+          @include output-theme($module, "light", $strategy, "override");
+        }
+      }
+
+      // If the default them is not dark mode, output the prefers dark media query.
+      @if $default != "dark" and map.has-key($_themes, $module, "dark") {
+        @media (prefers-color-scheme: dark) {
+          @include output-theme($module, "dark", $strategy, "override");
+        }
       }
     }
 
-    // If the default them is not dark mode, output the prefers dark media query.
-    @if $default != "dark" and map.has-key($_themes, $module, "dark") {
-      @media (prefers-color-scheme: dark) {
-        @include output-theme($module, "dark", $strategy, "override");
+    // This outputs all custom themes using their theme class.
+    @each $key, $value in map.get($_themes, $module) {
+      .#{$_t}#{$key} {
+        @include output-theme($module, $key, $strategy, "override");
       }
-    }
-  }
-  
-  // This outputs all custom themes using their theme class.
-  @each $key, $value in map.get($_themes, $module) {
-    .#{$_t}#{$key} {
-      @include output-theme($module, $key, $strategy, "override");
     }
   }
 }

--- a/packages/core/src/scss/modules/_theme.scss
+++ b/packages/core/src/scss/modules/_theme.scss
@@ -239,28 +239,29 @@ $_themes: (
 ///   @include theme.output("notice");
 ///
 @mixin output($module: "core", $strategy: config.get("output-strategy")) {
-  // Output the default theme in the root selector.
+  // Output the default theme using the root selector.
   #{$root-selector} {
     @include output-theme($module, $default, $strategy);
   }
 
+  // This outputs the theme for system preference.
   #{$root-selector} {
     // If the default them is not light mode, output the prefers light media query.
-    @if $default != 'light' {
+    @if $default != "light" and map.has-key($_themes, $module, "light") {
       @media (prefers-color-scheme: light) {
         @include output-theme($module, "light", $strategy, "override");
       }
     }
     
     // If the default them is not dark mode, output the prefers dark media query.
-    @if $default != 'dark' {
+    @if $default != "dark" and map.has-key($_themes, $module, "dark") {
       @media (prefers-color-scheme: dark) {
         @include output-theme($module, "dark", $strategy, "override");
       }
     }
   }
   
-  // Run the output function on all module themes.
+  // This outputs all custom themes using their theme class.
   @each $key, $value in map.get($_themes, $module) {
     .#{$_t}#{$key} {
       @include output-theme($module, $key, $strategy, "override");

--- a/packages/core/src/scss/modules/_theme.scss
+++ b/packages/core/src/scss/modules/_theme.scss
@@ -17,7 +17,9 @@ $_t: config.get("prefix-themes");
 
 /// Set the default theme. Should match an existing theme in the $_themes map.
 /// @type string
-$default: "light" !default;
+/// @alias config.get("prefix-themes")
+/// @access private
+$_default: config.get("default-theme") !default;
 
 /// CSS selector to use for outputting the root CSS custom properties.
 /// @type string
@@ -124,8 +126,8 @@ $_themes: (
     @error "Module map has not been set: \"#{$module}\"";
   }
 
-  @if not map.has-key($_themes, $module, $default, $prop) {
-    @error "Property does not exist in the default theme: \"#{$module}\" > \"#{$default}\" > \"#{$prop}\"";
+  @if not map.has-key($_themes, $module, $_default, $prop) {
+    @error "Property does not exist in the default theme: \"#{$module}\" > \"#{$_default}\" > \"#{$prop}\"";
   }
 
   // Return the CSS custom property reference.
@@ -153,6 +155,10 @@ $_themes: (
 ///   @include theme.set("card", "dark");
 ///
 @mixin set($module, $theme, $prop: null, $value: null) {
+  // 
+  @if ($theme == "default") {
+    $theme: $_default;
+  }
   @if not ($value) and ($prop) and (meta.type-of($prop) != "map") {
     $value: $prop;
     $prop: $theme;
@@ -198,7 +204,7 @@ $_themes: (
 /// selector or theme class are not included in the output
 /// @param {string} $module
 ///   The module to output.
-/// @param {string} $theme [$default]
+/// @param {string} $theme [config.get("default-theme")]
 ///   The theme to output.
 /// @param {string} $strategy [config.get("output-strategy")]
 ///   The output strategy to apply.
@@ -212,7 +218,7 @@ $_themes: (
 ///     @include theme.output-theme("button", "light");
 ///   }
 ///
-@mixin output-theme($module, $theme: $default, $strategy: config.get("output-strategy"), $args...) {
+@mixin output-theme($module, $theme: config.get("default-theme"), $strategy: config.get("output-strategy"), $args...) {
   // Check if module exists in themes map.
   @if not map.has-key($_themes, $module) {
     @error "Module \"#{$module}\" has not been set in themes map";
@@ -230,9 +236,9 @@ $_themes: (
   $color-scheme: map.get($moduleMap, "color-scheme");
   $moduleMap: map.remove($moduleMap, "color-scheme");
 
-  // Merge the values of $default with all other themes.
-  @if ($theme != $default) {
-    $moduleMap: map.merge(map.get($_themes, $module, $default), $moduleMap);
+  // Merge the values of `$_default` with all other themes.
+  @if ($theme != $_default) {
+    $moduleMap: map.merge(map.get($_themes, $module, $_default), $moduleMap);
   }
 
   // Output custom properties via usage output.
@@ -270,17 +276,17 @@ $_themes: (
     // the root selector. This should come before the theme class output.
     #{$root-selector} {
       // Output the default theme.
-      @include output-theme($module, $default, $strategy);
+      @include output-theme($module, $_default, $strategy);
 
       // If the default them is not light mode, output the prefers light media query.
-      @if $default != "light" and map.has-key($_themes, $module, "light") {
+      @if $_default != "light" and map.has-key($_themes, $module, "light") {
         @media (prefers-color-scheme: light) {
           @include output-theme($module, "light", $strategy, "override");
         }
       }
 
       // If the default them is not dark mode, output the prefers dark media query.
-      @if $default != "dark" and map.has-key($_themes, $module, "dark") {
+      @if $_default != "dark" and map.has-key($_themes, $module, "dark") {
         @media (prefers-color-scheme: dark) {
           @include output-theme($module, "dark", $strategy, "override");
         }

--- a/packages/core/src/scss/root/palette.scss
+++ b/packages/core/src/scss/root/palette.scss
@@ -1,3 +1,5 @@
 @use "@vrembem/core";
 
-@include core.palette-output();
+:root {
+  @include core.palette-output();
+}

--- a/packages/core/src/scss/root/variables.scss
+++ b/packages/core/src/scss/root/variables.scss
@@ -1,7 +1,5 @@
 @use "@vrembem/core";
 
 :root {
-  @include core.css-output("core");
-  @include core.css-output("form-control");
-  @include core.css-output("transition");
+  @include core.css-output();
 }

--- a/packages/core/src/scss/utilities/_empty-map.scss
+++ b/packages/core/src/scss/utilities/_empty-map.scss
@@ -1,0 +1,5 @@
+@use "sass:map";
+
+@function empty-map() {
+  @return map.remove((x:x), x);
+}


### PR DESCRIPTION
## What changed?

This PR improves the themes module by adding some quality of life features such as:

- Themes now inherit properties from the default theme. This allows modules to only define properties that are different from the default instead of having to explicitly declare all of them. This is useful for themes that reference core theme values for example.
- Because of theme inheritance, themes can now be created by only providing a theme name.
- When setting theme properties, you can now pass the string "default" to correctly target the default theme instead of knowing ahead of time what the default theme is called.
- Moved the default theme setting into the config module.
- Improved how `theme.remove()` works to allow more options in how properties or entire themes are removed.
- All custom properties can now be output using `css.output()`.
- All theme custom properties can now be output using `theme.output()`.

**Additional changes**

- Reverted theme output priority. This was causing theme classes to not properly override system preferences.
- Theme classes are again being applied to the `html` instead of the `body` element.
- Removed selector from `palette.output()`. This allows the mixin to be used in more contexts similar to `css.output()`.
- Added `empty-map()` function to core utilities that allows easily providing an empty map as a value.