### PR TITLE
Apply inert attribute on popovers when they're closed

### DIFF
--- a/packages/popover/src/js/close.js
+++ b/packages/popover/src/js/close.js
@@ -7,7 +7,8 @@ export async function close(query) {
   // If a modal exists and its state is opened.
   if (popover && popover.state === "opened") {
 
-    // Update state class.
+    // Update inert state and state class.
+    popover.el.inert = true;
     popover.el.classList.remove(this.settings.stateActive);
 
     // Update accessibility attribute(s).

--- a/packages/popover/src/js/open.js
+++ b/packages/popover/src/js/open.js
@@ -4,7 +4,8 @@ export async function open(query) {
   // Get the popover from collection.
   const popover = getPopover.call(this, query);
 
-  // Update state class.
+  // Update inert state and state class.
+  popover.el.inert = false;
   popover.el.classList.add(this.settings.stateActive);
 
   // Update accessibility attribute(s).

--- a/packages/popover/src/js/register.js
+++ b/packages/popover/src/js/register.js
@@ -51,6 +51,8 @@ export async function register(el, trigger) {
   if (entry.el.classList.contains(this.settings.stateActive)) {
     await entry.open();
     handleDocumentClick.call(this, entry);
+  } else {
+    entry.el.inert = true;
   }
 
   // Set the popper placement property.


### PR DESCRIPTION
## What changed?

With the new popover styles, popover content was accessible via keyboard tabbing. This PR applies the `inert` attribute on popovers when they're closed preventing them from being accessible via keyboard focus.