### PR TITLE
Add "form-control" and "transition" modules back in the "core" css module

### DIFF
--- a/docs/src/styles/_code-example.scss
+++ b/docs/src/styles/_code-example.scss
@@ -75,7 +75,7 @@
   }
 
   > *:not(.popover) {
-    transition: all css.get("transition", "duration") css.get("transition", "timing-function");
+    transition: all css.get("transition-duration") css.get("transition-timing-function");
   }
 }
 

--- a/docs/src/styles/_navibar.scss
+++ b/docs/src/styles/_navibar.scss
@@ -47,8 +47,8 @@
   width: calc(100% - 1em);
   margin-right: 1em;
   transition-property: top, opacity;
-  transition-duration: css.get("transition", "duration");
-  transition-timing-function: css.get("transition", "timing-function");
+  transition-duration: css.get("transition-duration");
+  transition-timing-function: css.get("transition-timing-function");
   opacity: 0;
 
   &:focus {

--- a/docs/src/styles/_pagi.scss
+++ b/docs/src/styles/_pagi.scss
@@ -31,8 +31,8 @@
   display: block;
   padding: 1rem;
   transition: border-color;
-  transition-duration: css.get("transition", "duration");
-  transition-timing-function: css.get("transition", "timing-function");
+  transition-duration: css.get("transition-duration");
+  transition-timing-function: css.get("transition-timing-function");
   border: 1px solid theme.get("border-color");
   border-radius: css.get("border-radius");
   line-height: css.get("line-height-sm");

--- a/packages/button/src/_variables.scss
+++ b/packages/button/src/_variables.scss
@@ -5,7 +5,7 @@
 @use "@vrembem/core/theme";
 
 $breakpoints: core.$breakpoints !default;
-$size: css.get("form-control", "size") !default;
+$size: css.get("form-control-size") !default;
 $padding: calc(#{list.nth(core.$form-control-padding, 1)} - 1px) list.nth(core.$form-control-padding, 2) !default;
 $gap: 0.5rem !default;
 $background: null !default;
@@ -27,8 +27,8 @@ $line-height: 1.6 !default;
 
 // Transition
 $transition-property: background, color, border-color, box-shadow !default;
-$transition-duration: css.get("transition", "duration") !default;
-$transition-timing-function: css.get("transition", "timing-function") !default;
+$transition-duration: css.get("transition-duration") !default;
+$transition-timing-function: css.get("transition-timing-function") !default;
 
 // Disabled
 $disabled-opacity: 0.6 !default;
@@ -46,13 +46,13 @@ $icon-padding-sm: calc(#{list.nth(core.$form-control-padding-sm, 1)} - 1px);
 $icon-padding-lg: calc(#{list.nth(core.$form-control-padding-lg, 1)} - 1px);
 
 // button_size_sm
-$size-sm: css.get("form-control", "size-sm") !default;
+$size-sm: css.get("form-control-size-sm") !default;
 $size-sm-padding: calc(#{list.nth(core.$form-control-padding-sm, 1)} - 1px) list.nth(core.$form-control-padding-sm, 2) !default;
 $size-sm-font-size: css.get("font-size-sm") !default;
 $size-sm-line-height: css.get("line-height-sm") !default;
 
 // button_size_lg
-$size-lg: css.get("form-control", "size-lg") !default;
+$size-lg: css.get("form-control-size-lg") !default;
 $size-lg-padding: calc(#{list.nth(core.$form-control-padding-lg, 1)} - 1px) list.nth(core.$form-control-padding-lg, 2) !default;
 $size-lg-font-size: css.get("font-size-lg") !default;
 $size-lg-line-height: css.get("line-height-lg") !default;

--- a/packages/card/src/_variables.scss
+++ b/packages/card/src/_variables.scss
@@ -27,8 +27,8 @@ $title-font-weight: css.get("font-weight-semi-bold") !default;
 
 // Transition
 $transition-property: background-color, border-color, box-shadow, transform !default;
-$transition-duration: css.get("transition", "duration") !default;
-$transition-timing-function: css.get("transition", "timing-function") !default;
+$transition-duration: css.get("transition-duration") !default;
+$transition-timing-function: css.get("transition-timing-function") !default;
 
 // Custom properties
 @include css.set("card", (

--- a/packages/checkbox/src/_variables.scss
+++ b/packages/checkbox/src/_variables.scss
@@ -3,7 +3,7 @@
 @use "@vrembem/core/palette";
 @use "@vrembem/core/theme";
 
-$size: css.get("form-control", "size") !default;
+$size: css.get("form-control-size") !default;
 $box-size: 18px !default;
 $icon-size: 12px !default;
 $icon-color: null !default;
@@ -20,18 +20,18 @@ $background-opacity-focus: 20% !default;
 $background-opacity-active: 30% !default;
 
 // Transition
-$transition-duration: css.get("transition", "duration-short") !default;
-$transition-timing-function: css.get("transition", "timing-function") !default;
+$transition-duration: css.get("transition-duration-short") !default;
+$transition-timing-function: css.get("transition-timing-function") !default;
 
 // checkbox_size_sm
-$size-sm: css.get("form-control", "size-sm") !default;
+$size-sm: css.get("form-control-size-sm") !default;
 $size-sm-border-width: 2px !default;
 $size-sm-box: 14px !default;
 $size-sm-icon: 10px !default;
 $size-sm-icon-stroke: 2.5 !default;
 
 // checkbox_size_lg
-$size-lg: css.get("form-control", "size-lg") !default;
+$size-lg: css.get("form-control-size-lg") !default;
 $size-lg-border-width: 2.5px !default;
 $size-lg-box: 24px !default;
 $size-lg-icon: 18px !default;

--- a/packages/core/src/scss/variables/_form-control.scss
+++ b/packages/core/src/scss/variables/_form-control.scss
@@ -8,7 +8,7 @@ $form-control-size: 2.5rem !default;      // 40px
 $form-control-size-sm: 1.875rem !default; // 30px
 $form-control-size-lg: 3.125rem !default; // 50px
 
-@include css.set("form-control", (
+@include css.set("core", "form-control", (
   "padding": $form-control-padding,
   "padding-sm": $form-control-padding-sm,
   "padding-lg": $form-control-padding-lg,

--- a/packages/core/src/scss/variables/_transition.scss
+++ b/packages/core/src/scss/variables/_transition.scss
@@ -5,7 +5,7 @@ $transition-duration-short: 0.15s !default;
 $transition-duration-long: 0.6s !default;
 $transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !default;
 
-@include css.set("transition", (
+@include css.set("core", "transition", (
   "duration": $transition-duration,
   "duration-short": $transition-duration-short,
   "duration-long": $transition-duration-long,

--- a/packages/drawer/src/scss/_variables.scss
+++ b/packages/drawer/src/scss/_variables.scss
@@ -20,8 +20,8 @@ $border: null !default;
 $sep-border: null !default;
 $background: theme.get("background-darker") !default;
 $shadow: none !default;
-$transition-duration: css.get("transition", "duration") !default;
-$transition-timing-function: css.get("transition", "timing-function") !default;
+$transition-duration: css.get("transition-duration") !default;
+$transition-timing-function: css.get("transition-timing-function") !default;
 
 $frame-height: 100vh !default;
 

--- a/packages/input/src/_variables.scss
+++ b/packages/input/src/_variables.scss
@@ -4,7 +4,7 @@
 @use "@vrembem/core/palette";
 @use "@vrembem/core/theme";
 
-$size: css.get("form-control", "size") !default;
+$size: css.get("form-control-size") !default;
 $padding: calc(#{list.nth(core.$form-control-padding, 1)} - 1px) !default;
 $background: null !default;
 $background-hover: null !default;
@@ -34,13 +34,13 @@ $transition-duration: core.$transition-duration-short !default;
 $transition-timing-function: core.$transition-timing-function !default;
 
 // input_size_sm
-$size-sm: css.get("form-control", "size-sm") !default;
+$size-sm: css.get("form-control-size-sm") !default;
 $size-sm-padding: calc(#{list.nth(core.$form-control-padding-sm, 1)} - 1px) calc(#{list.nth(core.$form-control-padding-sm, 1)} * 2) !default;
 $size-sm-font-size: css.get("font-size-sm") !default;
 $size-sm-line-height: css.get("line-height-sm") !default;
 
 // input_size_lg
-$size-lg: css.get("form-control", "size-lg") !default;
+$size-lg: css.get("form-control-size-lg") !default;
 $size-lg-padding: calc(#{list.nth(core.$form-control-padding-lg, 1)} - 1px) !default;
 $size-lg-font-size: css.get("font-size-lg") !default;
 $size-lg-line-height: css.get("line-height-lg") !default;

--- a/packages/menu/src/_variables.scss
+++ b/packages/menu/src/_variables.scss
@@ -4,8 +4,8 @@
 @use "@vrembem/core/palette";
 @use "@vrembem/core/theme";
 
-$size: css.get("form-control", "size") !default;
-$padding: css.get("form-control", "padding") !default;
+$size: css.get("form-control-size") !default;
+$padding: css.get("form-control-padding") !default;
 $gap: 1px !default;
 $border-color: null !default;
 $border-color-hover: null !default;
@@ -39,14 +39,14 @@ $disabled-background: none !default;
 $disabled-foreground: theme.get("foreground-lighter") !default;
 
 // menu_size_sm
-$size-sm: css.get("form-control", "size-sm") !default;
-$size-sm-padding: css.get("form-control", "padding-sm") !default;
+$size-sm: css.get("form-control-size-sm") !default;
+$size-sm-padding: css.get("form-control-padding-sm") !default;
 $size-sm-font-size: css.get("font-size-sm") !default;
 $size-sm-line-height: css.get("line-height-sm") !default;
 
 // menu_size_sm
-$size-lg: css.get("form-control", "size-lg") !default;
-$size-lg-padding: css.get("form-control", "padding-lg") !default;
+$size-lg: css.get("form-control-size-lg") !default;
+$size-lg-padding: css.get("form-control-padding-lg") !default;
 $size-lg-font-size: css.get("font-size-lg") !default;
 $size-lg-line-height: css.get("line-height-lg") !default;
 

--- a/packages/modal/src/scss/_variables.scss
+++ b/packages/modal/src/scss/_variables.scss
@@ -13,8 +13,8 @@ $prefix-modifier-value: config.get("prefix-modifier-values") !default;
 $z-index: 1000 !default;
 $width: 36em !default;
 $travel: 5em !default;
-$transition-duration: css.get("transition", "duration") !default;
-$transition-timing-function: css.get("transition", "timing-function") !default;
+$transition-duration: css.get("transition-duration") !default;
+$transition-timing-function: css.get("transition-timing-function") !default;
 $shadow: css.get("box-shadow-5") !default;
 
 $screen-background: palette.get("neutral", 10) !default;

--- a/packages/radio/src/_variables.scss
+++ b/packages/radio/src/_variables.scss
@@ -3,7 +3,7 @@
 @use "@vrembem/core/palette";
 @use "@vrembem/core/theme";
 
-$size: css.get("form-control", "size") !default;
+$size: css.get("form-control-size") !default;
 $circle-size: 20px !default;
 $dot-size: 8px !default;
 $dot-color: null !default;
@@ -18,17 +18,17 @@ $background-opacity-focus: 20% !default;
 $background-opacity-active: 30% !default;
 
 // Transition
-$transition-duration: css.get("transition", "duration-short") !default;
-$transition-timing-function: css.get("transition", "timing-function") !default;
+$transition-duration: css.get("transition-duration-short") !default;
+$transition-timing-function: css.get("transition-timing-function") !default;
 
 // radio_size_sm
-$size-sm: css.get("form-control", "size-sm") !default;
+$size-sm: css.get("form-control-size-sm") !default;
 $size-sm-border-width: 2px !default;
 $size-sm-circle: 16px !default;
 $size-sm-dot: 6px !default;
 
 // radio_size_lg
-$size-lg: css.get("form-control", "size-lg") !default;
+$size-lg: css.get("form-control-size-lg") !default;
 $size-lg-border-width: 2.5px !default;
 $size-lg-circle: 26px !default;
 $size-lg-dot: 10px !default;

--- a/packages/switch/src/_variables.scss
+++ b/packages/switch/src/_variables.scss
@@ -3,7 +3,7 @@
 @use "@vrembem/core/palette";
 @use "@vrembem/core/theme";
 
-$size: css.get("form-control", "size") !default;
+$size: css.get("form-control-size") !default;
 $track-size: 20px !default;
 $color: palette.get("primary") !default;
 $thumb-fill: null !default;
@@ -18,16 +18,16 @@ $background-opacity-focus: 20% !default;
 $background-opacity-active: 30% !default;
 
 // Transition
-$transition-duration: css.get("transition", "duration-short") !default;
-$transition-timing-function: css.get("transition", "timing-function") !default;
+$transition-duration: css.get("transition-duration-short") !default;
+$transition-timing-function: css.get("transition-timing-function") !default;
 
 // switch_size_sm
-$size-sm: css.get("form-control", "size-sm") !default;
+$size-sm: css.get("form-control-size-sm") !default;
 $size-sm-border-width: 2px !default;
 $size-sm-track: 16px !default;
 
 // switch_size_lg
-$size-lg: css.get("form-control", "size-lg") !default;
+$size-lg: css.get("form-control-size-lg") !default;
 $size-lg-border-width: 2.5px !default;
 $size-lg-track: 26px !default;
 


### PR DESCRIPTION
## What changed?

I've noticed that having a separate module for "form-control" and "transition" was a bit annoying and hard to remember so I moved all of those properties back under the "core" module. When using `css.get`, core is used as the default module so it's not even needed in the css reference calls.