### PR TITLE
Add focus-ring variables and apply to form-controls

### DIFF
--- a/packages/button/src/_button.scss
+++ b/packages/button/src/_button.scss
@@ -26,7 +26,7 @@
   }
 
   &:focus-visible {
-    outline: core.focus-ring-value("button", var.$accent);
+    @include core.focus-ring-value("button", var.$accent);
     border-color: css.get("button", "border-color-focus-visible", "border-color-focus", "border-color-hover", "border-color", var.$border-color-focus-visible);
     background-color: css.get("button", "background-focus-visible", "background-focus", "background-hover", "background", var.$background-focus-visible);
     box-shadow: css.get("button", "box-shadow-focus-visible", "box-shadow-focus", "box-shadow-hover", "box-shadow", var.$box-shadow-focus-visible);

--- a/packages/button/src/_button.scss
+++ b/packages/button/src/_button.scss
@@ -30,6 +30,7 @@
     background-color: css.get("button", "background-focus-visible", "background-focus", "background-hover", "background", var.$background-focus-visible);
     box-shadow: css.get("button", "box-shadow-focus-visible", "box-shadow-focus", "box-shadow-hover", "box-shadow", var.$box-shadow-focus-visible);
     color: css.get("button", "foreground-focus-visible", "foreground-focus", "foreground-hover", "foreground", var.$foreground-focus-visible);
+    outline: var.$focus-ring;
   }
 
   &:active {

--- a/packages/button/src/_button.scss
+++ b/packages/button/src/_button.scss
@@ -26,7 +26,7 @@
   }
 
   &:focus-visible {
-    outline: var.$focus-ring;
+    outline: core.focus-ring-value("button", var.$accent);
     border-color: css.get("button", "border-color-focus-visible", "border-color-focus", "border-color-hover", "border-color", var.$border-color-focus-visible);
     background-color: css.get("button", "background-focus-visible", "background-focus", "background-hover", "background", var.$background-focus-visible);
     box-shadow: css.get("button", "box-shadow-focus-visible", "box-shadow-focus", "box-shadow-hover", "box-shadow", var.$box-shadow-focus-visible);

--- a/packages/button/src/_button.scss
+++ b/packages/button/src/_button.scss
@@ -26,7 +26,7 @@
   }
 
   &:focus-visible {
-    @include core.focus-ring-value("button", var.$accent);
+    @include core.focus-ring("button", var.$accent);
     border-color: css.get("button", "border-color-focus-visible", "border-color-focus", "border-color-hover", "border-color", var.$border-color-focus-visible);
     background-color: css.get("button", "background-focus-visible", "background-focus", "background-hover", "background", var.$background-focus-visible);
     box-shadow: css.get("button", "box-shadow-focus-visible", "box-shadow-focus", "box-shadow-hover", "box-shadow", var.$box-shadow-focus-visible);

--- a/packages/button/src/_button.scss
+++ b/packages/button/src/_button.scss
@@ -26,11 +26,11 @@
   }
 
   &:focus-visible {
+    outline: var.$focus-ring;
     border-color: css.get("button", "border-color-focus-visible", "border-color-focus", "border-color-hover", "border-color", var.$border-color-focus-visible);
     background-color: css.get("button", "background-focus-visible", "background-focus", "background-hover", "background", var.$background-focus-visible);
     box-shadow: css.get("button", "box-shadow-focus-visible", "box-shadow-focus", "box-shadow-hover", "box-shadow", var.$box-shadow-focus-visible);
     color: css.get("button", "foreground-focus-visible", "foreground-focus", "foreground-hover", "foreground", var.$foreground-focus-visible);
-    outline: var.$focus-ring;
   }
 
   &:active {

--- a/packages/button/src/_mixins.scss
+++ b/packages/button/src/_mixins.scss
@@ -1,15 +1,15 @@
+@use "@vrembem/core";
 @use "@vrembem/core/css";
 @use "./variables" as var;
 
 /// Output the base styles for a button component.
 @mixin button-base() {
+  @include core.focus-ring-base();
   position: relative;
   display: inline-flex;
   gap: css.get("button", "gap", var.$gap);
   align-items: center;
   justify-content: center;
-  outline: 0 solid transparent;
-  outline-offset: css.get("focus-ring-offset");
   border-style: solid;
   background-clip: border-box;
   font-family: inherit;

--- a/packages/button/src/_mixins.scss
+++ b/packages/button/src/_mixins.scss
@@ -8,7 +8,8 @@
   gap: css.get("button", "gap", var.$gap);
   align-items: center;
   justify-content: center;
-  outline: none;
+  outline: 0 solid transparent;
+  outline-offset: css.get("focus-ring-offset");
   border-style: solid;
   background-clip: border-box;
   font-family: inherit;

--- a/packages/button/src/_variables.scss
+++ b/packages/button/src/_variables.scss
@@ -24,11 +24,15 @@ $border-color-focus: $border-color-hover !default;
 $border-color-focus-visible: $accent !default;
 $border-color-active: $foreground-active !default;
 
-$box-shadow: 0 0 0 0 hsl(from $accent h s l / 0%) !default;
+$box-shadow: none !default;
 $box-shadow-hover: $box-shadow !default;
 $box-shadow-focus: $box-shadow !default;
-$box-shadow-focus-visible: 0 0 0 3px hsl(from $accent h s l / 40%) !default;
+$box-shadow-focus-visible: $box-shadow !default;
 $box-shadow-active: $box-shadow !default;
+
+$focus-ring-opacity: css.get("button", "focus-ring-opacity", css.get("focus-ring-opacity")) !default;
+$focus-ring-color: css.get("button", "focus-ring-color", css.get("core", "focus-ring-color", hsl(from $accent h s l / $focus-ring-opacity))) !default;
+$focus-ring: css.get("focus-ring-width") css.get("focus-ring-style") $focus-ring-color !default;
 
 // State: disabled
 $disabled-opacity: 0.6 !default;

--- a/packages/button/src/_variables.scss
+++ b/packages/button/src/_variables.scss
@@ -30,10 +30,6 @@ $box-shadow-focus: $box-shadow !default;
 $box-shadow-focus-visible: $box-shadow !default;
 $box-shadow-active: $box-shadow !default;
 
-$focus-ring-opacity: css.get("button", "focus-ring-opacity", css.get("focus-ring-opacity")) !default;
-$focus-ring-color: css.get("button", "focus-ring-color", css.get("core", "focus-ring-color", hsl(from $accent h s l / $focus-ring-opacity))) !default;
-$focus-ring: css.get("focus-ring-width") css.get("focus-ring-style") $focus-ring-color !default;
-
 // State: disabled
 $disabled-opacity: 0.6 !default;
 

--- a/packages/core/index.scss
+++ b/packages/core/index.scss
@@ -9,7 +9,7 @@
 
 @forward "./src/scss/library/bem";
 @forward "./src/scss/library/css-query";
-@forward "./src/scss/library/focus-ring-value";
+@forward "./src/scss/library/focus-ring";
 @forward "./src/scss/library/form-control";
 @forward "./src/scss/library/get-side";
 @forward "./src/scss/library/loading-spinner";

--- a/packages/core/index.scss
+++ b/packages/core/index.scss
@@ -4,6 +4,7 @@
 @forward "./src/scss/variables/box-shadow";
 @forward "./src/scss/variables/typography";
 @forward "./src/scss/variables/transition";
+@forward "./src/scss/variables/focus-ring";
 @forward "./src/scss/variables/form-control";
 
 @forward "./src/scss/library/bem";

--- a/packages/core/index.scss
+++ b/packages/core/index.scss
@@ -9,7 +9,8 @@
 
 @forward "./src/scss/library/bem";
 @forward "./src/scss/library/css-query";
-@forward "./src/scss/library/form-control" as form-control-*;
+@forward "./src/scss/library/focus-ring-value";
+@forward "./src/scss/library/form-control";
 @forward "./src/scss/library/get-side";
 @forward "./src/scss/library/loading-spinner";
 @forward "./src/scss/library/media-max";

--- a/packages/core/src/scss/library/_focus-ring-value.scss
+++ b/packages/core/src/scss/library/_focus-ring-value.scss
@@ -1,0 +1,12 @@
+@use "../modules/css";
+
+/// TODO: Add documentation
+@function focus-ring-value($module, $color) {
+  $_focus-ring-opacity: css.get("core", "focus-ring-opacity");
+  $_focus-ring-color: css.get("core", "focus-ring-color", hsl(from $color h s l / $_focus-ring-opacity));
+  @if ($module) {
+    $_focus-ring-opacity: css.get($module, "focus-ring-opacity", $_focus-ring-opacity);
+    $_focus-ring-color: css.get($module, "focus-ring-color", css.get("core", "focus-ring-color", hsl(from $color h s l / $_focus-ring-opacity)));
+  }
+  @return css.get("focus-ring-width") css.get("focus-ring-style") $_focus-ring-color;
+}

--- a/packages/core/src/scss/library/_focus-ring-value.scss
+++ b/packages/core/src/scss/library/_focus-ring-value.scss
@@ -1,12 +1,23 @@
 @use "../modules/css";
 
-/// TODO: Add documentation
-@function focus-ring-value($module, $color) {
+/// Apply the base styles for focus-ring using the outline properties.
+@mixin focus-ring-base() {
+  outline: css.get("focus-ring-width") css.get("focus-ring-style") transparent;
+  outline-offset: css.get("focus-ring-offset");
+}
+
+/// Builds the focus ring styles by applying a number of custom property values
+/// and optional component overrides using the outline property.
+/// @param {string} $module
+///   The module to allow component specific overrides for.
+/// @param {string} $color
+///   The color to use as the fallback value.
+@mixin focus-ring-value($module, $color) {
   $_focus-ring-opacity: css.get("core", "focus-ring-opacity");
-  $_focus-ring-color: css.get("core", "focus-ring-color", hsl(from $color h s l / $_focus-ring-opacity));
+  $_focus-ring-color: css.get("core", "focus-ring-color", $color);
   @if ($module) {
     $_focus-ring-opacity: css.get($module, "focus-ring-opacity", $_focus-ring-opacity);
-    $_focus-ring-color: css.get($module, "focus-ring-color", css.get("core", "focus-ring-color", hsl(from $color h s l / $_focus-ring-opacity)));
+    $_focus-ring-color: css.get($module, "focus-ring-color", $_focus-ring-color);
   }
-  @return css.get("focus-ring-width") css.get("focus-ring-style") $_focus-ring-color;
+  outline: css.get("focus-ring-width") css.get("focus-ring-style") hsl(from $_focus-ring-color h s l / $_focus-ring-opacity);
 }

--- a/packages/core/src/scss/library/_focus-ring.scss
+++ b/packages/core/src/scss/library/_focus-ring.scss
@@ -12,7 +12,7 @@
 ///   The module to allow component specific overrides for.
 /// @param {string} $color
 ///   The color to use as the fallback value.
-@mixin focus-ring-value($module, $color) {
+@mixin focus-ring($module, $color) {
   $_focus-ring-opacity: css.get("core", "focus-ring-opacity");
   $_focus-ring-color: css.get("core", "focus-ring-color", $color);
   @if ($module) {

--- a/packages/core/src/scss/library/_form-control.scss
+++ b/packages/core/src/scss/library/_form-control.scss
@@ -8,7 +8,7 @@ $_set-custom-property: true;
 /// border-width values.
 /// @return {value}
 ///   The CSS value in the form of a calc function.
-@function get-size() {
+@function form-control-get-size() {
   $_line-height: css.get("form-control-line-height");
   $_padding: css.get("form-control-padding-y");
   $_border-width: css.get("form-control-border-width");
@@ -18,10 +18,10 @@ $_set-custom-property: true;
 
 /// Set the form-control-size custom property. This mixin contains a check to
 /// ensure the property is only set once.
-@mixin set-size() {
+@mixin form-control-set-size() {
   @if ($_set-custom-property) {
     $_set-custom-property: false !global;
-    @include css.set("core", "form-control-size", get-size());
+    @include css.set("core", "form-control-size", form-control-get-size());
   }
 }
 
@@ -32,8 +32,8 @@ $_set-custom-property: true;
 ///   The module to allow component specific overrides for.
 /// @param {string} $prefix [null]
 ///   The prefix to apply to the width/height css property.
-@mixin size($module: null, $prefix: null) {
-  @include set-size();
+@mixin form-control-size($module: null, $prefix: null) {
+  @include form-control-set-size();
   @if ($module) {
     @include mix.size(
       css.get($module, "size", css.get("form-control-size")),
@@ -53,7 +53,7 @@ $_set-custom-property: true;
 /// property and the form-control custom property as the fallback.
 /// @param {string} $module
 ///   The module to pass to `css.get` calls.
-@mixin properties($module) {
+@mixin form-control-properties($module) {
   @if ($module != "menu") {
     font-size: css.get($module, "font-size", css.get("form-control-font-size"));
     line-height: css.get($module, "line-height", css.get("form-control-line-height"));

--- a/packages/core/src/scss/variables/_focus-ring.scss
+++ b/packages/core/src/scss/variables/_focus-ring.scss
@@ -1,0 +1,14 @@
+@use "../modules/css";
+@use "../modules/palette";
+
+$focus-ring-width: 3px !default;
+$focus-ring-style: solid !default;
+$focus-ring-offset: 0 !default;
+$focus-ring-opacity: 40% !default;
+
+@include css.set("core", "focus-ring", (
+  "width": $focus-ring-width,
+  "style": $focus-ring-style,
+  "offset": $focus-ring-offset,
+  "opacity": $focus-ring-opacity,
+));

--- a/packages/core/src/scss/variables/_focus-ring.scss
+++ b/packages/core/src/scss/variables/_focus-ring.scss
@@ -1,5 +1,4 @@
 @use "../modules/css";
-@use "../modules/palette";
 
 $focus-ring-width: 3px !default;
 $focus-ring-style: solid !default;

--- a/packages/core/src/scss/variables/_form-control.scss
+++ b/packages/core/src/scss/variables/_form-control.scss
@@ -52,8 +52,8 @@ $background-opacity-active: 30% !default;
   "background-opacity-active": $background-opacity-active
 ));
 
-$form-control-transition-property: box-shadow !default;
-$form-control-transition-duration: css.defer("transition-duration") !default;
+$form-control-transition-property: box-shadow, outline !default;
+$form-control-transition-duration: css.defer("transition-duration-short") !default;
 $form-control-transition-timing-function: css.defer("transition-timing-function") !default;
 @include css.set("core", "form-control", (
   "transition-property": $form-control-transition-property,

--- a/packages/input/src/_input.scss
+++ b/packages/input/src/_input.scss
@@ -10,7 +10,7 @@
   background-color: css.get("input", "background", var.$background);
   box-shadow: css.get("input", "box-shadow", var.$box-shadow);
   color: css.get("input", "foreground", var.$foreground);
-  
+
   &:hover {
     border-color: css.get("input", "border-color-hover", "border-color", var.$border-color-hover);
     background-color: css.get("input", "background-hover", "background", var.$background-hover);
@@ -23,6 +23,10 @@
     background-color: css.get("input", "background-focus", "background-hover", "background", var.$background-focus);
     box-shadow: css.get("input", "box-shadow-focus", "box-shadow-hover", "box-shadow", var.$box-shadow-focus);
     color: css.get("input", "foreground-focus", "foreground-hover", "foreground", var.$foreground-focus);
+  }
+
+  &:focus-visible {
+    outline: var.$focus-ring;
   }
 
   &:read-only {

--- a/packages/input/src/_input.scss
+++ b/packages/input/src/_input.scss
@@ -26,7 +26,7 @@
   }
 
   &:focus-visible {
-    outline: core.focus-ring-value("input", var.$accent);
+    @include core.focus-ring-value("input", var.$accent);
   }
 
   &:read-only {

--- a/packages/input/src/_input.scss
+++ b/packages/input/src/_input.scss
@@ -26,7 +26,7 @@
   }
 
   &:focus-visible {
-    outline: var.$focus-ring;
+    outline: core.focus-ring-value("input", var.$accent);
   }
 
   &:read-only {

--- a/packages/input/src/_input.scss
+++ b/packages/input/src/_input.scss
@@ -26,7 +26,7 @@
   }
 
   &:focus-visible {
-    @include core.focus-ring-value("input", var.$accent);
+    @include core.focus-ring("input", var.$accent);
   }
 
   &:read-only {

--- a/packages/input/src/_mixins.scss
+++ b/packages/input/src/_mixins.scss
@@ -1,5 +1,4 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
 
 /// Output the base styles for an input component.
 @mixin input-base() {

--- a/packages/input/src/_mixins.scss
+++ b/packages/input/src/_mixins.scss
@@ -1,10 +1,13 @@
+@use "@vrembem/core/css";
+
 /// Output the base styles for an input component.
 @mixin input-base() {
   position: relative;
   display: block;
   width: 100%;
   max-width: 100%;
-  outline: none;
+  outline: 0 solid transparent;
+  outline-offset: css.get("focus-ring-offset");
   border-style: solid;
   font-family: inherit;
   appearance: none;

--- a/packages/input/src/_mixins.scss
+++ b/packages/input/src/_mixins.scss
@@ -1,13 +1,13 @@
+@use "@vrembem/core";
 @use "@vrembem/core/css";
 
 /// Output the base styles for an input component.
 @mixin input-base() {
+  @include core.focus-ring-base();
   position: relative;
   display: block;
   width: 100%;
   max-width: 100%;
-  outline: 0 solid transparent;
-  outline-offset: css.get("focus-ring-offset");
   border-style: solid;
   font-family: inherit;
   appearance: none;

--- a/packages/input/src/_variables.scss
+++ b/packages/input/src/_variables.scss
@@ -18,9 +18,13 @@ $border-color: css.get("border-color-dark") !default;
 $border-color-hover: css.get("border-color-darker") !default;
 $border-color-focus: $accent !default;
 
-$box-shadow: 0 0 0 0 hsl(from $accent h s l / 0%), inset 0 0.1rem 0.2rem rgb(0 0 0 / 10%) !default;
+$box-shadow: inset 0 0.1rem 0.2rem rgb(0 0 0 / 10%) !default;
 $box-shadow-hover: $box-shadow !default;
-$box-shadow-focus: 0 0 0 3px hsl(from $accent h s l / 40%), inset 0 0.1rem 0.2rem rgb(0 0 0 / 10%) !default;
+$box-shadow-focus: none !default;
+
+$focus-ring-opacity: css.get("input", "focus-ring-opacity", css.get("focus-ring-opacity")) !default;
+$focus-ring-color: css.get("input", "focus-ring-color", css.get("core", "focus-ring-color", hsl(from $accent h s l / $focus-ring-opacity))) !default;
+$focus-ring: css.get("focus-ring-width") css.get("focus-ring-style") $focus-ring-color !default;
 
 // State: placeholder
 $foreground-placeholder: null !default;

--- a/packages/input/src/_variables.scss
+++ b/packages/input/src/_variables.scss
@@ -22,10 +22,6 @@ $box-shadow: inset 0 0.1rem 0.2rem rgb(0 0 0 / 10%) !default;
 $box-shadow-hover: $box-shadow !default;
 $box-shadow-focus: none !default;
 
-$focus-ring-opacity: css.get("input", "focus-ring-opacity", css.get("focus-ring-opacity")) !default;
-$focus-ring-color: css.get("input", "focus-ring-color", css.get("core", "focus-ring-color", hsl(from $accent h s l / $focus-ring-opacity))) !default;
-$focus-ring: css.get("focus-ring-width") css.get("focus-ring-style") $focus-ring-color !default;
-
 // State: placeholder
 $foreground-placeholder: null !default;
 

--- a/packages/menu/src/_menu.scss
+++ b/packages/menu/src/_menu.scss
@@ -45,11 +45,11 @@
   }
 
   &:focus-visible {
+    outline: var.$focus-ring;
     border-color: css.get("menu", "border-color-focus-visible", "border-color-focus", "border-color-hover", "border-color", var.$border-color-focus-visible);
     background-color: css.get("menu", "background-focus-visible", "background-focus", "background-hover", "background", var.$background-focus-visible);
     box-shadow: css.get("menu", "box-shadow-focus-visible", "box-shadow-focus", "box-shadow-hover", "box-shadow", var.$box-shadow-focus-visible);
     color: css.get("menu", "foreground-focus-visible", "foreground-focus", "foreground-hover", "foreground", var.$foreground-focus-visible);
-    outline: var.$focus-ring;
   }
 
   &:active {

--- a/packages/menu/src/_menu.scss
+++ b/packages/menu/src/_menu.scss
@@ -45,7 +45,7 @@
   }
 
   &:focus-visible {
-    outline: core.focus-ring-value("menu", var.$accent);
+    @include core.focus-ring-value("menu", var.$accent);
     border-color: css.get("menu", "border-color-focus-visible", "border-color-focus", "border-color-hover", "border-color", var.$border-color-focus-visible);
     background-color: css.get("menu", "background-focus-visible", "background-focus", "background-hover", "background", var.$background-focus-visible);
     box-shadow: css.get("menu", "box-shadow-focus-visible", "box-shadow-focus", "box-shadow-hover", "box-shadow", var.$box-shadow-focus-visible);

--- a/packages/menu/src/_menu.scss
+++ b/packages/menu/src/_menu.scss
@@ -29,7 +29,7 @@
   background-color: css.get("menu", "background", var.$background);
   box-shadow: css.get("menu", "box-shadow", var.$box-shadow);
   color: css.get("menu", "foreground", var.$foreground);
-  
+
   &:hover {
     border-color: css.get("menu", "border-color-hover", "border-color", var.$border-color-hover);
     background-color: css.get("menu", "background-hover", "background", var.$background-hover);
@@ -49,6 +49,7 @@
     background-color: css.get("menu", "background-focus-visible", "background-focus", "background-hover", "background", var.$background-focus-visible);
     box-shadow: css.get("menu", "box-shadow-focus-visible", "box-shadow-focus", "box-shadow-hover", "box-shadow", var.$box-shadow-focus-visible);
     color: css.get("menu", "foreground-focus-visible", "foreground-focus", "foreground-hover", "foreground", var.$foreground-focus-visible);
+    outline: var.$focus-ring;
   }
 
   &:active {

--- a/packages/menu/src/_menu.scss
+++ b/packages/menu/src/_menu.scss
@@ -45,7 +45,7 @@
   }
 
   &:focus-visible {
-    @include core.focus-ring-value("menu", var.$accent);
+    @include core.focus-ring("menu", var.$accent);
     border-color: css.get("menu", "border-color-focus-visible", "border-color-focus", "border-color-hover", "border-color", var.$border-color-focus-visible);
     background-color: css.get("menu", "background-focus-visible", "background-focus", "background-hover", "background", var.$background-focus-visible);
     box-shadow: css.get("menu", "box-shadow-focus-visible", "box-shadow-focus", "box-shadow-hover", "box-shadow", var.$box-shadow-focus-visible);

--- a/packages/menu/src/_menu.scss
+++ b/packages/menu/src/_menu.scss
@@ -45,7 +45,7 @@
   }
 
   &:focus-visible {
-    outline: var.$focus-ring;
+    outline: core.focus-ring-value("menu", var.$accent);
     border-color: css.get("menu", "border-color-focus-visible", "border-color-focus", "border-color-hover", "border-color", var.$border-color-focus-visible);
     background-color: css.get("menu", "background-focus-visible", "background-focus", "background-hover", "background", var.$background-focus-visible);
     box-shadow: css.get("menu", "box-shadow-focus-visible", "box-shadow-focus", "box-shadow-hover", "box-shadow", var.$box-shadow-focus-visible);

--- a/packages/menu/src/_mixins.scss
+++ b/packages/menu/src/_mixins.scss
@@ -1,16 +1,16 @@
+@use "@vrembem/core";
 @use "@vrembem/core/css";
 @use "./variables" as var;
 
 /// Output the base styles for a menu action component element.
 @mixin menu-action-base() {
+  @include core.focus-ring-base();
   position: relative;
   display: flex;
   gap: css.get("menu", "action-gap", var.$action-gap);
   align-items: center;
   justify-content: flex-start;
   width: 100%;
-  outline: 0 solid transparent;
-  outline-offset: css.get("focus-ring-offset");
   border-style: solid;
   background-clip: border-box;
   font-family: inherit;

--- a/packages/menu/src/_mixins.scss
+++ b/packages/menu/src/_mixins.scss
@@ -9,7 +9,8 @@
   align-items: center;
   justify-content: flex-start;
   width: 100%;
-  outline: none;
+  outline: 0 solid transparent;
+  outline-offset: css.get("focus-ring-offset");
   border-style: solid;
   background-clip: border-box;
   font-family: inherit;

--- a/packages/menu/src/_variables.scss
+++ b/packages/menu/src/_variables.scss
@@ -26,11 +26,15 @@ $border-color-focus: $border-color !default;
 $border-color-focus-visible: $accent !default;
 $border-color-active: $border-color !default;
 
-$box-shadow: 0 0 0 0 hsl(from $accent h s l / 0%) !default;
+$box-shadow: none !default;
 $box-shadow-hover: $box-shadow !default;
 $box-shadow-focus: $box-shadow !default;
-$box-shadow-focus-visible: 0 0 0 3px hsl(from $accent h s l / 40%) !default;
+$box-shadow-focus-visible: $box-shadow !default;
 $box-shadow-active: $box-shadow !default;
+
+$focus-ring-opacity: css.get("menu", "focus-ring-opacity", css.get("focus-ring-opacity")) !default;
+$focus-ring-color: css.get("menu", "focus-ring-color", css.get("core", "focus-ring-color", hsl(from $accent h s l / $focus-ring-opacity))) !default;
+$focus-ring: css.get("focus-ring-width") css.get("focus-ring-style") $focus-ring-color !default;
 
 // Element modifier: menu__action_icon
 $icon-padding: css.get("form-control-padding-y");

--- a/packages/menu/src/_variables.scss
+++ b/packages/menu/src/_variables.scss
@@ -32,10 +32,6 @@ $box-shadow-focus: $box-shadow !default;
 $box-shadow-focus-visible: $box-shadow !default;
 $box-shadow-active: $box-shadow !default;
 
-$focus-ring-opacity: css.get("menu", "focus-ring-opacity", css.get("focus-ring-opacity")) !default;
-$focus-ring-color: css.get("menu", "focus-ring-color", css.get("core", "focus-ring-color", hsl(from $accent h s l / $focus-ring-opacity))) !default;
-$focus-ring: css.get("focus-ring-width") css.get("focus-ring-style") $focus-ring-color !default;
-
 // Element modifier: menu__action_icon
 $icon-padding: css.get("form-control-padding-y");
 


### PR DESCRIPTION
## What changed?

This PR adds new focus-ring variables along with a supporting library module. These are applied to button, input and menu action form-controls which replaces the previously used box-shadow styles.

**New mixins**
- `focus-ring-base()` - Apply the base styles for focus-ring using the outline properties.
- `focus-ring()` - Builds the focus ring styles by applying a number of custom property values and optional component overrides using the outline property.