### PR TITLE
Add missing root.scss value in package.json "files" property

### DIFF
--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -27,7 +27,8 @@
     "dist",
     "src",
     "index.js",
-    "index.scss"
+    "index.scss",
+    "root.scss"
   ],
   "scripts": {
     "serve": "vite",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -27,7 +27,8 @@
     "dist",
     "src",
     "index.js",
-    "index.scss"
+    "index.scss",
+    "root.scss"
   ],
   "scripts": {
     "serve": "vite",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -27,7 +27,8 @@
     "dist",
     "src",
     "index.js",
-    "index.scss"
+    "index.scss",
+    "root.scss"
   ],
   "scripts": {
     "serve": "vite",


### PR DESCRIPTION
## What changed?

This PR adds missing `root.scss` value in package.json "files" property of drawer, modal and popover components.