### PR TITLE
Improve support for multiple popovers on a single trigger

### DIFF
--- a/docs/src/components/CodeBlock.astro
+++ b/docs/src/components/CodeBlock.astro
@@ -20,7 +20,7 @@ const { inline = false } = Astro.props;
     )
   }
   <Popover
-    buttonClass="code-block__copy-button"
+    triggerClass="code-block__copy-button"
     popoverClass="popover_tooltip"
     aria-label="Copy code example"
     arrow

--- a/docs/src/components/Popover.astro
+++ b/docs/src/components/Popover.astro
@@ -30,16 +30,20 @@ if (placement) {
 
 ---
 
-<button
-  id={triggerId}
-  data-popover-trigger={popoverId}
-  aria-controls={popoverId}
-  aria-describedby={tooltipId}
-  class={triggerClass}
-  {...rest}
->
-  <slot name="trigger">Popover Trigger</slot>
-</button>
+{
+  Astro.slots.has("trigger") && (
+    <button
+      id={triggerId}
+      data-popover-trigger={popoverId}
+      aria-controls={popoverId}
+      aria-describedby={tooltipId}
+      class={triggerClass}
+      {...rest}
+    >
+      <slot name="trigger" />
+    </button>
+  )
+}
 
 {
   Astro.slots.has("default") && (
@@ -49,7 +53,7 @@ if (placement) {
       class={("popover " + popoverClass).trim()}
       style={css}
     >
-      <slot>Popover Content</slot>
+      <slot />
       { 
         arrow && (
           <span class="popover__arrow"></span>

--- a/docs/src/components/Popover.astro
+++ b/docs/src/components/Popover.astro
@@ -2,22 +2,26 @@
 interface Props {
   id?: string;
   arrow?: boolean;
-  ariaLabel?: string;
-  buttonClass?: string;
+  triggerClass?: string;
   popoverClass?: string;
+  tooltipClass?: string;
   placement?: string;
 }
 
 const { 
   id, 
   arrow = false,
-  ariaLabel, 
-  buttonClass = "link", 
+  triggerClass = "link", 
   popoverClass = "",
-  placement
+  tooltipClass = "",
+  placement,
+  ...rest
 } = Astro.props;
 
-const uid = `popover-${id ? id : JSON.stringify(Math.floor(Math.random() * Date.now()))}`;
+const uid = id ? id : JSON.stringify(Math.floor(Math.random() * Date.now()));
+const triggerId = `popover-trigger-${uid}`;
+const popoverId = Astro.slots.has("default") ? `popover-${uid}` : null;
+const tooltipId = Astro.slots.has("tooltip") ? `popover-tooltip-${uid}` : null;
 
 const css = {};
 if (placement) {
@@ -27,26 +31,46 @@ if (placement) {
 ---
 
 <button
-  id={`${uid}-trigger`}
-  data-popover-trigger={uid}
-  aria-controls={uid}
-  aria-label={ariaLabel}
-  class={buttonClass}>
+  id={triggerId}
+  data-popover-trigger={popoverId}
+  aria-controls={popoverId}
+  aria-describedby={tooltipId}
+  class={triggerClass}
+  {...rest}
+>
   <slot name="trigger">Popover Trigger</slot>
 </button>
 
-<div
-  id={uid}
-  aria-labelledby={`${uid}-trigger`}
-  class={("popover " + popoverClass).trim()}
-  style={css}>
-  <slot>Popover Content</slot>
-  { 
-    arrow && (
+{
+  Astro.slots.has("default") && (
+    <div
+      id={popoverId}
+      aria-labelledby={triggerId}
+      class={("popover " + popoverClass).trim()}
+      style={css}
+    >
+      <slot>Popover Content</slot>
+      { 
+        arrow && (
+          <span class="popover__arrow"></span>
+        )
+      }
+    </div>
+  )
+}
+
+{
+  Astro.slots.has("tooltip") && (
+    <div
+      id={tooltipId}
+      class={("popover popover_tooltip " + tooltipClass).trim()}
+      style={css}
+    >
+      <slot name="tooltip" />
       <span class="popover__arrow"></span>
-    )
-  }
-</div>
+    </div>
+  )
+}
 
 <script>
   import "../modules/usePopover";

--- a/docs/src/components/ThemeSwitcherPopover.astro
+++ b/docs/src/components/ThemeSwitcherPopover.astro
@@ -6,16 +6,20 @@ import ThemeSwitcherMenu from "./ThemeSwitcherMenu.astro";
 
 <Popover
   id="theme-switcher"
-  ariaLabel="Switch selected theme"
-  buttonClass="button button_icon form-control-size overflow-hidden"
+  aria-label="Switch selected theme"
+  triggerClass="button button_icon form-control-size overflow-hidden"
   popoverClass="popover_size_auto vb-theme-light"
-  placement="bottom-end">
+  placement="bottom-end"
+>
   <Fragment slot="trigger">
     <svg class="icon icon_style_fill theme-icon theme-icon_root" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path fill-rule="evenodd" clip-rule="evenodd" d="M21 12C21 7.36745 17.5 3.55237 13 3.05493L13 20.9451C17.4999 20.4476 21 16.6326 21 12ZM12 1C18.0751 1 23 5.92487 23 12C23 18.0751 18.0751 23 12 23C5.92487 23 0.999999 18.0751 1 12C1 5.92487 5.92487 0.999999 12 1Z" fill="currentColor" />
     </svg>
     <Icon name="sun" classes="theme-icon theme-icon_light" />
     <Icon name="moon" classes="theme-icon theme-icon_dark" />
+  </Fragment>
+  <Fragment slot="tooltip">
+    Switch theme
   </Fragment>
   <ThemeSwitcherMenu />
 </Popover>

--- a/docs/src/content/packages/popover.mdx
+++ b/docs/src/content/packages/popover.mdx
@@ -8,6 +8,7 @@ status: "circle"
 import CodeExample from "../../components/CodeExample.astro";
 import DocBlock from "../../components/DocBlock.astro";
 import Menu from "../../examples/Menu.astro";
+import Icon from '../../components/Icon.astro';
 
 # Popover
 
@@ -238,7 +239,7 @@ Adjusts the size of the popover. There are two options relative to the default s
 
 Applies styles to create a popover tooltip. The default placement of a tooltip is `top` and are triggered by the `hover` and `focus` events. Tooltips also require a different set of attributes for accessibility:
 
-- The popover element should have the `role="tooltip"` set.
+- The popover element should have the `role="tooltip"` set. This is set automatically if the tooltip modifier is used.
 - The popover trigger should have `aria-describedby` (instead of `aria-controls`) set to the ID of the popover element.
 
 <CodeExample>
@@ -248,15 +249,15 @@ Applies styles to create a popover tooltip. The default placement of a tooltip i
       <button type="button" class="link" aria-describedby="popover-tooltip-2">CSS</button>
       <button type="button" class="link" aria-describedby="popover-tooltip-3">JS</button>
     </div>
-    <div id="popover-tooltip-1" class="popover popover_tooltip" role="tooltip">
+    <div id="popover-tooltip-1" class="popover popover_tooltip">
       Hypertext Markup Language
       <span class="popover__arrow"></span>
     </div>
-    <div id="popover-tooltip-2" class="popover popover_tooltip" role="tooltip">
+    <div id="popover-tooltip-2" class="popover popover_tooltip">
       Cascading Style Sheets
       <span class="popover__arrow"></span>
     </div>
-    <div id="popover-tooltip-3" class="popover popover_tooltip" role="tooltip">
+    <div id="popover-tooltip-3" class="popover popover_tooltip">
       JavaScript
       <span class="popover__arrow"></span>
     </div>
@@ -271,6 +272,36 @@ Applies styles to create a popover tooltip. The default placement of a tooltip i
 </CodeExample>
 
 > For more information regarding tooltip accessibility and best practices, please see: [ARIA: tooltip role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role).
+
+### Multiple popovers
+
+There are cases where a single popover trigger requires both a tooltip and a click toggle popover. This can be achieved by using `aria-controls` and `aria-describedby` attributes with the values of their corresponding popover IDs.
+
+<CodeExample>
+  <Fragment slot="output">
+    <button type="button" class="button button_icon" aria-controls="popover-multi-2" aria-describedby="popover-multi-1">
+      <Icon name="menu" />
+    </button>
+    <div id="popover-multi-1" class="popover popover_tooltip">
+      Menu
+      <span class="popover__arrow"></span>
+    </div>
+    <div id="popover-multi-2" class="popover popover_size_sm">
+      <Menu name="edit-shortcuts" />
+    </div>
+  </Fragment>
+  ```html
+  <button aria-controls="unique-id-1" aria-describedby="unique-id-2">
+    ...
+  </button>
+  <div id="unique-id-1" class="popover">
+    ...
+  </div>
+  <div id="unique-id-2" class="popover popover_tooltip">
+    ...
+  </div>
+  ```
+</CodeExample>
 
 ## Customization
 

--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -6,6 +6,7 @@ import Footer from "../components/Footer.astro";
 import LayoutDrawer from "../components/LayoutDrawer.astro";
 import LayoutAside from "../components/LayoutAside.astro";
 import Icon from "../components/Icon.astro";
+import Popover from "../components/Popover.astro";
 
 interface Props {
   title?: string;
@@ -47,12 +48,21 @@ const { title, layout = {} } = Astro.props;
           {
             layout.hasAside && (
               <div class="toolbar-mini">
-                <button
+                <Popover
+                  id="on-this-page-menu"
+                  aria-label="Open on this page menu"
+                  triggerClass="button button_icon"
+                  tooltipClass="text-nowrap"
+                  placement="bottom-end"
                   data-drawer-open="layout-aside"
-                  class="button button_icon"
                 >
-                  <Icon name="compass" />
-                </button>
+                  <Fragment slot="trigger">
+                    <Icon name="compass" />
+                  </Fragment>
+                  <Fragment slot="tooltip">
+                    On this page
+                  </Fragment>
+                </Popover>
               </div>
             )
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8309,11 +8309,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/focusable-selectors": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/focusable-selectors/-/focusable-selectors-0.8.4.tgz",
-      "integrity": "sha512-0XxbkD0KhOnX10qmnfF9U8DkDD8N/e4M77wMYw2Itoi4vdcoRjSkqXLZFIzkrLIOxzmzCGy88fNG1EbeXMD/zw=="
-    },
     "node_modules/follow-redirects": {
       "version": "1.15.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
@@ -14187,9 +14182,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
-      "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==",
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.12.tgz",
+      "integrity": "sha512-qXDmcVlZV4XRtKFzddidpfVP4oMSGhga+xdMc25mv8kaLUHtgzCDhUxkrN8exkGdTlLNaXj7CV3GtON7zuGZ+w==",
       "dev": true
     },
     "node_modules/nx": {
@@ -19072,10 +19067,7 @@
     "packages/core": {
       "name": "@vrembem/core",
       "version": "4.0.0-next.23",
-      "license": "MIT",
-      "dependencies": {
-        "focusable-selectors": "^0.8.4"
-      }
+      "license": "MIT"
     },
     "packages/dialog": {
       "name": "@vrembem/dialog",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,5 @@
     "stylelint-order": "^6.0.4",
     "vite": "^5.4.1",
     "vitest": "^2.0.1"
-  },
-  "overrides": {
-    "nwsapi": "2.2.2"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,8 +63,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "d966f513f86f66dddf93ed60ddefe51124562dc0",
-  "dependencies": {
-    "focusable-selectors": "^0.8.4"
-  }
+  "gitHead": "d966f513f86f66dddf93ed60ddefe51124562dc0"
 }

--- a/packages/core/src/js/FocusTrap.js
+++ b/packages/core/src/js/FocusTrap.js
@@ -1,5 +1,3 @@
-import focusableSelectors from "focusable-selectors";
-
 export class FocusTrap {
   #focusable;
   #handleFocusTrap;
@@ -77,8 +75,9 @@ export class FocusTrap {
     const initFocus = document.activeElement;
     const initScrollTop = el.scrollTop;
 
-    // Query for all the focusable elements.
-    const els = el.querySelectorAll(focusableSelectors.join(","));
+    // Query al the focusable elements.
+    const selector = focusableSelectors.join(",");
+    const els = el.querySelectorAll(selector);
 
     // Loop through all focusable elements.
     els.forEach((el) => {
@@ -99,6 +98,27 @@ export class FocusTrap {
     return focusable;
   }
 }
+
+// This has been copied over from focusable-selectors package and modified.
+// https://github.com/KittyGiraudel/focusable-selectors
+const notInert = ':not([inert])'; // Previously `:not([inert]):not([inert] *)`
+const notNegTabIndex = ':not([tabindex^="-"])';
+const notDisabled = ':not(:disabled)';
+const focusableSelectors = [
+  `a[href]${notInert}${notNegTabIndex}`,
+  `area[href]${notInert}${notNegTabIndex}`,
+  `input:not([type="hidden"]):not([type="radio"])${notInert}${notNegTabIndex}${notDisabled}`,
+  `input[type="radio"]${notInert}${notNegTabIndex}${notDisabled}`,
+  `select${notInert}${notNegTabIndex}${notDisabled}`,
+  `textarea${notInert}${notNegTabIndex}${notDisabled}`,
+  `button${notInert}${notNegTabIndex}${notDisabled}`,
+  `details${notInert} > summary:first-of-type${notNegTabIndex}`,
+  `iframe${notInert}${notNegTabIndex}`,
+  `audio[controls]${notInert}${notNegTabIndex}`,
+  `video[controls]${notInert}${notNegTabIndex}`,
+  `[contenteditable]${notInert}${notNegTabIndex}`,
+  `[tabindex]${notInert}${notNegTabIndex}`,
+];
 
 function handleFocusTrap(event) {
   // Check if the click was a tab and return if not.

--- a/packages/core/src/js/FocusTrap.js
+++ b/packages/core/src/js/FocusTrap.js
@@ -101,9 +101,9 @@ export class FocusTrap {
 
 // This has been copied over from focusable-selectors package and modified.
 // https://github.com/KittyGiraudel/focusable-selectors
-const notInert = ':not([inert])'; // Previously `:not([inert]):not([inert] *)`
-const notNegTabIndex = ':not([tabindex^="-"])';
-const notDisabled = ':not(:disabled)';
+const notInert = ":not([inert])"; // Previously `:not([inert]):not([inert] *)`
+const notNegTabIndex = ":not([tabindex^=\"-\"])";
+const notDisabled = ":not(:disabled)";
 const focusableSelectors = [
   `a[href]${notInert}${notNegTabIndex}`,
   `area[href]${notInert}${notNegTabIndex}`,

--- a/packages/popover/index.html
+++ b/packages/popover/index.html
@@ -53,19 +53,19 @@
       </div>
 
       <div>
-        <div id="popover-left" class="popover popover_size_auto popover_tooltip" style="--vb-popover-placement: left;">
+        <div id="popover-left" class="popover popover_tooltip" style="--vb-popover-placement: left;">
           Tooltip
           <span class="popover__arrow"></span>
         </div>
-        <div id="popover-top" class="popover popover_size_auto popover_tooltip" style="--vb-popover-placement: top;">
+        <div id="popover-top" class="popover popover_tooltip">
           Tooltip
           <span class="popover__arrow"></span>
         </div>
-        <div id="popover-bottom" class="popover popover_size_auto popover_tooltip" style="--vb-popover-placement: bottom;">
+        <div id="popover-bottom" class="popover popover_tooltip" style="--vb-popover-placement: bottom;">
           Tooltip
           <span class="popover__arrow"></span>
         </div>
-        <div id="popover-right" class="popover popover_size_auto popover_tooltip" style="--vb-popover-placement: right;">
+        <div id="popover-right" class="popover popover_tooltip" style="--vb-popover-placement: right;">
           Tooltip
           <span class="popover__arrow"></span>
         </div>

--- a/packages/popover/index.html
+++ b/packages/popover/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Vrembem Demo: %VITE_PACKAGE%</title>
+  <title>%VITE_NAME%</title>
   <link rel="icon" type="image/png" href="https://sebnitu.com/icons/vb-favicon.png">
   <link rel="icon" type="image/svg+xml" href="https://sebnitu.com/icons/vb-favicon.svg">
   <link rel="stylesheet" href="./index.scss">
@@ -26,17 +26,17 @@
 
   <header class="section background-dark">
     <div class="section__container max-width-xs spacing-sm">
-      <h1 class="text-size-lg">Vrembem</h1>
-      <p class="foreground-light">A component library based on the BEM methodology.</p>
+      <h1 class="text-size-lg">%VITE_NAME%</h1>
+      <p class="foreground-light">%VITE_DESCRIPTION%</p>
       <ol class="foreground-lighter flex flex_gap flex_gap-y_sm margin-top-lg list-style-none">
         <li class="flex flex_gap_sm align-items-center">
           <svg class="icon icon_size_sm" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path></svg>
-          <a class="link" target="_blank" href="https://github.com/sebnitu/vrembem">repo</a>
+          <a class="link" target="_blank" href="https://github.com/sebnitu/%VITE_ROOT%">%VITE_ROOT%</a>
         </li>
         <li class="foreground-neutral-80">/</li>
         <li class="flex flex_gap_sm align-items-center">
           <svg class="icon icon_size_sm" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
-          <a class="link" target="_blank" href="https://github.com/sebnitu/vrembem/tree/main/packages/%VITE_PACKAGE%#readme">%VITE_PACKAGE%</a>
+          <a class="link" target="_blank" href="https://github.com/sebnitu/%VITE_ROOT%/tree/main/packages/%VITE_PACKAGE%#readme">%VITE_PACKAGE%</a>
         </li>
       </ol>
     </div>

--- a/packages/popover/index.html
+++ b/packages/popover/index.html
@@ -43,7 +43,7 @@
   </header>
 
   <section class="section">
-    <div class="section__container max-width-xs spacing text-align-center">
+    <div class="section__container max-width-xs spacing">
 
       <div class="flex justify-content-center">
         <button class="button" aria-describedby="popover-left">Left</button>
@@ -55,15 +55,19 @@
       <div>
         <div id="popover-left" class="popover popover_size_auto popover_tooltip" style="--vb-popover-placement: left;">
           Tooltip
+          <span class="popover__arrow"></span>
         </div>
         <div id="popover-top" class="popover popover_size_auto popover_tooltip" style="--vb-popover-placement: top;">
           Tooltip
+          <span class="popover__arrow"></span>
         </div>
         <div id="popover-bottom" class="popover popover_size_auto popover_tooltip" style="--vb-popover-placement: bottom;">
           Tooltip
+          <span class="popover__arrow"></span>
         </div>
         <div id="popover-right" class="popover popover_size_auto popover_tooltip" style="--vb-popover-placement: right;">
           Tooltip
+          <span class="popover__arrow"></span>
         </div>
       </div>
 

--- a/packages/popover/src/js/close.js
+++ b/packages/popover/src/js/close.js
@@ -12,7 +12,7 @@ export async function close(query) {
     popover.el.classList.remove(this.settings.stateActive);
 
     // Update accessibility attribute(s).
-    if (popover.trigger.hasAttribute("aria-controls")) {
+    if (!popover.isTooltip) {
       popover.trigger.setAttribute("aria-expanded", "false");
     }
 

--- a/packages/popover/src/js/close.js
+++ b/packages/popover/src/js/close.js
@@ -60,9 +60,12 @@ export function closeCheck(popover) {
       popover.trigger.closest(":hover") === popover.trigger;
 
     // Check if trigger or element are being focused.
-    const isFocused = document.activeElement.closest(
+    let isFocused = document.activeElement.closest(
       `#${popover.id}, [aria-controls="${popover.id}"], [aria-describedby="${popover.id}"]`
     );
+
+    // If a focused element was returned, ensure that it is focus-visible.
+    isFocused = (isFocused) ? isFocused.matches(":focus-visible"): null;
 
     // Close if the trigger and element are not currently hovered or focused.
     if (!isHovered && !isFocused) {

--- a/packages/popover/src/js/close.js
+++ b/packages/popover/src/js/close.js
@@ -56,8 +56,8 @@ export function closeCheck(popover) {
   setTimeout(() => {
     // Check if trigger or element are being hovered.
     const isHovered =
-      popover.el.closest(":hover") === popover.el ||
-      popover.trigger.closest(":hover") === popover.trigger;
+      popover.el.matches(":hover") === popover.el ||
+      popover.trigger.matches(":hover") === popover.trigger;
 
     // Check if trigger or element are being focused.
     let isFocused = document.activeElement.closest(
@@ -65,7 +65,7 @@ export function closeCheck(popover) {
     );
 
     // If a focused element was returned, ensure that it is focus-visible.
-    isFocused = (isFocused) ? isFocused.matches(":focus-visible"): null;
+    isFocused = (isFocused) ? isFocused.matches(":focus-visible") : false;
 
     // Close if the trigger and element are not currently hovered or focused.
     if (!isHovered && !isFocused) {

--- a/packages/popover/src/js/defaults.js
+++ b/packages/popover/src/js/defaults.js
@@ -3,6 +3,7 @@ export default {
 
   // Selectors
   selectorPopover: ".popover",
+  selectorTooltip: ".popover_tooltip",
   selectorArrow: ".popover__arrow",
 
   // State classes

--- a/packages/popover/src/js/handlers.js
+++ b/packages/popover/src/js/handlers.js
@@ -10,7 +10,12 @@ export function handleClick(popover) {
   }
 }
 
-export function handleMouseEnter(popover) {
+export function handleMouseEnter(popover, event) {
+  // Guard to ensure only focus-visible triggers the tooltip on focus events.
+  if (event.type == "focus" && !popover.trigger.matches(":focus-visible")) {
+    return;
+  }
+
   // Clear any existing toggle delays.
   if (popover.toggleDelayId) {
     clearTimeout(popover.toggleDelayId);

--- a/packages/popover/src/js/handlers.js
+++ b/packages/popover/src/js/handlers.js
@@ -1,6 +1,20 @@
 import { closeAll, closeCheck } from "./close";
 
 export function handleClick(popover) {
+  // Check if trigger is linked to a tooltip.
+  const tooltipId = popover.trigger.getAttribute("aria-describedby");
+  if (tooltipId) {
+    // Get the entry and check if it's a tooltip.
+    const entry = this.get(tooltipId);
+    if (entry.isTooltip) {
+      // Clear any active toggle delays and close the tooltip.
+      if (entry.toggleDelayId) {
+        clearTimeout(entry.toggleDelayId);
+      }
+      entry.close();
+    }
+  }
+
   if (popover.state === "opened") {
     popover.close();
   } else {
@@ -13,6 +27,12 @@ export function handleClick(popover) {
 export function handleMouseEnter(popover, event) {
   // Guard to ensure only focus-visible triggers the tooltip on focus events.
   if (event.type == "focus" && !popover.trigger.matches(":focus-visible")) {
+    return;
+  }
+
+  // Guard to ensure a popover is not already open for this trigger.
+  const isExpanded = popover.trigger.getAttribute("aria-expanded");
+  if (isExpanded && isExpanded == "true") {
     return;
   }
 

--- a/packages/popover/src/js/helpers/getPopoverElements.js
+++ b/packages/popover/src/js/helpers/getPopoverElements.js
@@ -11,9 +11,9 @@ export function getPopoverElements(query) {
     if (!trigger && !popover) {
       return { error: new Error(`No popover elements found using the ID: "${id}".`) };
     } else if (!trigger) {
-      return { error: new Error("No popover trigger associated with the provided popover.") };
+      return { error: new Error(`No popover trigger associated with the provided popover: "${id}".`) };
     } else if (!popover) {
-      return { error: new Error("No popover associated with the provided popover trigger.") };
+      return { error: new Error(`No popover associated with the provided popover trigger: "${id}".`) };
     } else {
       return { popover, trigger };
     }

--- a/packages/popover/src/js/open.js
+++ b/packages/popover/src/js/open.js
@@ -9,7 +9,7 @@ export async function open(query) {
   popover.el.classList.add(this.settings.stateActive);
 
   // Update accessibility attribute(s).
-  if (popover.trigger.hasAttribute("aria-controls")) {
+  if (!popover.isTooltip) {
     popover.trigger.setAttribute("aria-expanded", "true");
   }
 

--- a/packages/popover/src/js/register.js
+++ b/packages/popover/src/js/register.js
@@ -73,7 +73,7 @@ export function registerEventListeners(entry) {
   // If event listeners aren't already setup.
   if (!entry.__eventListeners) {
     // Add event listeners based on event type.
-    const eventType = entry.config["event"];
+    const eventType = (entry.isTooltip) ? "hover" : entry.config["event"];
 
     // If the event type is hover.
     if (eventType === "hover") {

--- a/packages/popover/src/js/register.js
+++ b/packages/popover/src/js/register.js
@@ -23,7 +23,7 @@ export async function register(el, trigger) {
     popper: createPopper(trigger, el),
     config: getConfig(el, this.settings),
     get isTooltip() {
-      return trigger.hasAttribute("aria-describedby");
+      return !!el.closest(root.settings.selectorTooltip) || el.getAttribute("role") == "tooltip";
     },
     open() {
       return open.call(root, this);
@@ -35,6 +35,11 @@ export async function register(el, trigger) {
       return deregister.call(root, this);
     }
   };
+
+  // Set role="tooltip" attribute if the popover is a tooltip.
+  if (entry.isTooltip) {
+    entry.el.setAttribute("role", "tooltip");
+  }
 
   // Set aria-expanded to false if trigger has aria-controls attribute.
   if (entry.trigger.hasAttribute("aria-controls")) {

--- a/packages/popover/src/js/register.js
+++ b/packages/popover/src/js/register.js
@@ -42,7 +42,7 @@ export async function register(el, trigger) {
   }
 
   // Set aria-expanded to false if trigger has aria-controls attribute.
-  if (entry.trigger.hasAttribute("aria-controls")) {
+  if (!entry.isTooltip) {
     entry.trigger.setAttribute("aria-expanded", "false");
   }
 

--- a/packages/popover/src/scss/_popover.scss
+++ b/packages/popover/src/scss/_popover.scss
@@ -4,6 +4,7 @@
 
 $_offset: calc(calc(css.get("popover", "offset") + 1) * 1px);
 
+// TODO: Move this into utilities
 .transition-none {
   transition: none !important;
 }

--- a/packages/popover/src/scss/_popover_tooltip.scss
+++ b/packages/popover/src/scss/_popover_tooltip.scss
@@ -5,7 +5,6 @@
   @include css.override("popover", (
     "event": "hover",
     "placement": "top",
-    "arrow-size": 8px,
     "toggle-delay": 300,
     "width": auto,
     "max-width": 16rem,

--- a/packages/popover/src/scss/_popover_tooltip.scss
+++ b/packages/popover/src/scss/_popover_tooltip.scss
@@ -3,7 +3,6 @@
 
 #{core.bem("popover", null, "tooltip")} {
   @include css.override("popover", (
-    "event": "hover",
     "placement": "top",
     "toggle-delay": 300,
     "width": auto,

--- a/packages/popover/src/scss/_variables.scss
+++ b/packages/popover/src/scss/_variables.scss
@@ -23,7 +23,7 @@ $transition-property: opacity !default;
 $transition-duration: css.get("transition-duration-short") !default;
 $transition-timing-function: css.get("transition-timing-function") !default;
 
-$arrow-size: 12px !default;
+$arrow-size: 8px !default;
 $arrow-padding: 10 !default;
 
 $size-sm-width: 12em !default;

--- a/packages/popover/tests/close.test.js
+++ b/packages/popover/tests/close.test.js
@@ -72,21 +72,21 @@ describe("closeCheck()", () => {
     expect(popover.collection[0].el).not.toHaveClass("is-active");
   });
 
-  it("should not close popover if closeCheck detects a focus on trigger elements", () => {
+  it("should close popover if closeCheck detects a focus but not focus-visible on trigger elements", () => {
     document.body.innerHTML = markup;
     popover = new Popover({ autoMount: true });
     popover.collection[0].trigger.focus();
     closeCheck.call(popover, popover.collection[0]);
     vi.advanceTimersByTime(100);
-    expect(popover.collection[0].el).toHaveClass("is-active");
+    expect(popover.collection[0].el).not.toHaveClass("is-active");
   });
 
-  it("should not close popover if closeCheck detects a focus on popover elements", () => {
+  it("should close popover if closeCheck detects a focus but not focus-visible on popover elements", () => {
     document.body.innerHTML = markup;
     popover = new Popover({ autoMount: true });
     popover.collection[0].el.focus();
     closeCheck.call(popover, popover.collection[0]);
     vi.advanceTimersByTime(100);
-    expect(popover.collection[0].el).toHaveClass("is-active");
+    expect(popover.collection[0].el).not.toHaveClass("is-active");
   });
 });

--- a/packages/popover/tests/collection.test.js
+++ b/packages/popover/tests/collection.test.js
@@ -62,7 +62,7 @@ describe("register() & entry.deregister()", () => {
     const trigger = document.querySelector("#third");
     let catchError = false;
     await popover.register(trigger).catch((error) => {
-      expect(error.message).toBe("No popover associated with the provided popover trigger.");
+      expect(error.message).toBe("No popover associated with the provided popover trigger: \"missing\".");
       catchError = true;
     });
     expect(catchError).toBe(true);

--- a/packages/popover/tests/helpers.test.js
+++ b/packages/popover/tests/helpers.test.js
@@ -210,7 +210,7 @@ describe("getPopoverElements()", () => {
     const trigger = document.querySelector("[aria-controls=\"asdf\"]");
     popover = new Popover();
     const func = getPopoverElements.call(popover, trigger);
-    expect(func.error.message).toBe("No popover associated with the provided popover trigger.");
+    expect(func.error.message).toBe("No popover associated with the provided popover trigger: \"asdf\".");
   });
 
   it("should throw error if no popover trigger is found using a popover", () => {
@@ -218,7 +218,7 @@ describe("getPopoverElements()", () => {
     const target = document.querySelector("#fdsa");
     popover = new Popover();
     const func = getPopoverElements.call(popover, target);
-    expect(func.error.message).toBe("No popover trigger associated with the provided popover.");
+    expect(func.error.message).toBe("No popover trigger associated with the provided popover: \"fdsa\".");
   });
 
   it("should throw error if unable to resolve a popover ID with provided query", () => {

--- a/packages/popover/vite.config.js
+++ b/packages/popover/vite.config.js
@@ -1,5 +1,8 @@
 import { resolve } from "path";
 import { defineConfig } from "vite";
+import data from "./package.json";
+
+const parts = data.name.replace("@", "").split("/");
 
 export default defineConfig({
   build: {
@@ -12,6 +15,9 @@ export default defineConfig({
     sourcemap: true
   },
   define: {
-    "import.meta.env.VITE_PACKAGE": JSON.stringify("popover"),
+    "import.meta.env.VITE_ROOT": JSON.stringify(parts[0]),
+    "import.meta.env.VITE_PACKAGE": JSON.stringify(parts[1]),
+    "import.meta.env.VITE_NAME": JSON.stringify(data.name),
+    "import.meta.env.VITE_DESCRIPTION": JSON.stringify(data.description)
   }
 });

--- a/packages/vrembem/index.html
+++ b/packages/vrembem/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Vrembem Demo: %VITE_PACKAGE%</title>
+  <title>%VITE_NAME%</title>
   <link rel="icon" type="image/png" href="https://sebnitu.com/icons/vb-favicon.png">
   <link rel="icon" type="image/svg+xml" href="https://sebnitu.com/icons/vb-favicon.svg">
   <link rel="stylesheet" href="./index.scss">
@@ -59,17 +59,17 @@
 
   <header class="section background-dark">
     <div class="section__container max-width-xs spacing-sm">
-      <h1 class="text-size-lg">Vrembem</h1>
-      <p class="foreground-light">A component library based on the BEM methodology.</p>
+      <h1 class="text-size-lg">%VITE_NAME%</h1>
+      <p class="foreground-light">%VITE_DESCRIPTION%</p>
       <ol class="foreground-lighter flex flex_gap flex_gap-y_sm margin-top-lg list-style-none">
         <li class="flex flex_gap_sm align-items-center">
           <svg class="icon icon_size_sm" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path></svg>
-          <a class="link" target="_blank" href="https://github.com/sebnitu/vrembem">repo</a>
+          <a class="link" target="_blank" href="https://github.com/sebnitu/vrembem">%VITE_NAME%</a>
         </li>
         <li class="foreground-neutral-80">/</li>
         <li class="flex flex_gap_sm align-items-center">
           <svg class="icon icon_size_sm" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
-          <a class="link" target="_blank" href="https://github.com/sebnitu/vrembem/tree/main/packages/%VITE_PACKAGE%#readme">%VITE_PACKAGE%</a>
+          <a class="link" target="_blank" href="https://github.com/sebnitu/vrembem/tree/main/packages/%VITE_NAME%#readme">%VITE_NAME%</a>
         </li>
       </ol>
     </div>

--- a/packages/vrembem/vite.config.js
+++ b/packages/vrembem/vite.config.js
@@ -1,5 +1,6 @@
 import { resolve } from "path";
 import { defineConfig } from "vite";
+import data from "./package.json";
 
 export default defineConfig({
   build: {
@@ -12,6 +13,7 @@ export default defineConfig({
     sourcemap: true
   },
   define: {
-    "import.meta.env.VITE_PACKAGE": JSON.stringify("vrembem"),
+    "import.meta.env.VITE_NAME": JSON.stringify(data.name),
+    "import.meta.env.VITE_DESCRIPTION": JSON.stringify(data.description)
   }
 });


### PR DESCRIPTION
## What changed?

This PR improves on the ability for popover triggers to have multiple popovers such as a menu dropdown and a tooltip. This is most commonly used with button icons where additional context may be needed for what the button does.

To accomplish this, the `isTooltip` property has been refactored to more accurately determine if a popover is indeed a tooltip. Tooltips now have additional guards set for when used together with click toggled popovers so that they no longer overlap and are handled more elegantly. For example:

- Tooltips can no longer be opened if a click popover is already open.
- Tooltips are displayed on `:focus-visible` instead of just `:focus`.
- The Role attribute is automatically applied if a popover has the tooltip modifier.
- Clicking a popover trigger will dismiss tooltips.
- Automatically applies the hover event to tooltip popovers.

**Additional Changes**
- Used a consistent arrow size value for all popovers.
- Improved error message for when a popover element is not found.
- Updates Vite demos to use package data. This allows for applying Vite demos in a more flexible way across multiple packages (future update).
- Refactors the FocusTrap module to copy code from focusable-selectors package and incorporate changes to prevent test errors.
- Improved Popover astro component to better allow for popover and tooltips on a single trigger and applies tooltips to button icons where needed.
- Adds documentation for using multiple popovers on a single trigger.