### PR TITLE
Add basic transition utilities

### DIFF
--- a/packages/popover/src/scss/_popover.scss
+++ b/packages/popover/src/scss/_popover.scss
@@ -4,11 +4,6 @@
 
 $_offset: calc(calc(css.get("popover", "offset") + 1) * 1px);
 
-// TODO: Move this into utilities
-.transition-none {
-  transition: none !important;
-}
-
 #{core.bem("popover")} {
   position: absolute;
   z-index: css.get("popover", "z-index", var.$z-index);

--- a/packages/utility/build/base.scss
+++ b/packages/utility/build/base.scss
@@ -1,0 +1,1 @@
+@forward "../index.scss";

--- a/packages/utility/build/index.scss
+++ b/packages/utility/build/index.scss
@@ -1,0 +1,2 @@
+@forward "../index.scss";
+@forward "../root.scss";

--- a/packages/utility/build/root.scss
+++ b/packages/utility/build/root.scss
@@ -1,0 +1,1 @@
+@forward "../root.scss";

--- a/packages/utility/index.scss
+++ b/packages/utility/index.scss
@@ -23,3 +23,5 @@
 
 @forward "./src/font";
 @forward "./src/text";
+
+@forward "./src/transition";

--- a/packages/utility/package.json
+++ b/packages/utility/package.json
@@ -24,8 +24,8 @@
     "build": "npm-run-all clean styles",
     "clean": "del dev && del dist",
     "styles": "npm-run-all styles:dev styles:dist",
-    "styles:dev": "sass index.scss dev/index.css --load-path=../../node_modules",
-    "styles:dist": "sass index.scss dist/index.css --load-path=../../node_modules --style=compressed",
+    "styles:dev": "sass build:dev --load-path=../../node_modules",
+    "styles:dist": "sass build:dist --load-path=../../node_modules --style=compressed",
     "watch": "npm run watch:styles",
     "watch:styles": "concurrently 'npm run styles:dev -- --watch ./src' 'npm run styles:dist -- --watch ./src'"
   },

--- a/packages/utility/src/_transition.scss
+++ b/packages/utility/src/_transition.scss
@@ -1,0 +1,15 @@
+@use "@vrembem/core/css";
+@use "./variables" as var;
+
+$_u: var.$prefix-utility;
+$_c: var.$class-transition;
+
+@if (var.$output-transition) {
+  .#{$_u}#{$_c}-none {
+    transition: none !important;
+  }
+
+  .#{$_u}#{$_c}-all {
+    transition: all css.get("transition-duration") css.get("transition-timing-function") !important;
+  }
+}

--- a/packages/utility/src/_variables.scss
+++ b/packages/utility/src/_variables.scss
@@ -19,6 +19,7 @@ $output-padding: $output !default;
 $output-position: $output !default;
 $output-spacing: $output !default;
 $output-text: $output !default;
+$output-transition: $output !default;
 
 $class-background: "background" !default;
 $class-foreground: "foreground" !default;
@@ -33,6 +34,7 @@ $class-overflow: "overflow" !default;
 $class-padding: "padding" !default;
 $class-position: "position" !default;
 $class-text: "text" !default;
+$class-transition: "transition" !default;
 
 $breakpoints: core.$breakpoints !default;
 


### PR DESCRIPTION
## What changed?

This PR removes the temporary transition class in the popover component and adds two basic transition utilities to the utility module. This also sets up the utility component to run the build directory for output files. This will be more useful later when the utility component has been given  custom properties support.