### PR TITLE
Refactor popover and add custom properties support

### DIFF
--- a/docs/src/content/packages/popover.mdx
+++ b/docs/src/content/packages/popover.mdx
@@ -243,9 +243,21 @@ Applies styles to create a popover tooltip. The default placement of a tooltip i
 
 <CodeExample>
   <Fragment slot="output">
-    <button type="button" class="link" aria-describedby="popover-tooltip">HTML</button>
-    <div id="popover-tooltip" class="popover popover_tooltip" role="tooltip">
+    <div class="flex">
+      <button type="button" class="link" aria-describedby="popover-tooltip-1">HTML</button>
+      <button type="button" class="link" aria-describedby="popover-tooltip-2">CSS</button>
+      <button type="button" class="link" aria-describedby="popover-tooltip-3">JS</button>
+    </div>
+    <div id="popover-tooltip-1" class="popover popover_tooltip" role="tooltip">
       Hypertext Markup Language
+      <span class="popover__arrow"></span>
+    </div>
+    <div id="popover-tooltip-2" class="popover popover_tooltip" role="tooltip">
+      Cascading Style Sheets
+      <span class="popover__arrow"></span>
+    </div>
+    <div id="popover-tooltip-3" class="popover popover_tooltip" role="tooltip">
+      JavaScript
       <span class="popover__arrow"></span>
     </div>
   </Fragment>

--- a/docs/src/content/packages/popover.mdx
+++ b/docs/src/content/packages/popover.mdx
@@ -243,7 +243,7 @@ Applies styles to create a popover tooltip. The default placement of a tooltip i
 
 <CodeExample>
   <Fragment slot="output">
-    <span class="link" aria-describedby="popover-tooltip">HTML</span>
+    <button type="button" class="link" aria-describedby="popover-tooltip">HTML</button>
     <div id="popover-tooltip" class="popover popover_tooltip" role="tooltip">
       Hypertext Markup Language
       <span class="popover__arrow"></span>

--- a/packages/popover/index.html
+++ b/packages/popover/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Vrembem / Package: %VITE_PACKAGE%</title>
+  <title>Vrembem Demo: %VITE_PACKAGE%</title>
   <link rel="icon" type="image/png" href="https://sebnitu.com/icons/vb-favicon.png">
   <link rel="icon" type="image/svg+xml" href="https://sebnitu.com/icons/vb-favicon.svg">
   <link rel="stylesheet" href="./index.scss">
@@ -31,7 +31,7 @@
       <ol class="foreground-lighter flex flex_gap flex_gap-y_sm margin-top-lg list-style-none">
         <li class="flex flex_gap_sm align-items-center">
           <svg class="icon icon_size_sm" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path></svg>
-          <a class="link" target="_blank" href="https://github.com/sebnitu/vrembem">vrembem</a>
+          <a class="link" target="_blank" href="https://github.com/sebnitu/vrembem">repo</a>
         </li>
         <li class="foreground-neutral-80">/</li>
         <li class="flex flex_gap_sm align-items-center">
@@ -46,24 +46,24 @@
     <div class="section__container max-width-xs spacing text-align-center">
 
       <div class="flex justify-content-center">
-        <button class="button" aria-controls="popover-left">Popover</button>
-        <button class="button" aria-controls="popover-top">Popover</button>
-        <button class="button" aria-controls="popover-bottom">Popover</button>
-        <button class="button" aria-controls="popover-right">Popover</button>
+        <button class="button" aria-describedby="popover-left">Left</button>
+        <button class="button" aria-describedby="popover-top">Top</button>
+        <button class="button" aria-describedby="popover-bottom">Bottom</button>
+        <button class="button" aria-describedby="popover-right">Right</button>
       </div>
 
       <div>
         <div id="popover-left" class="popover popover_size_auto popover_tooltip" style="--vb-popover-placement: left;">
-          Pop
+          Tooltip
         </div>
         <div id="popover-top" class="popover popover_size_auto popover_tooltip" style="--vb-popover-placement: top;">
-          Pop
+          Tooltip
         </div>
         <div id="popover-bottom" class="popover popover_size_auto popover_tooltip" style="--vb-popover-placement: bottom;">
-          Pop
+          Tooltip
         </div>
         <div id="popover-right" class="popover popover_size_auto popover_tooltip" style="--vb-popover-placement: right;">
-          Pop
+          Tooltip
         </div>
       </div>
 

--- a/packages/popover/index.html
+++ b/packages/popover/index.html
@@ -3,80 +3,72 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>@vrembem/popover</title>
-  <link rel="icon" type="image/png" sizes="32x32" href="https://sebnitu.com/dist/favicon.png">
-</head>
-<body>
-  <main>
-    <header class="section background-dark">
-      <div class="section__container max-width-xs spacing">
-        <h1>@vrembem/popover</h1>
-        <p>A component that is initially hidden and revealed upon user interaction either through a click or hover event. Popover can contain lists of actions, links, or additional supplementary content.</p>
-        <div class="flex align-items-center foreground-lighter">
-          <div class="flex flex_gap_sm align-items-center">
-            <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
-            </svg>
-            <a class="link" href="https://github.com/sebnitu/vrembem">
-              <span>vrembem</span>
-            </a>
-          </div>
-          <span>/</span>
-          <div class="flex flex_gap_sm align-items-center">
-            <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line>
-            </svg>
-            <a class="link" href="https://github.com/sebnitu/vrembem/tree/main/packages/popover#readme">
-              <span>popover</span>
-            </a>
-          </div>
-        </div>
-      </div>
-    </header>
-
-    <section class="section">
-      <div class="section__container max-width-xs spacing text-align-center">
-
-        <div class="flex justify-content-center">
-          <button class="button" aria-controls="popover-left">Popover</button>
-          <button class="button" aria-controls="popover-top">Popover</button>
-          <button class="button" aria-controls="popover-bottom">Popover</button>
-          <button class="button" aria-controls="popover-right">Popover</button>
-        </div>
-
-        <div>
-          <div id="popover-left" class="popover popover_size_auto popover_tooltip" style="--vb-popover-placement: left;">
-            Pop
-          </div>
-          <div id="popover-top" class="popover popover_size_auto popover_tooltip" style="--vb-popover-placement: top;">
-            Pop
-          </div>
-          <div id="popover-bottom" class="popover popover_size_auto popover_tooltip" style="--vb-popover-placement: bottom;">
-            Pop
-          </div>
-          <div id="popover-right" class="popover popover_size_auto popover_tooltip" style="--vb-popover-placement: right;">
-            Pop
-          </div>
-        </div>
-
-      </div>
-    </section>
-  </main>
-
+  <title>Vrembem / Package: %VITE_PACKAGE%</title>
+  <link rel="icon" type="image/png" href="https://sebnitu.com/icons/vb-favicon.png">
+  <link rel="icon" type="image/svg+xml" href="https://sebnitu.com/icons/vb-favicon.svg">
+  <link rel="stylesheet" href="./index.scss">
   <script type="module">
     // Load CSS
-    import 'vrembem/scss';
+    import "vrembem/dist/index.css";
 
     // Load JS
-    import Popover from './index.js';
+    import Popover from "./index.js";
 
     // Init and attach instance to window
     const popover = new Popover();
     window.popover = await popover.mount();
 
     // Post message to console
-    console.log('Popover instance has been attached to window:', popover);
+    console.log("Popover instance has been attached to window:", popover);
   </script>
+</head>
+<body>
+
+  <header class="section background-dark">
+    <div class="section__container max-width-xs spacing-sm">
+      <h1 class="text-size-lg">Vrembem</h1>
+      <p class="foreground-light">A component library based on the BEM methodology.</p>
+      <ol class="foreground-lighter flex flex_gap flex_gap-y_sm margin-top-lg list-style-none">
+        <li class="flex flex_gap_sm align-items-center">
+          <svg class="icon icon_size_sm" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path></svg>
+          <a class="link" target="_blank" href="https://github.com/sebnitu/sandbox">sandbox</a>
+        </li>
+        <li class="foreground-neutral-80">/</li>
+        <li class="flex flex_gap_sm align-items-center">
+          <svg class="icon icon_size_sm" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
+          <a class="link" target="_blank" href="https://github.com/sebnitu/vrembem/tree/main/packages/%VITE_PACKAGE%#readme">%VITE_PACKAGE%</a>
+        </li>
+      </ol>
+    </div>
+  </header>
+
+  <section class="section">
+    <div class="section__container max-width-xs spacing text-align-center">
+
+      <div class="flex justify-content-center">
+        <button class="button" aria-controls="popover-left">Popover</button>
+        <button class="button" aria-controls="popover-top">Popover</button>
+        <button class="button" aria-controls="popover-bottom">Popover</button>
+        <button class="button" aria-controls="popover-right">Popover</button>
+      </div>
+
+      <div>
+        <div id="popover-left" class="popover popover_size_auto popover_tooltip" style="--vb-popover-placement: left;">
+          Pop
+        </div>
+        <div id="popover-top" class="popover popover_size_auto popover_tooltip" style="--vb-popover-placement: top;">
+          Pop
+        </div>
+        <div id="popover-bottom" class="popover popover_size_auto popover_tooltip" style="--vb-popover-placement: bottom;">
+          Pop
+        </div>
+        <div id="popover-right" class="popover popover_size_auto popover_tooltip" style="--vb-popover-placement: right;">
+          Pop
+        </div>
+      </div>
+
+    </div>
+  </section>
 
 </body>
 </html>

--- a/packages/popover/index.html
+++ b/packages/popover/index.html
@@ -31,7 +31,7 @@
       <ol class="foreground-lighter flex flex_gap flex_gap-y_sm margin-top-lg list-style-none">
         <li class="flex flex_gap_sm align-items-center">
           <svg class="icon icon_size_sm" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path></svg>
-          <a class="link" target="_blank" href="https://github.com/sebnitu/sandbox">sandbox</a>
+          <a class="link" target="_blank" href="https://github.com/sebnitu/vrembem">vrembem</a>
         </li>
         <li class="foreground-neutral-80">/</li>
         <li class="flex flex_gap_sm align-items-center">

--- a/packages/popover/src/js/close.js
+++ b/packages/popover/src/js/close.js
@@ -1,4 +1,4 @@
-import { getPopover } from "./helpers";
+import { getPopover, getModifiers } from "./helpers";
 
 export async function close(query) {
   // Get the popover from collection.
@@ -17,7 +17,11 @@ export async function close(query) {
 
     // Disable popper event listeners.
     popover.popper.setOptions({
-      modifiers: [{ name: "eventListeners", enabled: false }]
+      placement: popover.config["placement"],
+      modifiers: [
+        { name: "eventListeners", enabled: false },
+        ...getModifiers(popover.config)
+      ]
     });
 
     // Update popover state.

--- a/packages/popover/src/js/defaults.js
+++ b/packages/popover/src/js/defaults.js
@@ -11,5 +11,6 @@ export default {
   // Feature settings
   eventListeners: true,
   eventType: "click",
-  placement: "bottom"
+  placement: "bottom",
+  hoverToggleDelay: 0
 };

--- a/packages/popover/src/js/handlers.js
+++ b/packages/popover/src/js/handlers.js
@@ -10,6 +10,36 @@ export function handleClick(popover) {
   }
 }
 
+export function handleMouseEnter(popover) {
+  // Clear any existing toggle delays.
+  if (popover.toggleDelayId) {
+    clearTimeout(popover.toggleDelayId);
+  }
+
+  // Remove the open/close delay if a tooltip popover is already active.
+  const delay = (this.activeTooltip) ? 0 : popover.config["toggle-delay"];
+
+  // Close any active tooltip popovers.
+  if (this.activeTooltip) { this.activeTooltip.close(); }
+
+  // Set the toggle delay before opening the popover.
+  popover.toggleDelayId = setTimeout(() => {
+    popover.open();
+  }, delay);
+}
+
+export function handleMouseLeave(popover) {
+  // Clear any existing toggle delays.
+  if (popover.toggleDelayId) {
+    clearTimeout(popover.toggleDelayId);
+  }
+
+  // Set the toggle delay before closing the popover.
+  popover.toggleDelayId = setTimeout(() => {
+    closeCheck.call(this, popover);
+  }, popover.config["toggle-delay"]);
+}
+
 export function handleKeydown(event) {
   switch (event.key) {
     case "Escape":

--- a/packages/popover/src/js/handlers.js
+++ b/packages/popover/src/js/handlers.js
@@ -20,7 +20,7 @@ export function handleMouseEnter(popover) {
   const delay = (this.activeTooltip) ? 0 : popover.config["toggle-delay"];
 
   // Close any active tooltip popovers.
-  if (this.activeTooltip) { this.activeTooltip.close(); }
+  if (this.activeTooltip) this.activeTooltip.close();
 
   // Set the toggle delay before opening the popover.
   popover.toggleDelayId = setTimeout(() => {

--- a/packages/popover/src/js/helpers/getConfig.js
+++ b/packages/popover/src/js/helpers/getConfig.js
@@ -12,7 +12,8 @@ export function getConfig(el, settings) {
     "overflow-padding": 0,
     "flip-padding": 0,
     "arrow-element": settings.selectorArrow,
-    "arrow-padding": 0
+    "arrow-padding": 0,
+    "toggle-delay": settings.hoverToggleDelay,
   };
 
   // Loop through config obj.

--- a/packages/popover/src/js/index.js
+++ b/packages/popover/src/js/index.js
@@ -20,6 +20,14 @@ export default class Popover extends Collection {
     if (this.settings.autoMount) this.mount();
   }
 
+  get active() {
+    return this.collection.find((popover) => popover.state == "opened");
+  }
+
+  get activeTooltip() {
+    return this.collection.find((popover) => popover.state == "opened" && popover.isTooltip);
+  }
+
   async mount(options) {
     // Update settings with passed options.
     if (options) this.settings = { ...this.settings, ...options };

--- a/packages/popover/src/js/register.js
+++ b/packages/popover/src/js/register.js
@@ -49,6 +49,11 @@ export async function register(el, trigger) {
     handleDocumentClick.call(this, entry);
   }
 
+  // Set the popper placement property.
+  entry.popper.setOptions({
+    placement: entry.config["placement"]
+  });
+
   // Return the registered entry.
   return entry;
 }

--- a/packages/popover/src/js/register.js
+++ b/packages/popover/src/js/register.js
@@ -1,9 +1,9 @@
 import { createPopper } from "@popperjs/core/dist/esm";
 
-import { handleClick, handleDocumentClick } from "./handlers";
+import { handleClick, handleMouseEnter, handleMouseLeave, handleDocumentClick } from "./handlers";
 import { deregister } from "./deregister";
 import { open } from "./open";
-import { close, closeCheck } from "./close";
+import { close } from "./close";
 import { getConfig } from "./helpers";
 
 export async function register(el, trigger) {
@@ -19,8 +19,12 @@ export async function register(el, trigger) {
     state: "closed",
     el: el,
     trigger: trigger,
+    toggleDelayId: null,
     popper: createPopper(trigger, el),
     config: getConfig(el, this.settings),
+    get isTooltip() {
+      return trigger.hasAttribute("aria-describedby");
+    },
     open() {
       return open.call(root, this);
     },
@@ -70,11 +74,11 @@ export function registerEventListeners(entry) {
       entry.__eventListeners = [{
         el: ["trigger"],
         type: ["mouseenter", "focus"],
-        listener: open.bind(this, entry)
+        listener: handleMouseEnter.bind(this, entry)
       }, {
         el: ["el", "trigger"],
         type: ["mouseleave", "focusout"],
-        listener: closeCheck.bind(this, entry)
+        listener: handleMouseLeave.bind(this, entry)
       }];
 
       // Loop through listeners and apply to the appropriate elements.

--- a/packages/popover/src/scss/_popover.scss
+++ b/packages/popover/src/scss/_popover.scss
@@ -2,11 +2,9 @@
 @use "@vrembem/core/css";
 @use "./variables" as var;
 
-$_v: var.$prefix-variable;
-$_b: var.$prefix-block;
-$_offset: calc(calc(var(--#{$_v}popover-offset) + 1) * 1px);
+$_offset: calc(calc(css.get("popover", "offset") + 1) * 1px);
 
-.#{$_b}popover {
+#{core.bem("popover")} {
   position: absolute;
   z-index: var.$z-index;
   top: 100%;
@@ -14,7 +12,7 @@ $_offset: calc(calc(var(--#{$_v}popover-offset) + 1) * 1px);
   display: block;
   width: var.$width;
   max-width: var.$max-width;
-  margin: calc(var(--#{$_v}popover-offset) * 1px) 0 0;
+  margin: calc(css.get("popover", "offset") * 1px) 0 0;
   padding: var.$padding;
   border: var.$border;
   border-radius: var.$border-radius;
@@ -52,8 +50,8 @@ $_offset: calc(calc(var(--#{$_v}popover-offset) + 1) * 1px);
   }
 }
 
-.#{$_b}popover[data-popper-placement^="top"] {
-  margin: 0 0 calc(var(--#{$_v}popover-offset) * 1px) 0;
+#{core.bem("popover")}[data-popper-placement^="top"] {
+  margin: 0 0 calc(css.get("popover", "offset") * 1px) 0;
 
   &::before {
     inset: 100% 0 auto;
@@ -62,8 +60,8 @@ $_offset: calc(calc(var(--#{$_v}popover-offset) + 1) * 1px);
   }
 }
 
-.#{$_b}popover[data-popper-placement^="bottom"] {
-  margin: calc(var(--#{$_v}popover-offset) * 1px) 0 0 0;
+#{core.bem("popover")}[data-popper-placement^="bottom"] {
+  margin: calc(css.get("popover", "offset") * 1px) 0 0 0;
 
   &::before {
     inset: auto 0 100%;
@@ -72,8 +70,8 @@ $_offset: calc(calc(var(--#{$_v}popover-offset) + 1) * 1px);
   }
 }
 
-.#{$_b}popover[data-popper-placement^="left"] {
-  margin: 0 calc(var(--#{$_v}popover-offset) * 1px) 0 0;
+#{core.bem("popover")}[data-popper-placement^="left"] {
+  margin: 0 calc(css.get("popover", "offset") * 1px) 0 0;
 
   &::before {
     inset: 0 auto 0 100%;
@@ -82,8 +80,8 @@ $_offset: calc(calc(var(--#{$_v}popover-offset) + 1) * 1px);
   }
 }
 
-.#{$_b}popover[data-popper-placement^="right"] {
-  margin: 0 0 0 calc(var(--#{$_v}popover-offset) * 1px);
+#{core.bem("popover")}[data-popper-placement^="right"] {
+  margin: 0 0 0 calc(css.get("popover", "offset") * 1px);
 
   &::before {
     inset: 0 100% 0 auto;

--- a/packages/popover/src/scss/_popover.scss
+++ b/packages/popover/src/scss/_popover.scss
@@ -18,19 +18,19 @@ $_offset: calc(calc(css.get("popover", "offset") + 1) * 1px);
   max-width: css.get("popover", "max-width", var.$max-width);
   margin: calc(css.get("popover", "offset") * 1px) 0 0;
   padding: css.get("popover", "padding", var.$padding);
+  transition-property: css.get("popover", "transition-property", var.$transition-property);
+  transition-duration: css.get("popover", "transition-duration", var.$transition-duration);
+  transition-timing-function: css.get("popover", "transition-timing-function", var.$transition-timing-function);
   border: css.get("popover", "border", var.$border);
   border-radius: css.get("popover", "border-radius", var.$border-radius);
   background: css.get("popover", "background", var.$background);
   background-clip: padding-box;
   box-shadow: css.get("popover", "box-shadow", var.$box-shadow);
+  opacity: 0;
   color: css.get("popover", "foreground", var.$foreground);
   font-size: css.get("popover", "font-size", var.$font-size);
   line-height: css.get("popover", "line-height", var.$line-height);
-  opacity: 0;
   pointer-events: none;
-  transition-property: css.get("popover", "transition-property", var.$transition-property);
-  transition-duration: css.get("popover", "transition-duration", var.$transition-duration);
-  transition-timing-function: css.get("popover", "transition-timing-function", var.$transition-timing-function);
 
   &::before {
     content: "";

--- a/packages/popover/src/scss/_popover.scss
+++ b/packages/popover/src/scss/_popover.scss
@@ -26,7 +26,7 @@ $_offset: calc(calc(var(--#{$_v}popover-offset) + 1) * 1px);
   line-height: var.$line-height;
   opacity: 0;
   pointer-events: none;
-  transition-property: opacity; // Adding tranform transition causes too many issues with popper.
+  transition-property: opacity; // Adding transform transition causes too many issues with popper.
   transition-duration: css.get("transition-duration-short");
   transition-timing-function: css.get("transition-timing-function");
 

--- a/packages/popover/src/scss/_popover.scss
+++ b/packages/popover/src/scss/_popover.scss
@@ -1,4 +1,5 @@
 @use "@vrembem/core";
+@use "@vrembem/core/css";
 @use "./variables" as var;
 
 $_v: var.$prefix-variable;
@@ -10,7 +11,7 @@ $_offset: calc(calc(var(--#{$_v}popover-offset) + 1) * 1px);
   z-index: var.$z-index;
   top: 100%;
   left: 0;
-  display: none;
+  display: block;
   width: var.$width;
   max-width: var.$max-width;
   margin: calc(var(--#{$_v}popover-offset) * 1px) 0 0;
@@ -23,6 +24,11 @@ $_offset: calc(calc(var(--#{$_v}popover-offset) + 1) * 1px);
   color: var.$foreground;
   font-size: var.$font-size;
   line-height: var.$line-height;
+  opacity: 0;
+  pointer-events: none;
+  transition-property: opacity, transform;
+  transition-duration: css.get("transition-duration");
+  transition-timing-function: css.get("transition-timing-function");
 
   &::before {
     content: "";
@@ -34,7 +40,8 @@ $_offset: calc(calc(var(--#{$_v}popover-offset) + 1) * 1px);
 
   &.is-active {
     z-index: (var.$z-index + 1);
-    display: block;
+    opacity: 1;
+    pointer-events: auto;
   }
 
   &:hover,

--- a/packages/popover/src/scss/_popover.scss
+++ b/packages/popover/src/scss/_popover.scss
@@ -26,8 +26,8 @@ $_offset: calc(calc(var(--#{$_v}popover-offset) + 1) * 1px);
   line-height: var.$line-height;
   opacity: 0;
   pointer-events: none;
-  transition-property: opacity, transform;
-  transition-duration: css.get("transition-duration");
+  transition-property: opacity; // Adding tranform transition causes too many issues with popper.
+  transition-duration: css.get("transition-duration-short");
   transition-timing-function: css.get("transition-timing-function");
 
   &::before {

--- a/packages/popover/src/scss/_popover.scss
+++ b/packages/popover/src/scss/_popover.scss
@@ -26,6 +26,7 @@ $_offset: calc(calc(var(--#{$_v}popover-offset) + 1) * 1px);
   line-height: var.$line-height;
   opacity: 0;
   pointer-events: none;
+  // TODO: Move this into variables.
   transition-property: opacity; // Adding transform transition causes too many issues with popper.
   transition-duration: css.get("transition-duration-short");
   transition-timing-function: css.get("transition-timing-function");

--- a/packages/popover/src/scss/_popover.scss
+++ b/packages/popover/src/scss/_popover.scss
@@ -4,30 +4,33 @@
 
 $_offset: calc(calc(css.get("popover", "offset") + 1) * 1px);
 
+.transition-none {
+  transition: none !important;
+}
+
 #{core.bem("popover")} {
   position: absolute;
-  z-index: var.$z-index;
+  z-index: css.get("popover", "z-index", var.$z-index);
   top: 100%;
   left: 0;
   display: block;
-  width: var.$width;
-  max-width: var.$max-width;
+  width: css.get("popover", "width", var.$width);
+  max-width: css.get("popover", "max-width", var.$max-width);
   margin: calc(css.get("popover", "offset") * 1px) 0 0;
-  padding: var.$padding;
-  border: var.$border;
-  border-radius: var.$border-radius;
-  background: var.$background;
-  background-clip: var.$background-clip;
-  box-shadow: var.$shadow;
-  color: var.$foreground;
-  font-size: var.$font-size;
-  line-height: var.$line-height;
+  padding: css.get("popover", "padding", var.$padding);
+  border: css.get("popover", "border", var.$border);
+  border-radius: css.get("popover", "border-radius", var.$border-radius);
+  background: css.get("popover", "background", var.$background);
+  background-clip: padding-box;
+  box-shadow: css.get("popover", "box-shadow", var.$box-shadow);
+  color: css.get("popover", "foreground", var.$foreground);
+  font-size: css.get("popover", "font-size", var.$font-size);
+  line-height: css.get("popover", "line-height", var.$line-height);
   opacity: 0;
   pointer-events: none;
-  // TODO: Move this into variables.
-  transition-property: opacity; // Adding transform transition causes too many issues with popper.
-  transition-duration: css.get("transition-duration-short");
-  transition-timing-function: css.get("transition-timing-function");
+  transition-property: css.get("popover", "transition-property", var.$transition-property);
+  transition-duration: css.get("popover", "transition-duration", var.$transition-duration);
+  transition-timing-function: css.get("popover", "transition-timing-function", var.$transition-timing-function);
 
   &::before {
     content: "";
@@ -38,7 +41,7 @@ $_offset: calc(calc(css.get("popover", "offset") + 1) * 1px);
   }
 
   &.is-active {
-    z-index: (var.$z-index + 1);
+    z-index: calc(css.get("popover", "z-index", var.$z-index) + 1);
     opacity: 1;
     pointer-events: auto;
   }
@@ -46,7 +49,7 @@ $_offset: calc(calc(css.get("popover", "offset") + 1) * 1px);
   &:hover,
   &:focus,
   &:focus-within {
-    z-index: (var.$z-index + 2);
+    z-index: calc(css.get("popover", "z-index", var.$z-index) + 2);
   }
 }
 

--- a/packages/popover/src/scss/_popover__arrow.scss
+++ b/packages/popover/src/scss/_popover__arrow.scss
@@ -1,52 +1,49 @@
 @use "@vrembem/core";
+@use "@vrembem/core/css";
 @use "./variables" as var;
 
-$_v: var.$prefix-variable;
-$_b: var.$prefix-block;
-$_e: var.$prefix-element;
-
-.#{$_b}popover#{$_e}arrow,
-.#{$_b}popover#{$_e}arrow::after {
-  @include core.size(var(--#{$_v}popover-arrow-size, var.$arrow-size));
+#{core.bem("popover", "arrow")},
+#{core.bem("popover", "arrow")}::after {
+  @include core.size(css.get("popover", "arrow-size", var.$arrow-size));
   position: absolute;
   z-index: -1;
   visibility: hidden;
   background-color: inherit;
 }
 
-.#{$_b}popover#{$_e}arrow::after {
+#{core.bem("popover", "arrow")}::after {
   content: "";
   visibility: visible;
   transform: rotate(45deg);
   background-clip: padding-box;
 }
 
-[data-popper-placement^="top"] > .#{$_b}popover#{$_e}arrow {
-  bottom: calc(var(--#{$_v}popover-arrow-size, var.$arrow-size) * -0.5);
+[data-popper-placement^="top"] > #{core.bem("popover", "arrow")} {
+  bottom: calc(css.get("popover", "arrow-size", var.$arrow-size) * -0.5);
 
   &::after {
     transform: rotate(-135deg);
   }
 }
 
-[data-popper-placement^="bottom"] > .#{$_b}popover#{$_e}arrow {
-  top: calc(var(--#{$_v}popover-arrow-size, var.$arrow-size) * -0.5);
+[data-popper-placement^="bottom"] > #{core.bem("popover", "arrow")} {
+  top: calc(css.get("popover", "arrow-size", var.$arrow-size) * -0.5);
 
   &::after {
     transform: rotate(45deg);
   }
 }
 
-[data-popper-placement^="left"] > .#{$_b}popover#{$_e}arrow {
-  right: calc(var(--#{$_v}popover-arrow-size, var.$arrow-size) * -0.5);
+[data-popper-placement^="left"] > #{core.bem("popover", "arrow")} {
+  right: calc(css.get("popover", "arrow-size", var.$arrow-size) * -0.5);
 
   &::after {
     transform: rotate(135deg);
   }
 }
 
-[data-popper-placement^="right"] > .#{$_b}popover#{$_e}arrow {
-  left: calc(var(--#{$_v}popover-arrow-size, var.$arrow-size) * -0.5);
+[data-popper-placement^="right"] > #{core.bem("popover", "arrow")} {
+  left: calc(css.get("popover", "arrow-size", var.$arrow-size) * -0.5);
 
   &::after {
     transform: rotate(-45deg);

--- a/packages/popover/src/scss/_popover__arrow.scss
+++ b/packages/popover/src/scss/_popover__arrow.scss
@@ -18,9 +18,6 @@ $_e: var.$prefix-element;
   content: "";
   visibility: visible;
   transform: rotate(45deg);
-  border: var(--#{$_v}popover-arrow-border, var.$arrow-border);
-  border-right-color: transparent;
-  border-bottom-color: transparent;
   background-clip: padding-box;
 }
 

--- a/packages/popover/src/scss/_popover_size.scss
+++ b/packages/popover/src/scss/_popover_size.scss
@@ -1,14 +1,15 @@
 @use "@vrembem/core";
+@use "@vrembem/core/css";
 @use "./variables" as var;
 
 #{core.bem("popover", null, "size", "auto")} {
-  width: auto;
+  @include css.override("popover", "width", auto);
 }
 
 #{core.bem("popover", null, "size", "sm")} {
-  width: var.$size-sm-width;
+  @include css.override("popover", "width", var.$size-sm-width);
 }
 
 #{core.bem("popover", null, "size", "lg")} {
-  width: var.$size-lg-width;
+  @include css.override("popover", "width", var.$size-lg-width);
 }

--- a/packages/popover/src/scss/_popover_size.scss
+++ b/packages/popover/src/scss/_popover_size.scss
@@ -1,18 +1,14 @@
+@use "@vrembem/core";
 @use "./variables" as var;
 
-$_b: var.$prefix-block;
-$_e: var.$prefix-element;
-$_m: var.$prefix-modifier;
-$_v: var.$prefix-modifier-value;
-
-.#{$_b}popover#{$_m}size#{$_v}auto {
+#{core.bem("popover", null, "size", "auto")} {
   width: auto;
 }
 
-.#{$_b}popover#{$_m}size#{$_v}sm {
+#{core.bem("popover", null, "size", "sm")} {
   width: var.$size-sm-width;
 }
 
-.#{$_b}popover#{$_m}size#{$_v}lg {
+#{core.bem("popover", null, "size", "lg")} {
   width: var.$size-lg-width;
 }

--- a/packages/popover/src/scss/_popover_tooltip.scss
+++ b/packages/popover/src/scss/_popover_tooltip.scss
@@ -10,7 +10,6 @@ $_m: var.$prefix-modifier;
   --#{$_v}popover-event: hover;
   --#{$_v}popover-placement: top;
   --#{$_v}popover-arrow-size: 8px;
-  --#{$_v}popover-arrow-border: none;
   --#{$_v}popover-toggle-delay: 300;
   width: auto;
   max-width: 16rem;

--- a/packages/popover/src/scss/_popover_tooltip.scss
+++ b/packages/popover/src/scss/_popover_tooltip.scss
@@ -11,6 +11,7 @@ $_m: var.$prefix-modifier;
   --#{$_v}popover-placement: top;
   --#{$_v}popover-arrow-size: 8px;
   --#{$_v}popover-arrow-border: none;
+  --#{$_v}popover-toggle-delay: 300;
   width: auto;
   max-width: 16rem;
   padding: 0.5rem 0.75rem;

--- a/packages/popover/src/scss/_popover_tooltip.scss
+++ b/packages/popover/src/scss/_popover_tooltip.scss
@@ -6,13 +6,13 @@
     "event": "hover",
     "placement": "top",
     "arrow-size": 8px,
-    "toggle-delay": 300
+    "toggle-delay": 300,
+    "width": auto,
+    "max-width": 16rem,
+    "padding": 0.5rem 0.75rem,
+    "background": css.get("foreground"),
+    "foreground": css.get("background"),
   ));
-  width: auto;
-  max-width: 16rem;
-  padding: 0.5rem 0.75rem;
-  background: css.get("foreground");
-  color: css.get("background");
 
   &.is-active {
     pointer-events: none;

--- a/packages/popover/src/scss/_popover_tooltip.scss
+++ b/packages/popover/src/scss/_popover_tooltip.scss
@@ -16,4 +16,5 @@ $_m: var.$prefix-modifier;
   padding: 0.5rem 0.75rem;
   background: css.get("foreground");
   color: css.get("background");
+  pointer-events: none;
 }

--- a/packages/popover/src/scss/_popover_tooltip.scss
+++ b/packages/popover/src/scss/_popover_tooltip.scss
@@ -1,16 +1,13 @@
+@use "@vrembem/core";
 @use "@vrembem/core/css";
-@use "./variables" as var;
 
-$_v: var.$prefix-variable;
-$_b: var.$prefix-block;
-$_e: var.$prefix-element;
-$_m: var.$prefix-modifier;
-
-.#{$_b}popover#{$_m}tooltip {
-  --#{$_v}popover-event: hover;
-  --#{$_v}popover-placement: top;
-  --#{$_v}popover-arrow-size: 8px;
-  --#{$_v}popover-toggle-delay: 300;
+#{core.bem("popover", null, "tooltip")} {
+  @include css.override("popover", (
+    "event": "hover",
+    "placement": "top",
+    "arrow-size": 8px,
+    "toggle-delay": 300
+  ));
   width: auto;
   max-width: 16rem;
   padding: 0.5rem 0.75rem;

--- a/packages/popover/src/scss/_popover_tooltip.scss
+++ b/packages/popover/src/scss/_popover_tooltip.scss
@@ -16,5 +16,8 @@ $_m: var.$prefix-modifier;
   padding: 0.5rem 0.75rem;
   background: css.get("foreground");
   color: css.get("background");
-  pointer-events: none;
+
+  &.is-active {
+    pointer-events: none;
+  }
 }

--- a/packages/popover/src/scss/_variables.scss
+++ b/packages/popover/src/scss/_variables.scss
@@ -30,7 +30,6 @@ $size-sm-width: 12em !default;
 $size-lg-width: 20em !default;
 
 // Custom properties
-// TODO: Test that required custom props are working as expected.
 @include css.set("popover", (
   "event": $event,
   "placement": $placement,

--- a/packages/popover/src/scss/_variables.scss
+++ b/packages/popover/src/scss/_variables.scss
@@ -3,6 +3,7 @@
 @use "@vrembem/core/usage";
 @use "@vrembem/core/css";
 
+// TODO: Remove the use of prefix variables in favor of core.bem function.
 $prefix-variable: config.get("prefix-variables") !default;
 $prefix-block: config.get("prefix-blocks") !default;
 $prefix-element: config.get("prefix-elements") !default;
@@ -35,6 +36,7 @@ $size-sm-width: 12em !default;
 $size-lg-width: 20em !default;
 
 // Custom properties
+// TODO: Test that required custom props are working as expected.
 @include css.set("popover", (
   "event": $event,
   "placement": $placement,

--- a/packages/popover/src/scss/_variables.scss
+++ b/packages/popover/src/scss/_variables.scss
@@ -3,13 +3,6 @@
 @use "@vrembem/core/usage";
 @use "@vrembem/core/css";
 
-// TODO: Remove the use of prefix variables in favor of core.bem function.
-$prefix-variable: config.get("prefix-variables") !default;
-$prefix-block: config.get("prefix-blocks") !default;
-$prefix-element: config.get("prefix-elements") !default;
-$prefix-modifier: config.get("prefix-modifiers") !default;
-$prefix-modifier-value: config.get("prefix-modifier-values") !default;
-
 $event: null !default;
 $placement: null !default;
 $offset: 8 !default;

--- a/packages/popover/src/scss/_variables.scss
+++ b/packages/popover/src/scss/_variables.scss
@@ -1,5 +1,4 @@
 @use "@vrembem/core";
-@use "@vrembem/core/config";
 @use "@vrembem/core/usage";
 @use "@vrembem/core/css";
 
@@ -17,10 +16,12 @@ $border: null !default;
 $border-radius: core.$border-radius !default;
 $foreground: css.get("foreground") !default;
 $background: css.get("background") !default;
-$background-clip: padding-box !default;
-$shadow: css.get("box-shadow-2") !default;
+$box-shadow: css.get("box-shadow-2") !default;
 $font-size: core.$font-size-sm !default;
 $line-height: null !default;
+$transition-property: opacity !default;
+$transition-duration: css.get("transition-duration-short") !default;
+$transition-timing-function: css.get("transition-timing-function") !default;
 
 $arrow-size: 12px !default;
 $arrow-padding: 10 !default;

--- a/packages/popover/src/scss/_variables.scss
+++ b/packages/popover/src/scss/_variables.scss
@@ -30,7 +30,6 @@ $line-height: null !default;
 
 $arrow-size: 12px !default;
 $arrow-padding: 10 !default;
-$arrow-border: core.$border !default;
 
 $size-sm-width: 12em !default;
 $size-lg-width: 20em !default;

--- a/packages/popover/src/scss/_variables.scss
+++ b/packages/popover/src/scss/_variables.scss
@@ -1,5 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
+@use "@vrembem/core/usage";
 @use "@vrembem/core/css";
 
 $prefix-variable: config.get("prefix-variables") !default;
@@ -42,4 +43,7 @@ $size-lg-width: 20em !default;
   "overflow-padding": $overflow-padding,
   "flip-padding": $flip-padding,
   "arrow-padding": $arrow-padding
-));
+), "required");
+
+// Required custom properties for JavaScript.
+@include usage.set("core", "prefix", "required");

--- a/packages/popover/tests/api.test.js
+++ b/packages/popover/tests/api.test.js
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import Popover from "../index.js";
+import { expect } from "vitest";
 
 let popover;
 
@@ -12,6 +13,8 @@ const markup = `
   <div id="asdf" class="popover">...</div>
   <button aria-controls="fdsa">...</button>
   <div id="fdsa" class="popover">...</div>
+  <button aria-describedby="tooltip">...</button>
+  <div id="tooltip" class="popover popover_tooltip">...</div>
 `;
 
 afterEach(() => {
@@ -25,20 +28,20 @@ describe("mount() & unmount()", () => {
     document.body.innerHTML = markup;
     popover = new Popover();
     popover.mount();
-    expect(popover.collection.length).toBe(2);
+    expect(popover.collection.length).toBe(3);
   });
 
   it("should auto mount the popover module autoMount is set to true", () => {
     document.body.innerHTML = markup;
     popover = new Popover({ autoMount: true });
-    expect(popover.collection.length).toBe(2);
+    expect(popover.collection.length).toBe(3);
   });
 
   it("running mount multiple times should not create duplicates in collection", async () => {
     document.body.innerHTML = markup;
     popover = new Popover({ autoMount: true });
     await popover.mount();
-    expect(popover.collection.length).toBe(2);
+    expect(popover.collection.length).toBe(3);
   });
 
   it("should not attach keyboard event listener if eventListeners is set to false", () => {
@@ -72,7 +75,7 @@ describe("mount() & unmount()", () => {
     const trigger = document.querySelector("button");
     const target = document.querySelector(".popover");
 
-    expect(popover.collection.length).toBe(2);
+    expect(popover.collection.length).toBe(3);
     await popover.unmount();
     expect(popover.collection.length).toBe(0);
     trigger.click();
@@ -162,9 +165,9 @@ describe("register() & deregister()", () => {
     document.body.innerHTML = markup;
     popover = new Popover({ autoMount: true });
 
-    expect(popover.collection.length).toBe(2);
+    expect(popover.collection.length).toBe(3);
     popover.deregister(popover.collection[0]);
-    expect(popover.collection.length).toBe(1);
+    expect(popover.collection.length).toBe(2);
 
     const el = document.querySelector(".popover");
     const trigger = document.querySelector("button");
@@ -188,7 +191,7 @@ describe("registerCollection() & deregisterCollection()", () => {
     const trigger = document.querySelector("button");
     const target = document.querySelector(".popover");
 
-    expect(popover.collection.length).toBe(2);
+    expect(popover.collection.length).toBe(3);
     trigger.click();
     expect(target).toHaveClass("is-active");
 
@@ -214,7 +217,7 @@ describe("registerCollection() & deregisterCollection()", () => {
 
     popover.registerCollection(items);
 
-    expect(popover.collection.length).toBe(2);
+    expect(popover.collection.length).toBe(3);
     trigger.click();
     expect(target).toHaveClass("is-active");
   });
@@ -288,5 +291,23 @@ describe("open() & close()", () => {
       catchError = true;
     });
     expect(catchError).toBe(true);
+  });
+});
+
+describe("active() & activeTooltip()", () => {
+  it("should return the active popover when popover.active is called", () => {
+    document.body.innerHTML = markup;
+    popover = new Popover({ autoMount: true });
+    expect(popover.active).toBe(undefined);
+    popover.get("asdf").open();
+    expect(popover.active).toBe(popover.get("asdf"));
+  });
+
+  it("should return the active tooltip popover when popover.activeTooltip is called", () => {
+    document.body.innerHTML = markup;
+    popover = new Popover({ autoMount: true });
+    expect(popover.activeTooltip).toBe(undefined);
+    popover.get("tooltip").open();
+    expect(popover.activeTooltip).toBe(popover.get("tooltip"));
   });
 });

--- a/packages/popover/tests/collection.test.js
+++ b/packages/popover/tests/collection.test.js
@@ -10,6 +10,10 @@ const markup = `
     <div id="asdf" class="popover">
       ...
     </div>
+    <button id="tooltip-trigger" aria-describedby="tooltip">...</button>
+    <div id="tooltip" class="popover popover_tooltip">
+      ...
+    </div>
     <button id="fdsa-trigger" aria-controls="fdsa">...</button>
     <div id="fdsa" class="popover" style="--vb-popover-event: hover;">
       ...
@@ -113,5 +117,16 @@ describe("register() & entry.deregister()", () => {
     entry.trigger.click();
     expect(entry.el).toHaveClass("is-active");
     expect(entry.state).toBe("opened");
+  });
+});
+
+describe("entry.isTooltip", () => {
+  it("should return whether or not a popover is a tooltip", async () => {
+    document.body.innerHTML = markup;
+    popover = new Popover();
+    const entry1 = await popover.register("asdf");
+    const entry2 = await popover.register("tooltip");
+    expect(entry1.isTooltip).toBe(false);
+    expect(entry2.isTooltip).toBe(true);
   });
 });

--- a/packages/popover/tests/handlers.test.js
+++ b/packages/popover/tests/handlers.test.js
@@ -116,7 +116,7 @@ describe("handleMouseEnter() & handleMouseLeave()", () => {
     expect(entry.state).toBe("opened");
 
     handleMouseLeave.bind(popover, entry)();
-    await delay(5); // Not sure why this is needed.
+    await delay(100); // Not sure why this is needed.
     expect(entry.state).toBe("closed");
   });
 
@@ -140,7 +140,7 @@ describe("handleMouseEnter() & handleMouseLeave()", () => {
     expect(entry2.state).toBe("opened");
 
     handleMouseLeave.bind(popover, entry2)();
-    await delay(5);
+    await delay(100);
 
     expect(entry2.state).toBe("closed");
   });

--- a/packages/popover/tests/helpers.test.js
+++ b/packages/popover/tests/helpers.test.js
@@ -47,7 +47,8 @@ describe("getConfig()", () => {
       "overflow-padding": 0,
       "flip-padding": 0,
       "arrow-element": ".popover__arrow",
-      "arrow-padding": 0
+      "arrow-padding": 0,
+      "toggle-delay": 0
     });
   });
 
@@ -62,6 +63,7 @@ describe("getConfig()", () => {
     target.style.setProperty("--popover-flip-padding", "8");
     target.style.setProperty("--popover-arrow-element", ".asdf");
     target.style.setProperty("--popover-arrow-padding", "4");
+    target.style.setProperty("--popover-toggle-delay", "500");
     const config = getConfig(target, popover.settings);
     expect(config).toEqual({
       "placement": "top",
@@ -70,7 +72,8 @@ describe("getConfig()", () => {
       "overflow-padding": "16",
       "flip-padding": "8",
       "arrow-element": ".asdf",
-      "arrow-padding": "4"
+      "arrow-padding": "4",
+      "toggle-delay": "500"
     });
   });
 });

--- a/packages/popover/vite.config.js
+++ b/packages/popover/vite.config.js
@@ -10,5 +10,8 @@ export default defineConfig({
     },
     emptyOutDir: false,
     sourcemap: true
+  },
+  define: {
+    "import.meta.env.VITE_PACKAGE": JSON.stringify("popover"),
   }
 });

--- a/packages/vrembem/index.html
+++ b/packages/vrembem/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Vrembem / Package: %VITE_PACKAGE%</title>
+  <title>Vrembem Demo: %VITE_PACKAGE%</title>
   <link rel="icon" type="image/png" href="https://sebnitu.com/icons/vb-favicon.png">
   <link rel="icon" type="image/svg+xml" href="https://sebnitu.com/icons/vb-favicon.svg">
   <link rel="stylesheet" href="./index.scss">
@@ -53,7 +53,6 @@
     // Attach themeStore to window for testing purposes. 
     window["themeStore"] = themeStore;
     console.log("themeStore", themeStore);
-    
   </script>
 </head>
 <body>
@@ -65,7 +64,7 @@
       <ol class="foreground-lighter flex flex_gap flex_gap-y_sm margin-top-lg list-style-none">
         <li class="flex flex_gap_sm align-items-center">
           <svg class="icon icon_size_sm" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path></svg>
-          <a class="link" target="_blank" href="https://github.com/sebnitu/vrembem">vrembem</a>
+          <a class="link" target="_blank" href="https://github.com/sebnitu/vrembem">repo</a>
         </li>
         <li class="foreground-neutral-80">/</li>
         <li class="flex flex_gap_sm align-items-center">

--- a/packages/vrembem/index.html
+++ b/packages/vrembem/index.html
@@ -65,7 +65,7 @@
       <ol class="foreground-lighter flex flex_gap flex_gap-y_sm margin-top-lg list-style-none">
         <li class="flex flex_gap_sm align-items-center">
           <svg class="icon icon_size_sm" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path></svg>
-          <a class="link" target="_blank" href="https://github.com/sebnitu/sandbox">sandbox</a>
+          <a class="link" target="_blank" href="https://github.com/sebnitu/vrembem">vrembem</a>
         </li>
         <li class="foreground-neutral-80">/</li>
         <li class="flex flex_gap_sm align-items-center">

--- a/packages/vrembem/index.html
+++ b/packages/vrembem/index.html
@@ -276,5 +276,6 @@
 
     </div>
   </section>
+
 </body>
 </html>


### PR DESCRIPTION
## What changed?

This PR refactors the popover component to allow for custom properties support, popover transitions and some additional improvements to popover tooltips and hover event handling. These changes include:

- Add a delay between popover hover event close and delay before open of tooltip
- Popover tooltips should hide after the trigger is no longer hovered by using `pointer-events: none;` on the popover
- Add popover animated transition styles
- Make JS specific popover css variables required (similar to modal and drawer)
- Apply new BEM naming function to popover component and remove redundant variables
