### PR TITLE
Add custom properties support to modals

### DIFF
--- a/docs/src/content/packages/modal.mdx
+++ b/docs/src/content/packages/modal.mdx
@@ -624,8 +624,8 @@ After the modal component has been instantiated the modal object is returned wit
   Returns an array of all currently opened modals. These are sorted in the order they're added to the array (first item was opened first, last item was opened last).
 </DocBlock>
 
-<DocBlock name="modal.active" type="property" returns="Object || undefined" src="modal/src/js/index.js" line="33">
-  Returns the currently active modal or the modal at the top of the stack if multiple modals are open. Will return `undefined` if no modals are open.
+<DocBlock name="modal.active" type="property" returns="Object || null" src="modal/src/js/index.js" line="33">
+  Returns the currently active modal or the modal at the top of the stack if multiple modals are open. Will return `null` if no modals are open.
 </DocBlock>
 
 <DocBlock name="modal.mount" type="method" returns="Object" src="modal/src/js/index.js" line="37" args={[

--- a/packages/core/src/scss/library/_focus-ring.scss
+++ b/packages/core/src/scss/library/_focus-ring.scss
@@ -1,4 +1,5 @@
 @use "../modules/css";
+@use "../variables/focus-ring" as var;
 
 /// Apply the base styles for focus-ring using the outline properties.
 @mixin focus-ring-base() {
@@ -12,8 +13,10 @@
 ///   The module to allow component specific overrides for.
 /// @param {string} $color
 ///   The color to use as the fallback value.
-@mixin focus-ring($module, $color) {
-  $_focus-ring-opacity: css.get("core", "focus-ring-opacity");
+/// @param {number} $opacity
+///   The value to set for the opacity of the color.
+@mixin focus-ring($module, $color, $opacity: var.$focus-ring-opacity) {
+  $_focus-ring-opacity: css.get("core", "focus-ring-opacity", $opacity);
   $_focus-ring-color: css.get("core", "focus-ring-color", $color);
   @if ($module) {
     $_focus-ring-opacity: css.get($module, "focus-ring-opacity", $_focus-ring-opacity);

--- a/packages/core/src/scss/variables/_focus-ring.scss
+++ b/packages/core/src/scss/variables/_focus-ring.scss
@@ -9,5 +9,4 @@ $focus-ring-opacity: 40% !default;
   "width": $focus-ring-width,
   "style": $focus-ring-style,
   "offset": $focus-ring-offset,
-  "opacity": $focus-ring-opacity,
 ));

--- a/packages/modal/src/js/stack.js
+++ b/packages/modal/src/js/stack.js
@@ -10,7 +10,8 @@ export function stack(settings) {
     },
 
     get top() {
-      return stackArray[stackArray.length - 1];
+      const result = stackArray[stackArray.length - 1];
+      return (result) ? result : null;
     },
 
     updateIndex() {

--- a/packages/modal/src/scss/_modal.scss
+++ b/packages/modal/src/scss/_modal.scss
@@ -1,4 +1,6 @@
 @use "@vrembem/core";
+@use "@vrembem/core/css";
+@use "@vrembem/core/palette";
 @use "./variables" as var;
 
 $_v: var.$prefix-variable;
@@ -7,7 +9,7 @@ $_e: var.$prefix-element;
 
 .#{$_b}modal {
   position: fixed;
-  z-index: var.$z-index;
+  z-index: css.get("modal", "z-index", var.$z-index);
   top: 0;
   right: 0;
   display: flex;
@@ -25,29 +27,29 @@ $_e: var.$prefix-element;
     inset: 0;
     width: 100%;
     height: 100%;
-    background-color: var.$screen-background;
+    background-color: css.get("modal", "screen-background", var.$screen-background);
     opacity: 0;
   }
 }
 
 .#{$_b}modal#{$_e}dialog {
-  width: var.$width;
-  max-width: 100%;
+  @include core.focus-ring-base();
+  width: css.get("modal", "width", var.$width);
+  max-width: css.get("modal", "max-width", var.$max-width);
   overflow: auto;
-  transform: translateY(-(var.$travel));
+  transform: translateY(calc(css.get("modal", "travel", var.$travel) * -1));
   transition-property: outline;
-  transition-duration: var(--#{$_v}modal-transition-duration);
-  transition-timing-function: var(--#{$_v}modal-transition-timing-function);
-  outline: var.$outline;
-  box-shadow: var.$shadow;
+  transition-duration: css.get("modal", "transition-duration");
+  transition-timing-function: css.get("modal", "transition-timing-function");
+  box-shadow: css.get("modal", "shadow", var.$shadow);
   opacity: 0;
 
-  &:focus {
-    outline: var.$outline-focus;
+  &:focus-visible {
+    @include core.focus-ring("modal", var.$focus-ring-color, var.$focus-ring-opacity);
   }
 
   &[role="alertdialog"]:focus {
-    outline: var.$outline-focus-alert;
+    @include core.focus-ring("modal", var.$focus-ring-color-alert, var.$focus-ring-opacity);
   }
 }
 
@@ -61,30 +63,26 @@ $_e: var.$prefix-element;
   visibility: visible;
   width: 100%;
   height: 100%;
-  padding: 1em;
-
-  @include core.media-min("medium") {
-    padding: 2em;
-  }
+  padding: css.get("modal", "screen-padding", var.$screen-padding);
 }
 
 .#{$_b}modal.is-opening,
 .#{$_b}modal.is-closing {
   &::before {
-    transition: opacity var(--#{$_v}modal-transition-duration) var(--#{$_v}modal-transition-timing-function);
+    transition: opacity css.get("modal", "transition-duration", var.$transition-duration) css.get("modal", "transition-timing-function", var.$transition-timing-function);
   }
 
   .#{$_b}modal#{$_e}dialog {
     transition-property: opacity, transform;
-    transition-duration: var(--#{$_v}modal-transition-duration);
-    transition-timing-function: var(--#{$_v}modal-transition-timing-function);
+    transition-duration: css.get("modal", "transition-duration", var.$transition-duration);
+    transition-timing-function: css.get("modal", "transition-timing-function", var.$transition-timing-function);
   }
 }
 
 .#{$_b}modal.is-opening,
 .#{$_b}modal.is-opened {
   &::before {
-    opacity: var.$screen-opacity;
+    opacity: css.get("modal", "screen-opacity", var.$screen-opacity);
   }
 
   .#{$_b}modal#{$_e}dialog {
@@ -94,5 +92,5 @@ $_e: var.$prefix-element;
 }
 
 .#{$_b}modal.is-closing .#{$_b}modal#{$_e}dialog {
-  transform: translateY(-(var.$travel));
+  transform: translateY(calc(css.get("modal", "travel", var.$travel) * -1));
 }

--- a/packages/modal/src/scss/_modal.scss
+++ b/packages/modal/src/scss/_modal.scss
@@ -3,11 +3,7 @@
 @use "@vrembem/core/palette";
 @use "./variables" as var;
 
-$_v: var.$prefix-variable;
-$_b: var.$prefix-block;
-$_e: var.$prefix-element;
-
-.#{$_b}modal {
+#{core.bem("modal")} {
   position: fixed;
   z-index: css.get("modal", "z-index", var.$z-index);
   top: 0;
@@ -32,7 +28,7 @@ $_e: var.$prefix-element;
   }
 }
 
-.#{$_b}modal#{$_e}dialog {
+#{core.bem("modal", "dialog")} {
   @include core.focus-ring-base();
   width: css.get("modal", "width", var.$width);
   max-width: css.get("modal", "max-width", var.$max-width);
@@ -53,44 +49,44 @@ $_e: var.$prefix-element;
   }
 }
 
-.#{$_b}modal.is-closed {
+#{core.bem("modal")}.is-closed {
   visibility: hidden;
 }
 
-.#{$_b}modal.is-opening,
-.#{$_b}modal.is-opened,
-.#{$_b}modal.is-closing {
+#{core.bem("modal")}.is-opening,
+#{core.bem("modal")}.is-opened,
+#{core.bem("modal")}.is-closing {
   visibility: visible;
   width: 100%;
   height: 100%;
   padding: css.get("modal", "screen-padding", var.$screen-padding);
 }
 
-.#{$_b}modal.is-opening,
-.#{$_b}modal.is-closing {
+#{core.bem("modal")}.is-opening,
+#{core.bem("modal")}.is-closing {
   &::before {
     transition: opacity css.get("modal", "transition-duration", var.$transition-duration) css.get("modal", "transition-timing-function", var.$transition-timing-function);
   }
 
-  .#{$_b}modal#{$_e}dialog {
+  #{core.bem("modal", "dialog")} {
     transition-property: opacity, transform;
     transition-duration: css.get("modal", "transition-duration", var.$transition-duration);
     transition-timing-function: css.get("modal", "transition-timing-function", var.$transition-timing-function);
   }
 }
 
-.#{$_b}modal.is-opening,
-.#{$_b}modal.is-opened {
+#{core.bem("modal")}.is-opening,
+#{core.bem("modal")}.is-opened {
   &::before {
     opacity: css.get("modal", "screen-opacity", var.$screen-opacity);
   }
 
-  .#{$_b}modal#{$_e}dialog {
+  #{core.bem("modal", "dialog")} {
     transform: translateY(0);
     opacity: 1;
   }
 }
 
-.#{$_b}modal.is-closing .#{$_b}modal#{$_e}dialog {
+#{core.bem("modal")}.is-closing #{core.bem("modal", "dialog")} {
   transform: translateY(calc(css.get("modal", "travel", var.$travel) * -1));
 }

--- a/packages/modal/src/scss/_modal_full.scss
+++ b/packages/modal/src/scss/_modal_full.scss
@@ -1,3 +1,4 @@
+@use "@vrembem/core/css";
 @use "./variables" as var;
 
 $_b: var.$prefix-block;
@@ -8,7 +9,7 @@ $_m: var.$prefix-modifier;
   .#{$_b}modal#{$_e}dialog {
     width: 100%;
     height: 100%;
-    transform: scale(0.75);
+    transform: scale(css.get("modal", "full-scale", var.$full-scale));
   }
 
   &.is-opened .#{$_b}modal#{$_e}dialog,
@@ -17,6 +18,6 @@ $_m: var.$prefix-modifier;
   }
 
   &.is-closing .#{$_b}modal#{$_e}dialog {
-    transform: scale(0.75);
+    transform: scale(css.get("modal", "full-scale", var.$full-scale));
   }
 }

--- a/packages/modal/src/scss/_modal_full.scss
+++ b/packages/modal/src/scss/_modal_full.scss
@@ -1,23 +1,20 @@
+@use "@vrembem/core";
 @use "@vrembem/core/css";
 @use "./variables" as var;
 
-$_b: var.$prefix-block;
-$_e: var.$prefix-element;
-$_m: var.$prefix-modifier;
-
-.#{$_b}modal#{$_m}full {
-  .#{$_b}modal#{$_e}dialog {
+#{core.bem("modal", null, "full")} {
+  #{core.bem("modal", "dialog")} {
     width: 100%;
     height: 100%;
     transform: scale(css.get("modal", "full-scale", var.$full-scale));
   }
 
-  &.is-opened .#{$_b}modal#{$_e}dialog,
-  &.is-opening .#{$_b}modal#{$_e}dialog {
+  &.is-opened #{core.bem("modal", "dialog")},
+  &.is-opening #{core.bem("modal", "dialog")} {
     transform: scale(1);
   }
 
-  &.is-closing .#{$_b}modal#{$_e}dialog {
+  &.is-closing #{core.bem("modal", "dialog")} {
     transform: scale(css.get("modal", "full-scale", var.$full-scale));
   }
 }

--- a/packages/modal/src/scss/_modal_pos.scss
+++ b/packages/modal/src/scss/_modal_pos.scss
@@ -1,63 +1,59 @@
+@use "@vrembem/core";
 @use "@vrembem/core/css";
 @use "./variables" as var;
 
-$_b: var.$prefix-block;
-$_e: var.$prefix-element;
-$_m: var.$prefix-modifier;
-$_v: var.$prefix-modifier-value;
-
-.#{$_b}modal#{$_m}pos#{$_v}top {
+#{core.bem("modal", null, "pos", "top")} {
   justify-content: flex-start;
 }
 
-.#{$_b}modal#{$_m}pos#{$_v}bottom {
+#{core.bem("modal", null, "pos", "bottom")} {
   justify-content: flex-end;
 
-  .#{$_b}modal#{$_e}dialog {
+  #{core.bem("modal", "dialog")} {
     transform: translateY(css.get("modal", "travel", var.$travel));
   }
 
   &.is-closing {
-    .#{$_b}modal#{$_e}dialog {
+    #{core.bem("modal", "dialog")} {
       transform: translateY(css.get("modal", "travel", var.$travel));
     }
   }
 }
 
-.#{$_b}modal#{$_m}pos#{$_v}left,
-.#{$_b}modal#{$_m}pos#{$_v}right {
-  .#{$_b}modal#{$_e}dialog {
+#{core.bem("modal", null, "pos", "left")},
+#{core.bem("modal", null, "pos", "right")} {
+  #{core.bem("modal", "dialog")} {
     @include css.override("modal", "width", var.$aside-width);
     @include css.override("modal", "max-width", var.$aside-max-width);
     height: 100%;
   }
 }
 
-.#{$_b}modal#{$_m}pos#{$_v}left {
+#{core.bem("modal", null, "pos", "left")} {
   align-items: flex-start;
 
-  .#{$_b}modal#{$_e}dialog {
+  #{core.bem("modal", "dialog")} {
     left: 0;
     transform: translateX(-100%);
   }
 
   &.is-closing {
-    .#{$_b}modal#{$_e}dialog {
+    #{core.bem("modal", "dialog")} {
       transform: translateX(-100%);
     }
   }
 }
 
-.#{$_b}modal#{$_m}pos#{$_v}right {
+#{core.bem("modal", null, "pos", "right")} {
   align-items: flex-end;
 
-  .#{$_b}modal#{$_e}dialog {
+  #{core.bem("modal", "dialog")} {
     right: 0;
     transform: translateX(100%);
   }
 
   &.is-closing {
-    .#{$_b}modal#{$_e}dialog {
+    #{core.bem("modal", "dialog")} {
       transform: translateX(100%);
     }
   }

--- a/packages/modal/src/scss/_modal_pos.scss
+++ b/packages/modal/src/scss/_modal_pos.scss
@@ -1,3 +1,4 @@
+@use "@vrembem/core/css";
 @use "./variables" as var;
 
 $_b: var.$prefix-block;
@@ -13,12 +14,12 @@ $_v: var.$prefix-modifier-value;
   justify-content: flex-end;
 
   .#{$_b}modal#{$_e}dialog {
-    transform: translateY(var.$travel);
+    transform: translateY(css.get("modal", "travel", var.$travel));
   }
 
   &.is-closing {
     .#{$_b}modal#{$_e}dialog {
-      transform: translateY(var.$travel);
+      transform: translateY(css.get("modal", "travel", var.$travel));
     }
   }
 }
@@ -26,8 +27,8 @@ $_v: var.$prefix-modifier-value;
 .#{$_b}modal#{$_m}pos#{$_v}left,
 .#{$_b}modal#{$_m}pos#{$_v}right {
   .#{$_b}modal#{$_e}dialog {
-    width: var.$aside-width;
-    max-width: var.$aside-max-width;
+    @include css.override("modal", "width", var.$aside-width);
+    @include css.override("modal", "max-width", var.$aside-max-width);
     height: 100%;
   }
 }

--- a/packages/modal/src/scss/_modal_size.scss
+++ b/packages/modal/src/scss/_modal_size.scss
@@ -1,3 +1,4 @@
+@use "@vrembem/core/css";
 @use "./variables" as var;
 
 $_b: var.$prefix-block;
@@ -7,6 +8,6 @@ $_v: var.$prefix-modifier-value;
 
 @each $key, $value in var.$size-scale {
   .#{$_b}modal#{$_m}size#{$_v}#{$key} .#{$_b}modal#{$_e}dialog {
-    width: $value;
+    @include css.override("modal", "width", $value);
   }
 }

--- a/packages/modal/src/scss/_modal_size.scss
+++ b/packages/modal/src/scss/_modal_size.scss
@@ -1,13 +1,9 @@
+@use "@vrembem/core";
 @use "@vrembem/core/css";
 @use "./variables" as var;
 
-$_b: var.$prefix-block;
-$_e: var.$prefix-element;
-$_m: var.$prefix-modifier;
-$_v: var.$prefix-modifier-value;
-
 @each $key, $value in var.$size-scale {
-  .#{$_b}modal#{$_m}size#{$_v}#{$key} .#{$_b}modal#{$_e}dialog {
+  #{core.bem("modal", null, "size", $key)} #{core.bem("modal", "dialog")} {
     @include css.override("modal", "width", $value);
   }
 }

--- a/packages/modal/src/scss/_variables.scss
+++ b/packages/modal/src/scss/_variables.scss
@@ -4,12 +4,6 @@
 @use "@vrembem/core/css";
 @use "@vrembem/core/palette";
 
-$prefix-variable: config.get("prefix-variables") !default;
-$prefix-block: config.get("prefix-blocks") !default;
-$prefix-element: config.get("prefix-elements") !default;
-$prefix-modifier: config.get("prefix-modifiers") !default;
-$prefix-modifier-value: config.get("prefix-modifier-values") !default;
-
 $z-index: 1000 !default;
 $width: 36em !default;
 $max-width: 100% !default;

--- a/packages/modal/src/scss/_variables.scss
+++ b/packages/modal/src/scss/_variables.scss
@@ -12,6 +12,7 @@ $prefix-modifier-value: config.get("prefix-modifier-values") !default;
 
 $z-index: 1000 !default;
 $width: 36em !default;
+$max-width: 100% !default;
 $travel: 5em !default;
 $transition-duration: css.get("transition-duration") !default;
 $transition-timing-function: css.get("transition-timing-function") !default;
@@ -19,14 +20,18 @@ $shadow: css.get("box-shadow-5") !default;
 
 $screen-background: palette.get("neutral", 10) !default;
 $screen-opacity: 0.8 !default;
+$screen-padding: 1em !default;
 
-$outline: 0 solid transparent !default;
-$outline-focus: 4px solid palette.get("primary") !default;
-$outline-focus-alert: 4px solid palette.get("important") !default;
+$focus-ring-color: palette.get("primary") !default;
+$focus-ring-color-alert: palette.get("important") !default;
+$focus-ring-opacity: 1 !default;
 
 // modal_pos_[value]
 $aside-width: 16em !default;
 $aside-max-width: 90% !default;
+
+// modal_full
+$full-scale: 0.75 !default;
 
 // modal_size_[key]
 $size-scale: (


### PR DESCRIPTION
## What changed?

This PR primarily applies custom properties support to the modal component. This is done in a similar way to how popover custom properties are applied in that they are provided fallback values and set the custom property names to override but do not output the custom properties directly.

**Additional Changes**
- `modal.active` now returns `null` instead of `undefined` if there are no active modals.
- Refactors `focus-ring` mixin to allow passing the opacity value of the color.
- Apply focus-ring to modal and remove outline variables.
- Added focus-ring and full scale variables.
- Apply new BEM naming function to modal component and remove prefix variables.