### PR TITLE
Add background color property to form-controls

### DIFF
--- a/packages/checkbox/src/_checkbox.scss
+++ b/packages/checkbox/src/_checkbox.scss
@@ -20,7 +20,7 @@
   align-items: center;
   justify-content: center;
   border-radius: css.get("checkbox", "background-border-radius");
-  background-color: hsl(from css.get("checkbox", "color") h s l / css.get("checkbox", "background-opacity"));
+  background-color: hsl(from css.get("checkbox", "background-color") h s l / css.get("checkbox", "background-opacity"));
 }
 
 #{core.bem("checkbox", "box")} {
@@ -54,7 +54,7 @@
   cursor: pointer;
 
   &:hover + #{core.bem("checkbox", "background")} {
-    background-color: hsl(from css.get("checkbox", "color") h s l / css.get("checkbox", "background-opacity-hover"));
+    background-color: hsl(from css.get("checkbox", "background-color") h s l / css.get("checkbox", "background-opacity-hover"));
 
     #{core.bem("checkbox", "box")} {
       border-color: css.get("checkbox", "color");
@@ -63,7 +63,7 @@
   }
 
   &:focus + #{core.bem("checkbox", "background")} {
-    background-color: hsl(from css.get("checkbox", "color") h s l / css.get("checkbox", "background-opacity-focus"));
+    background-color: hsl(from css.get("checkbox", "background-color") h s l / css.get("checkbox", "background-opacity-focus"));
 
     #{core.bem("checkbox", "box")} {
       border-color: css.get("checkbox", "color");
@@ -73,7 +73,7 @@
 
   &:focus-visible + #{core.bem("checkbox", "background")},
   &:active + #{core.bem("checkbox", "background")} {
-    background-color: hsl(from css.get("checkbox", "color") h s l / css.get("checkbox", "background-opacity-active"));
+    background-color: hsl(from css.get("checkbox", "background-color") h s l / css.get("checkbox", "background-opacity-active"));
 
     #{core.bem("checkbox", "box")} {
       border-color: css.get("checkbox", "color");

--- a/packages/checkbox/src/_variables.scss
+++ b/packages/checkbox/src/_variables.scss
@@ -13,6 +13,7 @@ $fill: null !default;
 $border-color: null !default;
 $border-width: 2px !default;
 $border-radius: css.get("border-radius") !default;
+$background-color: $color !default;
 $background-border-radius: css.get("border-radius-circle") !default;
 $background-opacity: 0% !default;
 $background-opacity-hover: 20% !default;
@@ -48,6 +49,7 @@ $size-lg-icon-stroke: 2 !default;
   "border-width": $border-width,
   "border-radius": $border-radius,
   "background": (
+    "color": $background-color,
     "border-radius": $background-border-radius,
     "opacity": $background-opacity,
     "opacity-hover": $background-opacity-hover,

--- a/packages/radio/src/_radio.scss
+++ b/packages/radio/src/_radio.scss
@@ -18,7 +18,7 @@
   align-items: center;
   justify-content: center;
   border-radius: css.get("radio", "background-border-radius");
-  background-color: hsl(from css.get("radio", "color") h s l / css.get("radio", "background-opacity"));
+  background-color: hsl(from css.get("radio", "background-color") h s l / css.get("radio", "background-opacity"));
 }
 
 #{core.bem("radio", "circle")} {
@@ -49,7 +49,7 @@
   cursor: pointer;
 
   &:hover + #{core.bem("radio", "background")} {
-    background-color: hsl(from css.get("radio", "color") h s l / css.get("radio", "background-opacity-hover"));
+    background-color: hsl(from css.get("radio", "background-color") h s l / css.get("radio", "background-opacity-hover"));
 
     #{core.bem("radio", "circle")} {
       border-color: css.get("radio", "color");
@@ -58,7 +58,7 @@
   }
 
   &:focus + #{core.bem("radio", "background")} {
-    background-color: hsl(from css.get("radio", "color") h s l / css.get("radio", "background-opacity-focus"));
+    background-color: hsl(from css.get("radio", "background-color") h s l / css.get("radio", "background-opacity-focus"));
 
     #{core.bem("radio", "circle")} {
       border-color: css.get("radio", "color");
@@ -68,7 +68,7 @@
 
   &:focus-visible + #{core.bem("radio", "background")},
   &:active + #{core.bem("radio", "background")} {
-    background-color: hsl(from css.get("radio", "color") h s l / css.get("radio", "background-opacity-active"));
+    background-color: hsl(from css.get("radio", "background-color") h s l / css.get("radio", "background-opacity-active"));
 
     #{core.bem("radio", "circle")} {
       border-color: css.get("radio", "color");

--- a/packages/radio/src/_variables.scss
+++ b/packages/radio/src/_variables.scss
@@ -11,6 +11,7 @@ $color: palette.get("primary") !default;
 $fill: null !default;
 $border-color: null !default;
 $border-width: 2px !default;
+$background-color: $color !default;
 $background-border-radius: css.get("border-radius-circle") !default;
 $background-opacity: 0% !default;
 $background-opacity-hover: 20% !default;
@@ -42,6 +43,7 @@ $size-lg-dot: 10px !default;
   "border-color": $border-color,
   "border-width": $border-width,
   "background": (
+    "color": $background-color,
     "border-radius": $background-border-radius,
     "opacity": $background-opacity,
     "opacity-hover": $background-opacity-hover,

--- a/packages/switch/src/_switch.scss
+++ b/packages/switch/src/_switch.scss
@@ -30,7 +30,7 @@ $_thumb-size: calc(css.get("switch", "track-size") - calc(css.get("switch", "bor
     left: calc(calc(css.get("switch", "size") * 0.25) * -1);
     transition: left css.get("switch", "transition-duration") css.get("switch", "transition-timing-function");
     border-radius: css.get("switch", "background-border-radius");
-    background-color: hsl(from css.get("switch", "color") h s l / css.get("switch", "background-opacity"));
+    background-color: hsl(from css.get("switch", "background-color") h s l / css.get("switch", "background-opacity"));
   }
 }
 
@@ -67,7 +67,7 @@ $_thumb-size: calc(css.get("switch", "track-size") - calc(css.get("switch", "bor
 
   &:hover + #{core.bem("switch", "background")} {
     &::after {
-      background-color: hsl(from css.get("switch", "color") h s l / css.get("switch", "background-opacity-hover"));
+      background-color: hsl(from css.get("switch", "background-color") h s l / css.get("switch", "background-opacity-hover"));
     }
 
     #{core.bem("switch", "track")} {
@@ -82,7 +82,7 @@ $_thumb-size: calc(css.get("switch", "track-size") - calc(css.get("switch", "bor
 
   &:focus + #{core.bem("switch", "background")} {
     &::after {
-      background-color: hsl(from css.get("switch", "color") h s l / css.get("switch", "background-opacity-focus"));
+      background-color: hsl(from css.get("switch", "background-color") h s l / css.get("switch", "background-opacity-focus"));
     }
 
     #{core.bem("switch", "track")} {
@@ -98,7 +98,7 @@ $_thumb-size: calc(css.get("switch", "track-size") - calc(css.get("switch", "bor
   &:focus-visible + #{core.bem("switch", "background")},
   &:active + #{core.bem("switch", "background")} {
     &::after {
-      background-color: hsl(from css.get("switch", "color") h s l / css.get("switch", "background-opacity-active"));
+      background-color: hsl(from css.get("switch", "background-color") h s l / css.get("switch", "background-opacity-active"));
     }
 
     #{core.bem("switch", "track")} {

--- a/packages/switch/src/_variables.scss
+++ b/packages/switch/src/_variables.scss
@@ -11,6 +11,7 @@ $track-fill: null !default;
 $border-color: null !default;
 $border-width: 2px !default;
 $border-radius: css.get("border-radius-circle") !default;
+$background-color: $color !default;
 $background-border-radius: css.get("border-radius-circle") !default;
 $background-opacity: 0% !default;
 $background-opacity-hover: 20% !default;
@@ -40,6 +41,7 @@ $size-lg-track: 26px !default;
   "border-width": $border-width,
   "border-radius": $border-radius,
   "background": (
+    "color": $background-color,
     "border-radius": $background-border-radius,
     "opacity": $background-opacity,
     "opacity-hover": $background-opacity-hover,


### PR DESCRIPTION
## What changed?

This PR adds the `background-color` property so that form-control backgrounds can be targeted separately from the general color of the control. Property inherits `color` by default. This applies to:

- `@vrembem/checkbox`
- `@vrembem/radio`
- `@vrembem/switch`
