### PR TITLE
Add css.defer function to better manage dependent custom property values and output

### DIFF
--- a/packages/checkbox/src/_checkbox.scss
+++ b/packages/checkbox/src/_checkbox.scss
@@ -14,6 +14,7 @@
 }
 
 #{core.bem("checkbox", "background")} {
+  @include core.form-control-size();
   @include core.size(css.get("checkbox", "size", css.get("form-control-size")));
   position: relative;
   z-index: 1;

--- a/packages/core/index.scss
+++ b/packages/core/index.scss
@@ -9,6 +9,7 @@
 @forward "./src/scss/library/bem";
 @forward "./src/scss/library/css-query";
 @forward "./src/scss/library/form-control-properties";
+@forward "./src/scss/library/form-control-size";
 @forward "./src/scss/library/get-side";
 @forward "./src/scss/library/loading-spinner";
 @forward "./src/scss/library/media-max";

--- a/packages/core/src/scss/library/_form-control-properties.scss
+++ b/packages/core/src/scss/library/_form-control-properties.scss
@@ -1,12 +1,14 @@
 @use "../modules/css";
 @use "../variables/form-control" as *;
 @use "./minus-border-width" as *;
+@use "./form-control-size";
 
 /// Set the shared form-control properties with the component specific custom
 /// property and the form-control custom property as the fallback.
 /// @param {string} $module
 ///   The module to pass to `css.get` calls.
 @mixin form-control-properties($module) {
+  @include form-control-size.set();
   min-width: css.get($module, "size", css.get("form-control-size"));
   min-height: css.get($module, "size", css.get("form-control-size"));
   transition-property: css.get($module, "transition-property", css.get("form-control-transition-property"));

--- a/packages/core/src/scss/library/_form-control-properties.scss
+++ b/packages/core/src/scss/library/_form-control-properties.scss
@@ -1,14 +1,14 @@
 @use "../modules/css";
 @use "../variables/form-control" as *;
 @use "./minus-border-width" as *;
-@use "./form-control-size";
+@use "./form-control-size" as *;
 
 /// Set the shared form-control properties with the component specific custom
 /// property and the form-control custom property as the fallback.
 /// @param {string} $module
 ///   The module to pass to `css.get` calls.
 @mixin form-control-properties($module) {
-  @include form-control-size.set();
+  @include form-control-size();
   min-width: css.get($module, "size", css.get("form-control-size"));
   min-height: css.get($module, "size", css.get("form-control-size"));
   transition-property: css.get($module, "transition-property", css.get("form-control-transition-property"));

--- a/packages/core/src/scss/library/_form-control-size.scss
+++ b/packages/core/src/scss/library/_form-control-size.scss
@@ -1,0 +1,21 @@
+@use "../modules/css";
+
+$_set-custom-property: true;
+
+// Sets the form-control-size css custom property.
+// Size is calculated using the line-height and vertical padding. This is used 
+// to set the minimum height and width of form controls.
+@mixin set() {
+  $_line-height: css.get("form-control-line-height");
+  $_padding: css.get("form-control-padding-y");
+  $_size: calc(calc(1em * $_line-height) + calc($_padding * 2)) !default;
+  @if ($_set-custom-property) {
+    @include css.set("core", "form-control-size", $_size);
+    $_set-custom-property: false !global;
+  }
+}
+
+// Returns the form-control-size css custom property reference.
+@function get() {
+  @return css.get("form-control-size");
+}

--- a/packages/core/src/scss/library/_form-control-size.scss
+++ b/packages/core/src/scss/library/_form-control-size.scss
@@ -5,17 +5,12 @@ $_set-custom-property: true;
 // Sets the form-control-size css custom property.
 // Size is calculated using the line-height and vertical padding. This is used 
 // to set the minimum height and width of form controls.
-@mixin set() {
-  $_line-height: css.get("form-control-line-height");
-  $_padding: css.get("form-control-padding-y");
-  $_size: calc(calc(1em * $_line-height) + calc($_padding * 2)) !default;
+@mixin form-control-size() {
   @if ($_set-custom-property) {
+    $_line-height: css.get("form-control-line-height");
+    $_padding: css.get("form-control-padding-y");
+    $_size: calc(calc(1em * $_line-height) + calc($_padding * 2)) !default;
     @include css.set("core", "form-control-size", $_size);
     $_set-custom-property: false !global;
   }
-}
-
-// Returns the form-control-size css custom property reference.
-@function get() {
-  @return css.get("form-control-size");
 }

--- a/packages/core/src/scss/modules/_config.scss
+++ b/packages/core/src/scss/modules/_config.scss
@@ -7,7 +7,7 @@
 /// @type map
 /// @access private
 $_options: (
-  "output-strategy": "used",
+  "output-strategy": "*",
   "prefix-variables": "vb-",
   "prefix-themes": "vb-theme-",
   "prefix-blocks": null,

--- a/packages/core/src/scss/modules/_config.scss
+++ b/packages/core/src/scss/modules/_config.scss
@@ -7,7 +7,7 @@
 /// @type map
 /// @access private
 $_options: (
-  "output-strategy": "*",
+  "output-strategy": "used",
   "prefix-variables": "vb-",
   "prefix-themes": "vb-theme-",
   "prefix-blocks": null,

--- a/packages/core/src/scss/modules/_css.scss
+++ b/packages/core/src/scss/modules/_css.scss
@@ -129,6 +129,15 @@ $_variables: (
   }
 }
 
+/// TODO: Add documentation
+@function defer($module, $prop: null) {
+  @if not $prop {
+    $prop: $module;
+    $module: "core";
+  }
+  @return "defer", $module, $prop;
+}
+
 /// Function to return a custom property reference that has been stored in the 
 /// `$_variables` map using set(). Can also return the entire `$_variables` map
 /// or one of the stored module maps.
@@ -193,15 +202,29 @@ $_variables: (
     // Loop through the props and append them to results as nested fallbacks.
     @for $i from 1 through $count {
       $prop: list.nth($props, $i);
+      $value: map.get($_variables, $module, $prop);
+
+      // Check if the value was deferred.
+      @if (meta.type-of($value) == "list") and (list.nth($value, 1) == "defer") {
+        // Create the reference using the stored value list.
+        $_ref: reference(list.nth($value, 2), list.nth($value, 3));
+        // Update the variables map with the value of the reference.
+        $_variables: map.set($_variables, $module, $prop, $_ref) !global;
+        // Store the reference in our result.
+        $result: reference($module, $prop);
+      }
+
       // If the property is not the first item in the list or exists in the
       // module or the module's default theme...
-      @if 
+      @else if 
         map.has-key($_variables, $module, $prop) or
         map.has-key($_variables, $module, config.get("default-theme"), $prop)
       {
         // store the reference in our result.
         $result: reference($module, $prop, $result);
-      } @else {
+      } 
+
+      @else {
         @if $count > 1 and $i == 1 {
           // First prop of the props list, store the raw value as our fallback.
           $result: $prop;

--- a/packages/core/src/scss/modules/_css.scss
+++ b/packages/core/src/scss/modules/_css.scss
@@ -216,7 +216,7 @@ $_variables: (
       $prop: list.nth($props, $i);
       $value: map.get($_variables, $module, $prop);
 
-      // Check if the value was deferred.
+      // Check if the value is a deferred property.
       @if (meta.type-of($value) == "list") and (list.nth($value, 1) == "defer") {
         // Create the reference using the stored value list.
         $_ref: reference(list.nth($value, 2), list.nth($value, 3));
@@ -226,8 +226,7 @@ $_variables: (
         $result: reference($module, $prop);
       }
 
-      // If the property is not the first item in the list or exists in the
-      // module or the module's default theme...
+      // Check if the property exists in the module or the its default theme.
       @else if 
         map.has-key($_variables, $module, $prop) or
         map.has-key($_variables, $module, config.get("default-theme"), $prop)
@@ -236,6 +235,7 @@ $_variables: (
         $result: reference($module, $prop, $result);
       } 
 
+      // All other cases depend on the property count and its position.
       @else {
         @if $count > 1 and $i == 1 {
           // First prop of the props list, store the raw value as our fallback.

--- a/packages/core/src/scss/modules/_css.scss
+++ b/packages/core/src/scss/modules/_css.scss
@@ -124,12 +124,24 @@ $_variables: (
     }
     // Set the usage before outputting the custom property.
     @if usage.set($module, $prop, $args...) {
+      // Check if the value has been deferred.
+      @if (meta.type-of($value) == "list") and (list.nth($value, 1) == "defer") {
+        // Create the reference using the deferred value list.
+        $value: reference(list.nth($value, 2), list.nth($value, 3));
+      }
+      // Define the custom property.
       #{_prefix($module)}#{$prop}: #{$value};
     }
   }
 }
 
-/// TODO: Add documentation
+/// Used in place of `set` for when a custom property is dependent on another.
+/// This allows the property to be omitted if the original definition is never
+/// actually referenced.
+/// @param {string} $module
+///   The module name to store the custom property under.
+/// @param {string | map} $prop
+///   The custom property name to store.
 @function defer($module, $prop: null) {
   @if not $prop {
     $prop: $module;

--- a/packages/core/src/scss/variables/_form-control.scss
+++ b/packages/core/src/scss/variables/_form-control.scss
@@ -60,21 +60,3 @@ $form-control-transition-timing-function: css.defer("transition-timing-function"
   "transition-duration": $form-control-transition-duration,
   "transition-timing-function": $form-control-transition-timing-function
 ));
-
-// Size is calculated using the line-height and vertical padding. This is used 
-// to set the minimum height and width of form controls.
-$form-control-size: calc(calc(1em * css.get("form-control-line-height")) + calc(css.get("form-control-padding-y") * 2)) !default;
-@include css.set("core", "form-control-size", $form-control-size);
-
-// // TESTING DEFER
-// @include css.set("core", "defer-test", true);
-// $form-control-test: css.defer("defer-test");
-// @include css.set("core", "asdf-defer-test", $form-control-test);
-
-// body {
-//   content: css.get("asdf-defer-test");
-// }
-
-// // Expected result:
-// // --vb-defer-test: true;
-// // --vb-asdf-defer-test: var(--vb-defer-test);

--- a/packages/core/src/scss/variables/_form-control.scss
+++ b/packages/core/src/scss/variables/_form-control.scss
@@ -1,11 +1,12 @@
 @use "../modules/css";
 @use "../modules/palette";
 @use "../modules/theme";
+@use "sass:list";
 
-$form-control-font-size: css.get("font-size") !default;
-$form-control-font-size-sm: css.get("font-size-sm") !default;
-$form-control-font-size-lg: css.get("font-size-lg") !default;
-$form-control-line-height: css.get("line-height") !default;
+$form-control-font-size: css.defer("font-size") !default;
+$form-control-font-size-sm: css.defer("font-size-sm") !default;
+$form-control-font-size-lg: css.defer("font-size-lg") !default;
+$form-control-line-height: css.defer("line-height") !default;
 @include css.set("core", "form-control", (
   "font-size": $form-control-font-size,
   "font-size-sm": $form-control-font-size-sm,
@@ -13,8 +14,8 @@ $form-control-line-height: css.get("line-height") !default;
   "line-height": $form-control-line-height,
 ));
 
-$form-control-border-width: css.get("border-width") !default;
-$form-control-border-radius: css.get("border-radius") !default;
+$form-control-border-width: css.defer("border-width") !default;
+$form-control-border-radius: css.defer("border-radius") !default;
 @include css.set("core", "form-control", (
   "border-width": $form-control-border-width,
   "border-radius": $form-control-border-radius,
@@ -30,7 +31,7 @@ $form-control-padding: $form-control-padding-y $form-control-padding-x !default;
 ));
 
 $form-control-accent: palette.get("primary") !default;
-$form-control-background: css.get("background") !default;
+$form-control-background: css.defer("background") !default;
 @include css.set("core", "form-control", (
   "accent": $form-control-accent,
   "background": $form-control-background,
@@ -38,7 +39,7 @@ $form-control-background: css.get("background") !default;
 @include theme.set("core", "light", "form-control-foreground", palette.get("neutral"));
 @include theme.set("core", "dark", "form-control-foreground", palette.get("neutral", 80));
 
-$background-border-radius: css.get("border-radius-circle") !default;
+$background-border-radius: css.defer("border-radius-circle") !default;
 $background-opacity: 0% !default;
 $background-opacity-hover: 20% !default;
 $background-opacity-focus: 20% !default;
@@ -52,8 +53,8 @@ $background-opacity-active: 30% !default;
 ));
 
 $form-control-transition-property: box-shadow !default;
-$form-control-transition-duration: css.get("transition-duration") !default;
-$form-control-transition-timing-function: css.get("transition-timing-function") !default;
+$form-control-transition-duration: css.defer("transition-duration") !default;
+$form-control-transition-timing-function: css.defer("transition-timing-function") !default;
 @include css.set("core", "form-control", (
   "transition-property": $form-control-transition-property,
   "transition-duration": $form-control-transition-duration,
@@ -65,3 +66,15 @@ $form-control-transition-timing-function: css.get("transition-timing-function") 
 $form-control-size: calc(calc(1em * css.get("form-control-line-height")) + calc(css.get("form-control-padding-y") * 2)) !default;
 @include css.set("core", "form-control-size", $form-control-size);
 
+// // TESTING DEFER
+// @include css.set("core", "defer-test", true);
+// $form-control-test: css.defer("defer-test");
+// @include css.set("core", "asdf-defer-test", $form-control-test);
+
+// body {
+//   content: css.get("asdf-defer-test");
+// }
+
+// // Expected result:
+// // --vb-defer-test: true;
+// // --vb-asdf-defer-test: var(--vb-defer-test);

--- a/packages/radio/src/_radio.scss
+++ b/packages/radio/src/_radio.scss
@@ -13,6 +13,7 @@
 }
 
 #{core.bem("radio", "background")} {
+  @include core.form-control-size();
   @include core.size(css.get("radio", "size", css.get("form-control-size")));
   position: relative;
   z-index: 1;

--- a/packages/switch/src/_switch.scss
+++ b/packages/switch/src/_switch.scss
@@ -5,6 +5,7 @@
 $_thumb-size: calc(css.get("switch", "track-size", var.$track-size) - calc(css.get("switch", "border-width", var.$border-width) * 2));
 
 #{core.bem("switch")} {
+  @include core.form-control-size();
   position: relative;
   display: inline-flex;
   flex: 0 0 auto;


### PR DESCRIPTION
## What changed?

This PR adds a new function `css.defer` to the CSS module that will prevent outputting custom properties if they're referenced in another custom property that isn't used. Once the dependent property is used, both custom properties will be output. This is done by setting a special value in the variables map which is evaluated in both `get` and `output` calls.

This PR also adds a necessary `form-control-size` mixin that handles setting the size custom property of form controls which relies on having available the values of `form-control-line-height` and `form-control-padding-y`. Since these values are not deferred, we use a mixin to set this property before it's used.
