### PR TITLE
Add and apply handleTooltipClick to focus event popovers

### DIFF
--- a/packages/popover/src/js/handlers.js
+++ b/packages/popover/src/js/handlers.js
@@ -1,26 +1,21 @@
 import { closeAll, closeCheck } from "./close";
 
 export function handleClick(popover) {
-  // Check if trigger is linked to a tooltip.
-  const tooltipId = popover.trigger.getAttribute("aria-describedby");
-  if (tooltipId) {
-    // Get the entry and check if it's a tooltip.
-    const entry = this.get(tooltipId);
-    if (entry.isTooltip) {
-      // Clear any active toggle delays and close the tooltip.
-      if (entry.toggleDelayId) {
-        clearTimeout(entry.toggleDelayId);
-      }
-      entry.close();
-    }
-  }
-
   if (popover.state === "opened") {
     popover.close();
   } else {
     this.trigger = popover.trigger;
     popover.open();
     handleDocumentClick.call(this, popover);
+  }
+}
+
+export function handleTooltipClick(popover) {
+  if (popover.isTooltip) {
+    if (popover.toggleDelayId) {
+      clearTimeout(popover.toggleDelayId);
+    }
+    popover.close();
   }
 }
 

--- a/packages/popover/src/js/register.js
+++ b/packages/popover/src/js/register.js
@@ -1,6 +1,6 @@
 import { createPopper } from "@popperjs/core/dist/esm";
 
-import { handleClick, handleMouseEnter, handleMouseLeave, handleDocumentClick } from "./handlers";
+import { handleClick, handleTooltipClick, handleMouseEnter, handleMouseLeave, handleDocumentClick } from "./handlers";
 import { deregister } from "./deregister";
 import { open } from "./open";
 import { close } from "./close";
@@ -86,6 +86,10 @@ export function registerEventListeners(entry) {
         el: ["el", "trigger"],
         type: ["mouseleave", "focusout"],
         listener: handleMouseLeave.bind(this, entry)
+      }, {
+        el: ["trigger"],
+        type: ["click"],
+        listener: handleTooltipClick.bind(this, entry)
       }];
 
       // Loop through listeners and apply to the appropriate elements.

--- a/packages/popover/tests/collection.test.js
+++ b/packages/popover/tests/collection.test.js
@@ -74,7 +74,7 @@ describe("register() & entry.deregister()", () => {
     const trigger = document.querySelector("#fdsa-trigger");
     popover.register(trigger, false);
     expect(popover.collection.length).toBe(1);
-    expect(popover.collection[0].__eventListeners.length).toBe(2);
+    expect(popover.collection[0].__eventListeners.length).toBe(3);
   });
 
   it("should attach open and close methods to registered popover", () => {


### PR DESCRIPTION
## What changed?

In cases where a button icon only has a tooltip and not a second popover, the tooltip should still be closed on click. This PR introduces the `handleTooltipClick` function and applies it to focus event popovers.