### PR TITLE
Remove inert polyfill

### DIFF
--- a/docs/_packages/drawer.md
+++ b/docs/_packages/drawer.md
@@ -315,8 +315,6 @@ Drawers while in their modal state follow a set of patterns expected from other 
 
 To take full advantage of modal drawer's accessibility features, it's recommended to set the `selectorInert` option to all elements that are outside the modal (most likely the `drawer-main` element). All elements that match the `selectorInert` selector will be given the `inert` attribute as well as `aria-hidden="true"` when a modal is opened.
 
-> Inert is not currently widely supported by all browsers. Consider using a polyfill such as [wicg-inert](https://github.com/WICG/inert) or Google's [inert-polyfill](https://github.com/GoogleChrome/inert-polyfill).
-
 ### Example
 
 Here's an example where we want the `drawer-main` content area to be inaccessible while drawer modals are open. We also want to disable other scrollable elements using the `selectorOverflow` option.

--- a/docs/_packages/modal.md
+++ b/docs/_packages/modal.md
@@ -192,8 +192,6 @@ Modals on the web have an expected set of patterns that this component follows. 
 
 To take full advantage of modal's accessibility features, it's recommended to set the `selectorInert` option to all elements that are outside the modal. If you have modal markup throughout your document, use the `teleport` option to consolidate all modals in the DOM to a single location. All elements that match the `selectorInert` selector will be given the `inert` attribute as well as `aria-hidden="true"` when a modal is opened.
 
-> Inert is not currently widely supported by all browsers. Consider using a polyfill such as [wicg-inert](https://github.com/WICG/inert) or Google's [inert-polyfill](https://github.com/GoogleChrome/inert-polyfill).
-
 ### Example
 
 Here's an example where we want the `<main>` content area to be inaccessible while modals are open. We also want all modals to be moved outside the main content element using the `after` method.

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -11,8 +11,7 @@
         "feather-icons": "^4.29.2",
         "list.js": "^2.3.1",
         "scroll-stash": "^1.1.2",
-        "svgxuse": "^1.2.6",
-        "wicg-inert": "^3.1.2"
+        "svgxuse": "^1.2.6"
       }
     },
     "../packages/base": {
@@ -316,11 +315,6 @@
     "node_modules/svgxuse": {
       "version": "1.2.6",
       "license": "MIT"
-    },
-    "node_modules/wicg-inert": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-3.1.2.tgz",
-      "integrity": "sha512-Ba9tGNYxXwaqKEi9sJJvPMKuo063umUPsHN0JJsjrs2j8KDSzkWLMZGZ+MH1Jf1Fq4OWZ5HsESJID6nRza2ang=="
     }
   },
   "dependencies": {
@@ -353,11 +347,6 @@
     },
     "svgxuse": {
       "version": "1.2.6"
-    },
-    "wicg-inert": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-3.1.2.tgz",
-      "integrity": "sha512-Ba9tGNYxXwaqKEi9sJJvPMKuo063umUPsHN0JJsjrs2j8KDSzkWLMZGZ+MH1Jf1Fq4OWZ5HsESJID6nRza2ang=="
     }
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -27,7 +27,6 @@
     "list.js": "^2.3.1",
     "scroll-stash": "^1.1.2",
     "svgxuse": "^1.2.6",
-    "vrembem": "^3.0.19",
-    "wicg-inert": "^3.1.2"
+    "vrembem": "^3.0.19"
   }
 }

--- a/docs/src/js/app.js
+++ b/docs/src/js/app.js
@@ -1,7 +1,6 @@
 import * as vb from 'vrembem';
 import ScrollStash from 'scroll-stash';
 import 'svgxuse';
-import 'wicg-inert';
 import './list.js';
 import './version';
 

--- a/example.html
+++ b/example.html
@@ -77,9 +77,6 @@
     </div>
   </div>
 
-  <!-- Inert polyfill -->
-  <script src="https://unpkg.com/wicg-inert/dist/inert.min.js"></script>
-
   <!-- Include Vrembem JavaScript -->
   <script src="https://unpkg.com/vrembem"></script>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,8 +43,7 @@
         "list.js": "^2.3.1",
         "scroll-stash": "^1.1.2",
         "svgxuse": "^1.2.6",
-        "vrembem": "^3.0.19",
-        "wicg-inert": "^3.1.2"
+        "vrembem": "^3.0.19"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -22691,11 +22690,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/wicg-inert": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-3.1.2.tgz",
-      "integrity": "sha512-Ba9tGNYxXwaqKEi9sJJvPMKuo063umUPsHN0JJsjrs2j8KDSzkWLMZGZ+MH1Jf1Fq4OWZ5HsESJID6nRza2ang=="
     },
     "node_modules/wide-align": {
       "version": "1.1.5",

--- a/packages/drawer/README.md
+++ b/packages/drawer/README.md
@@ -185,8 +185,6 @@ Drawers while in their modal state follow a set of patterns expected from other 
 
 To take full advantage of modal drawer's accessibility features, it's recommended to set the `selectorInert` option to all elements that are outside the modal (most likely the `drawer-main` element). All elements that match the `selectorInert` selector will be given the `inert` attribute as well as `aria-hidden="true"` when a modal is opened.
 
-> Inert is not currently widely supported by all browsers. Consider using a polyfill such as [wicg-inert](https://github.com/WICG/inert) or Google's [inert-polyfill](https://github.com/GoogleChrome/inert-polyfill).
-
 ### Example
 
 Here's an example where we want the `drawer-main` content area to be inaccessible while drawer modals are open. We also want to disable other scrollable elements using the `selectorOverflow` option.

--- a/packages/drawer/example.html
+++ b/packages/drawer/example.html
@@ -183,9 +183,6 @@
 
   </div><!-- .drawer-frame -->
 
-  <!-- Inert polyfill -->
-  <script src="https://unpkg.com/wicg-inert/dist/inert.min.js"></script>
-
   <!-- Component scripts -->
   <script src="./dev/scripts.umd.js"></script>
 

--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -118,8 +118,6 @@ Modals on the web have an expected set of patterns that this component follows. 
 
 To take full advantage of modal's accessibility features, it's recommended to set the `selectorInert` option to all elements that are outside the modal. If you have modal markup throughout your document, use the `teleport` option to consolidate all modals in the DOM to a single location. All elements that match the `selectorInert` selector will be given the `inert` attribute as well as `aria-hidden="true"` when a modal is opened.
 
-> Inert is not currently widely supported by all browsers. Consider using a polyfill such as [wicg-inert](https://github.com/WICG/inert) or Google's [inert-polyfill](https://github.com/GoogleChrome/inert-polyfill).
-
 ### Example
 
 Here's an example where we want the `<main>` content area to be inaccessible while modals are open. We also want all modals to be moved outside the main content element using the `after` method.

--- a/packages/modal/example.html
+++ b/packages/modal/example.html
@@ -248,9 +248,6 @@
 
   <div class="modals"></div>
 
-  <!-- Inert polyfill -->
-  <script src="https://unpkg.com/wicg-inert/dist/inert.min.js"></script>
-
   <!-- Component scripts -->
   <script src="./dev/scripts.umd.js"></script>
 


### PR DESCRIPTION
## What changed?

Inert is now widely supported by modern browsers and no longer needs a polyfill. This PR removes the polyfill usage from docs as well as documentation suggesting their usage.