### PR TITLE
Apply dialog custom property overrides to modal and drawer components

### DIFF
--- a/docs/src/content/packages/drawer.mdx
+++ b/docs/src/content/packages/drawer.mdx
@@ -97,7 +97,7 @@ The dialog element of a drawer is defined using the `drawer__dialog` class. Alon
       <aside id="drawer-2" class="drawer">
         <div class="drawer__dialog dialog" role="dialog" aria-labelledby="dialog-title" aria-describedby="dialog-description">
           <div class="dialog__header justify-content-between">
-            <h2 id="dialog-title">Drawer title</h2>
+            <h2 id="dialog-title" class="dialog__title">Drawer title</h2>
             <button class="link" data-drawer-close>Close</button>
           </div>
           <div class="dialog__body">
@@ -145,9 +145,11 @@ There are multiple ways a modal drawer can be created. The simplest being applyi
     <div class="drawer-frame" style="min-height: 8rem;">
       <aside id="drawer-3" class="drawer drawer_modal" data-drawer-config="{ 'selectorInert': null, 'selectorOverflow': null }">
         <div class="drawer__dialog dialog">
-          <div class="dialog__header">
-            <h2 class="flex-grow">Modal drawer</h2>
-            <button class="link" data-drawer-close>Close</button>
+          <div class="dialog__body">
+            <div class="flex">
+              <h2 class="flex-grow">Modal drawer</h2>
+              <button class="link" data-drawer-close>Close</button>
+            </div>
           </div>
         </div>
       </aside>
@@ -270,6 +272,9 @@ Drawer dialogs are given focus when opened as long as the `setTabindex` option i
             <h2 class="dialog__title">Drawer example</h2>
             <button class="link" data-drawer-close>Close</button>
           </div>
+          <div class="dialog__body">
+            <p>Focus should be initially set on the dialog element.</p>
+          </div>
         </div>
       </aside>
       <aside id="drawer-7" class="drawer">
@@ -357,12 +362,15 @@ Applies modal drawer styles to a drawer. This modifier should be applied before 
 
 <CodeExample flush>
   <Fragment slot="output">
-    <div class="drawer-frame" style="min-height: 8rem;">
+    <div class="drawer-frame" style="min-height: 12rem;">
       <aside id="drawer-8" class="drawer drawer_modal" data-drawer-config="{ 'selectorInert': null, 'selectorOverflow': null }">
         <div class="drawer__dialog dialog">
           <div class="dialog__header">
-            <p class="flex-grow">Drawer example</p>
+            <h2 class="dialog__title">Modal drawer example</h2>
             <button class="link" data-drawer-close>Close</button>
+          </div>
+          <div class="dialog__body">
+            <p>Set a drawer to modal mode by applying the <code>drawer_modal</code> modifier class.</p>
           </div>
         </div>
       </aside>

--- a/docs/src/content/packages/drawer.mdx
+++ b/docs/src/content/packages/drawer.mdx
@@ -144,9 +144,9 @@ There are multiple ways a modal drawer can be created. The simplest being applyi
   <Fragment slot="output">
     <div class="drawer-frame" style="min-height: 8rem;">
       <aside id="drawer-3" class="drawer drawer_modal" data-drawer-config="{ 'selectorInert': null, 'selectorOverflow': null }">
-        <div class="drawer__dialog padding">
-          <div class="flex justify-content-between">
-            <span>Modal drawer</span>
+        <div class="drawer__dialog dialog">
+          <div class="dialog__header">
+            <h2 class="flex-grow">Modal drawer</h2>
             <button class="link" data-drawer-close>Close</button>
           </div>
         </div>
@@ -180,24 +180,28 @@ In cases where you'd like a drawer to switch modes based on a specific viewport 
   <Fragment slot="output">
     <div class="drawer-frame">
       <aside id="drawer-4" class="drawer" data-drawer-breakpoint="1200px" data-drawer-config="{ 'selectorInert': null, 'selectorOverflow': null }">
-        <div class="drawer__dialog padding spacing">
-          <div class="flex justify-content-between">
-            <span>Drawer example</span>
+        <div class="drawer__dialog dialog">
+          <div class="dialog__header">
+            <h2 class="dialog__title">Drawer example</h2>
             <button class="link" data-drawer-close>Close</button>
           </div>
-          <code>data-drawer-breakpoint="1200px"</code>
+          <div class="dialog__body">
+            <code>data-drawer-breakpoint="1200px"</code>
+          </div>
         </div>
       </aside>
       <aside id="drawer-5" class="drawer" data-drawer-breakpoint="md" data-drawer-config="{ 'selectorInert': null, 'selectorOverflow': null }">
-        <div class="drawer__dialog padding spacing">
-          <div class="flex justify-content-between">
-            <span>Drawer example</span>
+        <div class="drawer__dialog dialog">
+          <div class="dialog__header">
+            <h2 class="dialog__title">Drawer example</h2>
             <button class="link" data-drawer-close>Close</button>
           </div>
-          <code>data-drawer-breakpoint="md"</code>
+          <div class="dialog__body">
+            <code>data-drawer-breakpoint="md"</code>
+          </div>
         </div>
       </aside>
-      <div class="drawer-main padding spacing">
+      <div class="drawer-main padding spacing" style="min-height: 12rem;">
         <p>Current viewport width: <code data-vp-width>...</code></p>
         <ul class="list">
           <li>
@@ -261,20 +265,22 @@ Drawer dialogs are given focus when opened as long as the `setTabindex` option i
   <Fragment slot="output">
     <div class="drawer-frame" style="min-height: 8rem;">
       <aside id="drawer-6" class="drawer">
-        <div class="drawer__dialog padding" tabindex="-1">
-          <div class="flex justify-content-between">
-            <span>Drawer example</span>
+        <div class="drawer__dialog dialog">
+          <div class="dialog__header">
+            <h2 class="dialog__title">Drawer example</h2>
             <button class="link" data-drawer-close>Close</button>
           </div>
         </div>
       </aside>
       <aside id="drawer-7" class="drawer">
-        <div class="drawer__dialog padding spacing">
-          <div class="flex justify-content-between">
-            <span>Drawer example</span>
+        <div class="drawer__dialog dialog">
+          <div class="dialog__header">
+            <h2 class="dialog__title">Drawer example</h2>
             <button class="link" data-drawer-close>Close</button>
           </div>
-          <input class="input" data-focus type="text" />
+          <div class="dialog__body">
+            <input class="input" data-focus type="text" />
+          </div>
         </div>
       </aside>
       <div class="drawer-main padding">
@@ -353,9 +359,9 @@ Applies modal drawer styles to a drawer. This modifier should be applied before 
   <Fragment slot="output">
     <div class="drawer-frame" style="min-height: 8rem;">
       <aside id="drawer-8" class="drawer drawer_modal" data-drawer-config="{ 'selectorInert': null, 'selectorOverflow': null }">
-        <div class="drawer__dialog padding">
-          <div class="flex justify-content-between">
-            <span>Drawer example</span>
+        <div class="drawer__dialog dialog">
+          <div class="dialog__header">
+            <p class="flex-grow">Drawer example</p>
             <button class="link" data-drawer-close>Close</button>
           </div>
         </div>
@@ -380,9 +386,9 @@ Drawers slide in from the left by default. To create a right side drawer, use th
   <Fragment slot="output">
     <div class="drawer-frame" style="min-height: 8rem;">
       <aside id="drawer-9" class="drawer drawer_switch">
-        <div class="drawer__dialog padding">
-          <div class="flex justify-content-between">
-            <span>Drawer example</span>
+        <div class="drawer__dialog dialog">
+          <div class="dialog__header">
+            <p class="flex-grow">Drawer example</p>
             <button class="link" data-drawer-close>Close</button>
           </div>
         </div>

--- a/packages/core/index.scss
+++ b/packages/core/index.scss
@@ -6,6 +6,7 @@
 @forward "./src/scss/variables/transition";
 @forward "./src/scss/variables/focus-ring";
 @forward "./src/scss/variables/form-control";
+@forward "./src/scss/variables/screen";
 
 @forward "./src/scss/library/bem";
 @forward "./src/scss/library/css-query";

--- a/packages/core/src/scss/library/_focus-ring.scss
+++ b/packages/core/src/scss/library/_focus-ring.scss
@@ -24,3 +24,5 @@
   }
   outline: css.get("focus-ring-width") css.get("focus-ring-style") hsl(from $_focus-ring-color h s l / $_focus-ring-opacity);
 }
+
+// TODO: Maybe add a function for setting the focus-ring-color custom property stack.

--- a/packages/core/src/scss/library/_focus-ring.scss
+++ b/packages/core/src/scss/library/_focus-ring.scss
@@ -1,6 +1,34 @@
 @use "../modules/css";
 @use "../variables/focus-ring" as var;
 
+/// Output the focus-ring-color custom property stack with core and value
+/// fallbacks.
+/// @param {string} $module
+///   The name of the module to start the property stack with.
+/// @param {css value} $value
+///   The CSS value to use as the final property fallback.
+/// @return {css var}
+///   The CSS variable with the provided module and value fallback stack.
+@function focus-ring-color($module, $value) {
+  $result: css.get("core", "focus-ring-color", $value);
+  $result: css.get($module, "focus-ring-color", $result);
+  @return $result;
+}
+
+/// Output the focus-ring-opacity custom property stack with core and value
+/// fallbacks.
+/// @param {string} $module
+///   The name of the module to start the property stack with.
+/// @param {css value} $value
+///   The CSS value to use as the final property fallback.
+/// @return {css var}
+///   The CSS variable with the provided module and value fallback stack.
+@function focus-ring-opacity($module, $value) {
+  $result: css.get("core", "focus-ring-opacity", $value);
+  $result: css.get($module, "focus-ring-opacity", $result);
+  @return $result;
+}
+
 /// Apply the base styles for focus-ring using the outline properties.
 @mixin focus-ring-base() {
   outline: css.get("focus-ring-width") css.get("focus-ring-style") transparent;
@@ -16,13 +44,5 @@
 /// @param {number} $opacity
 ///   The value to set for the opacity of the color.
 @mixin focus-ring($module, $color, $opacity: var.$focus-ring-opacity) {
-  $_focus-ring-opacity: css.get("core", "focus-ring-opacity", $opacity);
-  $_focus-ring-color: css.get("core", "focus-ring-color", $color);
-  @if ($module) {
-    $_focus-ring-opacity: css.get($module, "focus-ring-opacity", $_focus-ring-opacity);
-    $_focus-ring-color: css.get($module, "focus-ring-color", $_focus-ring-color);
-  }
-  outline: css.get("focus-ring-width") css.get("focus-ring-style") hsl(from $_focus-ring-color h s l / $_focus-ring-opacity);
+  outline: css.get("focus-ring-width") css.get("focus-ring-style") hsl(from focus-ring-color($module, $color) h s l / focus-ring-opacity($module, $opacity));
 }
-
-// TODO: Maybe add a function for setting the focus-ring-color custom property stack.

--- a/packages/core/src/scss/modules/_css.scss
+++ b/packages/core/src/scss/modules/_css.scss
@@ -226,7 +226,7 @@ $_variables: (
         $result: reference($module, $prop);
       }
 
-      // Check if the property exists in the module or the its default theme.
+      // Check if the property exists in the module or its default theme.
       @else if 
         map.has-key($_variables, $module, $prop) or
         map.has-key($_variables, $module, config.get("default-theme"), $prop)

--- a/packages/core/src/scss/variables/_screen.scss
+++ b/packages/core/src/scss/variables/_screen.scss
@@ -1,0 +1,12 @@
+@use "../modules/css";
+@use "../modules/palette";
+
+$screen-background: palette.get("neutral", 10) !default;
+$screen-opacity: 0.8 !default;
+$screen-padding: 1em !default;
+
+@include css.set("core", "screen", (
+  "background": $screen-background,
+  "opacity": $screen-opacity,
+  "padding": $screen-padding,
+));

--- a/packages/core/src/scss/variables/_screen.scss
+++ b/packages/core/src/scss/variables/_screen.scss
@@ -1,12 +1,12 @@
 @use "../modules/css";
 @use "../modules/palette";
 
-$screen-background: palette.get("neutral", 10) !default;
+$screen-color: palette.get("neutral", 10) !default;
 $screen-opacity: 0.8 !default;
 $screen-padding: 1em !default;
 
 @include css.set("core", "screen", (
-  "background": $screen-background,
+  "color": $screen-color,
   "opacity": $screen-opacity,
   "padding": $screen-padding,
 ));

--- a/packages/dialog/src/_dialog.scss
+++ b/packages/dialog/src/_dialog.scss
@@ -22,7 +22,7 @@
   &:focus-visible,
   &[role="alertdialog"] {
     @include core.focus-ring("dialog", var.$focus-ring-color, var.$focus-ring-opacity);
-    border-color: css.get("dialog", "focus-ring-color", css.get("core", "focus-ring", var.$focus-ring-color));
+    border-color: core.focus-ring-color("dialog", var.$focus-ring-color);
   }
 
   &[role="alertdialog"] {

--- a/packages/dialog/src/_dialog.scss
+++ b/packages/dialog/src/_dialog.scss
@@ -1,7 +1,9 @@
 @use "@vrembem/core";
 @use "@vrembem/core/css";
+@use "./variables" as var;
 
 #{core.bem("dialog")} {
+  @include core.focus-ring-base();
   position: relative;
   display: flex;
   flex-direction: column;
@@ -13,6 +15,17 @@
   box-shadow: css.get("dialog", "box-shadow");
   color: css.get("dialog", "foreground");
   -webkit-overflow-scrolling: touch;
+  transition-property: outline;
+  transition-duration: css.get("dialog", "transition-duration");
+  transition-timing-function: css.get("dialog", "transition-timing-function");
+
+  &:focus-visible {
+    @include core.focus-ring("dialog", var.$focus-ring-color, var.$focus-ring-opacity);
+  }
+
+  &[role="alertdialog"]:focus {
+    @include core.focus-ring("dialog", var.$focus-ring-color-alert, var.$focus-ring-opacity);
+  }
 }
 
 #{core.bem("dialog", "header")},

--- a/packages/dialog/src/_dialog.scss
+++ b/packages/dialog/src/_dialog.scss
@@ -11,12 +11,12 @@
   transition-property: outline, border-color;
   transition-duration: css.get("dialog", "transition-duration", var.$transition-duration);
   transition-timing-function: css.get("dialog", "transition-timing-function", var.$transition-timing-function);
-  border: css.get("dialog", "border");
-  border-radius: css.get("dialog", "border-radius");
-  background: css.get("dialog", "background");
+  border: css.get("dialog", "border", var.$border);
+  border-radius: css.get("dialog", "border-radius", var.$border-radius);
+  background: css.get("dialog", "background", var.$background);
   background-clip: padding-box;
-  box-shadow: css.get("dialog", "box-shadow");
-  color: css.get("dialog", "foreground");
+  box-shadow: css.get("dialog", "box-shadow", var.$box-shadow);
+  color: css.get("dialog", "foreground", var.$foreground);
   -webkit-overflow-scrolling: touch;
 
   &:focus-visible {
@@ -34,7 +34,7 @@
 #{core.bem("dialog", "body")},
 #{core.bem("dialog", "footer")} {
   flex: 0 0 auto;
-  padding: css.get("dialog", "padding");
+  padding: css.get("dialog", "padding", var.$padding);
 }
 
 #{core.bem("dialog", "header")},
@@ -43,32 +43,32 @@
   z-index: 1;
   display: flex;
   align-items: center;
-  background: css.get("dialog", "background");
+  background: css.get("dialog", "background", var.$background);
   vertical-align: middle;
-  gap: css.get("dialog", "gap");
+  gap: css.get("dialog", "gap", var.$gap);
 }
 
 #{core.bem("dialog", "header")} {
   top: 0;
-  border-bottom: css.get("dialog", "sep-border");
+  border-bottom: css.get("dialog", "sep-border", var.$sep-border);
 }
 
 #{core.bem("dialog", "body")} {
   flex-grow: 1;
 
   & + & {
-    border-top: css.get("dialog", "sep-border");
+    border-top: css.get("dialog", "sep-border", var.$sep-border);
   }
 }
 
 #{core.bem("dialog", "footer")} {
   bottom: 0;
-  border-top: css.get("dialog", "sep-border");
+  border-top: css.get("dialog", "sep-border", var.$sep-border);
 }
 
 #{core.bem("dialog", "title")} {
   flex-grow: 1;
-  font-size: css.get("dialog", "title-font-size");
-  font-weight: css.get("dialog", "title-font-weight");
-  line-height: css.get("dialog", "title-line-height");
+  font-size: css.get("dialog", "title-font-size", var.$title-font-size);
+  font-weight: css.get("dialog", "title-font-weight", var.$title-font-weight);
+  line-height: css.get("dialog", "title-line-height", var.$title-line-height);
 }

--- a/packages/dialog/src/_dialog.scss
+++ b/packages/dialog/src/_dialog.scss
@@ -8,6 +8,9 @@
   display: flex;
   flex-direction: column;
   overflow: auto;
+  transition-property: outline, border-color;
+  transition-duration: css.get("dialog", "transition-duration", var.$transition-duration);
+  transition-timing-function: css.get("dialog", "transition-timing-function", var.$transition-timing-function);
   border: css.get("dialog", "border");
   border-radius: css.get("dialog", "border-radius");
   background: css.get("dialog", "background");
@@ -15,16 +18,15 @@
   box-shadow: css.get("dialog", "box-shadow");
   color: css.get("dialog", "foreground");
   -webkit-overflow-scrolling: touch;
-  transition-property: outline;
-  transition-duration: css.get("dialog", "transition-duration");
-  transition-timing-function: css.get("dialog", "transition-timing-function");
 
   &:focus-visible {
     @include core.focus-ring("dialog", var.$focus-ring-color, var.$focus-ring-opacity);
+    border-color: var.$focus-ring-color;
   }
 
   &[role="alertdialog"]:focus {
     @include core.focus-ring("dialog", var.$focus-ring-color-alert, var.$focus-ring-opacity);
+    border-color: var.$focus-ring-color-alert;
   }
 }
 

--- a/packages/dialog/src/_dialog.scss
+++ b/packages/dialog/src/_dialog.scss
@@ -19,14 +19,14 @@
   color: css.get("dialog", "foreground", var.$foreground);
   -webkit-overflow-scrolling: touch;
 
-  &:focus-visible {
+  &:focus-visible,
+  &[role="alertdialog"] {
     @include core.focus-ring("dialog", var.$focus-ring-color, var.$focus-ring-opacity);
-    border-color: var.$focus-ring-color;
+    border-color: css.get("dialog", "focus-ring-color", css.get("core", "focus-ring", var.$focus-ring-color));
   }
 
-  &[role="alertdialog"]:focus {
-    @include core.focus-ring("dialog", var.$focus-ring-color-alert, var.$focus-ring-opacity);
-    border-color: var.$focus-ring-color-alert;
+  &[role="alertdialog"] {
+    @include css.override("dialog", "focus-ring-color", var.$focus-ring-color-alert);
   }
 }
 

--- a/packages/dialog/src/_root.scss
+++ b/packages/dialog/src/_root.scss
@@ -1,8 +1,5 @@
 @use "@vrembem/core/css";
-@use "@vrembem/core/theme";
 
 :root {
   @include css.output("dialog");
 }
-
-@include theme.output("dialog");

--- a/packages/dialog/src/_variables.scss
+++ b/packages/dialog/src/_variables.scss
@@ -1,5 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/css";
+@use "@vrembem/core/palette";
 @use "@vrembem/core/theme";
 
 $padding: 1em !default;
@@ -13,6 +14,12 @@ $box-shadow: css.get("box-shadow-4") !default;
 $title-font-size: css.get("font-size-lg") !default;
 $title-line-height: null !default;
 $title-font-weight: css.get("font-weight-semi-bold") !default;
+$transition-duration: css.get("transition-duration") !default;
+$transition-timing-function: css.get("transition-timing-function") !default;
+
+$focus-ring-color: palette.get("primary") !default;
+$focus-ring-color-alert: palette.get("important") !default;
+$focus-ring-opacity: 1 !default;
 
 // Custom properties
 @include css.set("dialog", (
@@ -30,6 +37,11 @@ $title-font-weight: css.get("font-weight-semi-bold") !default;
     "font-weight": $title-font-weight,
   )
 ));
+
+@include css.set("dialog", (
+  "transition-duration": $transition-duration,
+  "transition-timing-function": $transition-timing-function
+), "required");
 
 // Themes
 @include theme.set("dialog", "light", (

--- a/packages/dialog/src/_variables.scss
+++ b/packages/dialog/src/_variables.scss
@@ -5,10 +5,10 @@
 
 $padding: 1em !default;
 $gap: 0.5em !default;
-$background: null !default;
-$foreground: null !default;
-$border: null !default;
-$sep-border: null !default;
+$background: css.get("background") !default;
+$foreground: css.get("foreground") !default;
+$border: css.get("border") !default;
+$sep-border: css.get("border") !default;
 $border-radius: css.get("border-radius") !default;
 $box-shadow: css.get("box-shadow-4") !default;
 $title-font-size: css.get("font-size-lg") !default;
@@ -21,33 +21,7 @@ $focus-ring-color: palette.get("primary") !default;
 $focus-ring-color-alert: palette.get("important") !default;
 $focus-ring-opacity: 1 !default;
 
-// Custom properties
-@include css.set("dialog", (
-  "padding": $padding,
-  "gap": $gap,
-  "background": $background,
-  "foreground": $foreground,
-  "border": $border,
-  "sep-border": $sep-border,
-  "border-radius": $border-radius,
-  "box-shadow": $box-shadow,
-  "title": (
-    "font-size": $title-font-size,
-    "line-height": $title-line-height,
-    "font-weight": $title-font-weight,
-  )
-));
-
 @include css.set("dialog", (
   "transition-duration": $transition-duration,
   "transition-timing-function": $transition-timing-function
 ), "required");
-
-// Themes
-@include theme.set("dialog", "light", (
-  "background": css.get("background"),
-  "foreground": css.get("foreground"),
-  "border": core.$border,
-  "sep-border": core.$border
-));
-@include theme.set("dialog", "dark");

--- a/packages/drawer/src/scss/_drawer.scss
+++ b/packages/drawer/src/scss/_drawer.scss
@@ -35,17 +35,6 @@
   width: 0;
   height: 0;
   overflow: hidden;
-
-  // TODO: Maybe move this into the `_drawer_switch` modifier file?
-  // Left side drawer
-  &:not(#{core.bem("drawer", null, "switch")}) #{core.bem("drawer", "dialog")} {
-    border-left: none;
-  }
-
-  // Right side drawer
-  &#{core.bem("drawer", null, "switch")} #{core.bem("drawer", "dialog")} {
-    border-right: none;
-  }
 }
 
 #{core.bem("drawer", "dialog")} {
@@ -68,7 +57,6 @@
   -webkit-overflow-scrolling: touch;
 
   // Only target inline (not modal) drawer dialogs.
-  // TODO: Maybe add a class for targeting the inline state of drawers?
   #{core.bem("drawer")}:not(#{core.bem("drawer", null, "modal")}) & {
     @include css.override("dialog", var.$inline-dialog-override);
   }

--- a/packages/drawer/src/scss/_drawer.scss
+++ b/packages/drawer/src/scss/_drawer.scss
@@ -26,6 +26,7 @@
  */
 
 #{core.bem("drawer")} {
+  z-index: css.get("drawer", "z-index", var.$z-index);
   position: absolute;
   top: 0;
   bottom: 0;
@@ -42,27 +43,12 @@
   display: flex;
   flex-direction: column;
   width: css.get("drawer", "width", var.$width);
-  max-width: css.get("drawer", "max-width", var.$max-width);
+  max-width: 100%;
   height: 100%;
   overflow: auto;
-  border: none;
-  border-right: css.get("drawer", "border", var.$border);
   border-radius: 0;
-  background: css.get("drawer", "background", var.$background);
-  box-shadow: css.get("drawer", "box-shadow", var.$box-shadow);
   opacity: 0;
-  color: css.get("drawer", "foreground", var.$foreground);
   -webkit-overflow-scrolling: touch;
-
-  #{core.bem("dialog", "header")},
-  #{core.bem("dialog", "footer")} {
-    border-color: css.get("drawer", "sep-border-color", var.$sep-border-color);
-    background: css.get("drawer", "background", var.$background);
-  }
-
-  #{core.bem("dialog", "body")} {
-    background: css.get("drawer", "background", var.$background);
-  }
 }
 
 /**

--- a/packages/drawer/src/scss/_drawer.scss
+++ b/packages/drawer/src/scss/_drawer.scss
@@ -26,8 +26,8 @@
  */
 
 #{core.bem("drawer")} {
-  z-index: css.get("drawer", "z-index", var.$z-index);
   position: absolute;
+  z-index: css.get("drawer", "z-index", var.$z-index);
   top: 0;
   bottom: 0;
   visibility: hidden;
@@ -46,6 +46,8 @@
   max-width: 100%;
   height: 100%;
   overflow: auto;
+  transition-duration: css.get("drawer", "transition-duration", var.$transition-duration);
+  transition-timing-function: css.get("drawer", "transition-timing-function", var.$transition-timing-function);
   border-radius: 0;
   opacity: 0;
   -webkit-overflow-scrolling: touch;
@@ -78,8 +80,6 @@
 
   #{core.bem("drawer", "dialog")} {
     transition-property: opacity, transform;
-    transition-duration: css.get("drawer", "transition-duration", var.$transition-duration);
-    transition-timing-function: css.get("drawer", "transition-timing-function", var.$transition-timing-function);
   }
 }
 

--- a/packages/drawer/src/scss/_drawer.scss
+++ b/packages/drawer/src/scss/_drawer.scss
@@ -35,10 +35,21 @@
   width: 0;
   height: 0;
   overflow: hidden;
+
+  // TODO: Maybe move this into the `_drawer_switch` modifier file?
+  // Left side drawer
+  &:not(#{core.bem("drawer", null, "switch")}) #{core.bem("drawer", "dialog")} {
+    border-left: none;
+  }
+
+  // Right side drawer
+  &#{core.bem("drawer", null, "switch")} #{core.bem("drawer", "dialog")} {
+    border-right: none;
+  }
 }
 
 #{core.bem("drawer", "dialog")} {
-  @include css.override("dialog", var.$dialog-overrides);
+  @include css.override("dialog", var.$dialog-override);
   position: absolute;
   top: 0;
   display: flex;
@@ -49,13 +60,17 @@
   overflow: auto;
   transition-duration: css.get("drawer", "transition-duration", var.$transition-duration);
   transition-timing-function: css.get("drawer", "transition-timing-function", var.$transition-timing-function);
+  border-top: none;
+  border-bottom: none;
   border-radius: 0;
+  background-clip: border-box;
   opacity: 0;
   -webkit-overflow-scrolling: touch;
 
-  // TODO: Only target non-modal drawer dialogs.
+  // Only target inline (not modal) drawer dialogs.
+  // TODO: Maybe add a class for targeting the inline state of drawers?
   #{core.bem("drawer")}:not(#{core.bem("drawer", null, "modal")}) & {
-    background-color: pink;
+    @include css.override("dialog", var.$inline-dialog-override);
   }
 }
 

--- a/packages/drawer/src/scss/_drawer.scss
+++ b/packages/drawer/src/scss/_drawer.scss
@@ -38,6 +38,7 @@
 }
 
 #{core.bem("drawer", "dialog")} {
+  @include css.override("dialog", var.$dialog-overrides);
   position: absolute;
   top: 0;
   display: flex;
@@ -51,6 +52,11 @@
   border-radius: 0;
   opacity: 0;
   -webkit-overflow-scrolling: touch;
+
+  // TODO: Only target non-modal drawer dialogs.
+  #{core.bem("drawer")}:not(#{core.bem("drawer", null, "modal")}) & {
+    background-color: pink;
+  }
 }
 
 /**

--- a/packages/drawer/src/scss/_drawer_modal.scss
+++ b/packages/drawer/src/scss/_drawer_modal.scss
@@ -7,6 +7,7 @@
  */
 
 #{core.bem("drawer", null, "modal")} {
+  @include css.override("drawer", "z-index", var.$modal-z-index);
   right: auto;
   left: 0;
   width: 0;

--- a/packages/drawer/src/scss/_drawer_modal.scss
+++ b/packages/drawer/src/scss/_drawer_modal.scss
@@ -6,7 +6,7 @@
  * Drawer modal styles
  */
 
- #{core.bem("drawer", null, "modal")} {
+#{core.bem("drawer", null, "modal")} {
   right: auto;
   left: 0;
   width: 0;

--- a/packages/drawer/src/scss/_drawer_modal.scss
+++ b/packages/drawer/src/scss/_drawer_modal.scss
@@ -21,7 +21,7 @@
     inset: 0;
     width: 100%;
     height: 100%;
-    background-color: css.get("drawer", "screen-background", core.$screen-background);
+    background-color: css.get("drawer", "screen-color", core.$screen-color);
     opacity: 0;
   }
 

--- a/packages/drawer/src/scss/_drawer_modal.scss
+++ b/packages/drawer/src/scss/_drawer_modal.scss
@@ -7,7 +7,6 @@
  */
 
  #{core.bem("drawer", null, "modal")} {
-  z-index: css.get("drawer", "modal-z-index", var.$modal-z-index);
   right: auto;
   left: 0;
   width: 0;
@@ -27,15 +26,10 @@
 
   #{core.bem("drawer", "dialog")} {
     position: absolute;
-    z-index: calc(css.get("drawer", "modal-z-index", var.$modal-z-index) + 1);
     left: 0;
-    width: css.get("drawer", "modal-width", var.$modal-width);
-    max-width: css.get("drawer", "modal-max-width", var.$modal-max-width);
+    width: css.get("drawer", "width", var.$width);
+    max-width: css.get("drawer", "max-width", var.$max-width);
     transform: translateX(-100%);
-    border-right: css.get("drawer", "modal-border", var.$modal-border);
-    background-color: css.get("drawer", "modal-background", var.$modal-background);
-    box-shadow: css.get("drawer", "modal-box-shadow", var.$modal-box-shadow);
-    color: css.get("drawer", "modal-foreground", var.$modal-foreground);
   }
   
   &#{core.bem("drawer", null, "switch")} {
@@ -47,18 +41,7 @@
       right: 0;
       left: auto;
       transform: translateX(100%);
-      border-left: css.get("drawer", "modal-border", var.$modal-border);
     }
-  }
-
-  #{core.bem("dialog", "header")},
-  #{core.bem("dialog", "footer")} {
-    border-color: css.get("drawer", "modal-sep-border-color", var.$modal-sep-border-color);
-    background: css.get("drawer", "modal-background", var.$modal-background);
-  }
-
-  #{core.bem("dialog", "body")} {
-    background: css.get("drawer", "modal-background", var.$modal-background);
   }
 }
 

--- a/packages/drawer/src/scss/_drawer_modal.scss
+++ b/packages/drawer/src/scss/_drawer_modal.scss
@@ -21,7 +21,7 @@
     inset: 0;
     width: 100%;
     height: 100%;
-    background-color: css.get("drawer", "modal-screen-background", var.$modal-screen-background);
+    background-color: css.get("drawer", "screen-background", core.$screen-background);
     opacity: 0;
   }
 
@@ -86,7 +86,7 @@
   transform: translateX(0);
 
   &::before {
-    opacity: css.get("drawer", "modal-screen-opacity", var.$modal-screen-opacity);
+    opacity: css.get("drawer", "screen-opacity", core.$screen-opacity);
   }
 
   #{core.bem("drawer", "dialog")} {

--- a/packages/drawer/src/scss/_drawer_modal.scss
+++ b/packages/drawer/src/scss/_drawer_modal.scss
@@ -25,13 +25,15 @@
   }
 
   #{core.bem("drawer", "dialog")} {
+    @include css.override("dialog", var.$modal-dialog-override);
     position: absolute;
     left: 0;
     width: css.get("drawer", "width", var.$width);
     max-width: css.get("drawer", "max-width", var.$max-width);
     transform: translateX(-100%);
+    background-clip: padding-box;
   }
-  
+
   &#{core.bem("drawer", null, "switch")} {
     right: auto;
     left: 0;

--- a/packages/drawer/src/scss/_drawer_switch.scss
+++ b/packages/drawer/src/scss/_drawer_switch.scss
@@ -38,15 +38,15 @@
  * Drawer main margins
  */
 
-// IS .drawer NOT .drawer_modal .drawer_switch
-#{core.bem("drawer")}:not(#{core.bem("drawer", null, "modal")}, #{core.bem("drawer", null, "switch")}) {
+// IS .drawer NOT .drawer_switch OR .drawer_modal
+#{core.bem("drawer")}:not(#{core.bem("drawer", null, "switch")}, #{core.bem("drawer", null, "modal")}) {
   &.is-opening ~ #{core.bem(var.$class-main)},
   &.is-opened ~ #{core.bem(var.$class-main)} {
     margin-left: css.get("drawer", "width", var.$width);
   }
 }
 
-// IS .drawer .drawer_switch NOT .drawer_modal
+// IS .drawer AND .drawer_switch NOT .drawer_modal
 #{core.bem("drawer")}#{core.bem("drawer", null, "switch")}:not(#{core.bem("drawer", null, "modal")}) {
   &.is-opening ~ #{core.bem(var.$class-main)},
   &.is-opened ~ #{core.bem(var.$class-main)} {

--- a/packages/drawer/src/scss/_drawer_switch.scss
+++ b/packages/drawer/src/scss/_drawer_switch.scss
@@ -9,6 +9,10 @@
 #{core.bem("drawer")} {
   left: 0;
   transform: translateX(-100%);
+
+  &:not(#{core.bem("drawer", null, "switch")}) #{core.bem("drawer", "dialog")} {
+    border-left: none;
+  }
 }
 
 #{core.bem("drawer")}.is-opening,
@@ -28,6 +32,10 @@
   right: 0;
   left: auto;
   transform: translateX(100%);
+
+  #{core.bem("drawer", "dialog")} {
+    border-right: none;
+  }
 }
 
 #{core.bem("drawer", null, "switch")}.is-closing {

--- a/packages/drawer/src/scss/_drawer_switch.scss
+++ b/packages/drawer/src/scss/_drawer_switch.scss
@@ -9,10 +9,6 @@
 #{core.bem("drawer")} {
   left: 0;
   transform: translateX(-100%);
-
-  #{core.bem("drawer", "dialog")} {
-    border-right: css.get("drawer", "border", var.$border);
-  }
 }
 
 #{core.bem("drawer")}.is-opening,
@@ -32,11 +28,6 @@
   right: 0;
   left: auto;
   transform: translateX(100%);
-
-  #{core.bem("drawer", "dialog")} {
-    border-right: none;
-    border-left: css.get("drawer", "border", var.$border);
-  }
 }
 
 #{core.bem("drawer", null, "switch")}.is-closing {

--- a/packages/drawer/src/scss/_variables.scss
+++ b/packages/drawer/src/scss/_variables.scss
@@ -9,24 +9,11 @@ $class-main: "drawer-main" !default;
 
 $frame-height: 100vh !default;
 
+$z-index: 900 !default;
 $width: 18em !default;
-$max-width: 100% !default;
-$background: css.get("background-darker") !default;
-$foreground: css.get("foreground") !default;
-$border: none !default;
-$sep-border-color: css.get("border-color") !default;
-$box-shadow: none !default;
+$max-width: 80% !default;
 $transition-duration: css.get("transition-duration") !default;
 $transition-timing-function: css.get("transition-timing-function") !default;
-
-$modal-z-index: 900 !default;
-$modal-width: $width !default;
-$modal-max-width: 80% !default;
-$modal-background: css.get("background") !default;
-$modal-foreground: css.get("foreground") !default;
-$modal-border: none !default;
-$modal-sep-border-color: css.get("border-color") !default;
-$modal-box-shadow: css.get("box-shadow-5") !default;
 
 @include css.set("drawer", (
   "transition-duration": $transition-duration,

--- a/packages/drawer/src/scss/_variables.scss
+++ b/packages/drawer/src/scss/_variables.scss
@@ -12,8 +12,8 @@ $frame-height: 100vh !default;
 $z-index: 900 !default;
 $width: 18em !default;
 $max-width: 80% !default;
-$transition-duration: css.get("transition-duration") !default;
-$transition-timing-function: css.get("transition-timing-function") !default;
+$transition-duration: css.get("dialog", "transition-duration", css.get("transition-duration")) !default;
+$transition-timing-function: css.get("dialog", "transition-timing-function", css.get("transition-timing-function")) !default;
 
 @include css.set("drawer", (
   "transition-duration": $transition-duration,

--- a/packages/drawer/src/scss/_variables.scss
+++ b/packages/drawer/src/scss/_variables.scss
@@ -31,6 +31,7 @@ $inline-dialog-override: (
 
 // Only applies to modal drawer dialogs.
 $modal-dialog-override: () !default;
+$modal-z-index: 950 !default;
 
 @include css.set("drawer", (
   "transition-duration": $transition-duration,

--- a/packages/drawer/src/scss/_variables.scss
+++ b/packages/drawer/src/scss/_variables.scss
@@ -18,18 +18,19 @@ $max-width: 80% !default;
 $transition-duration: css.get("dialog", "transition-duration", css.get("transition-duration")) !default;
 $transition-timing-function: css.get("dialog", "transition-timing-function", css.get("transition-timing-function")) !default;
 
-// TODO: Maybe provide an "override" map with the properties to override dialog
-// custom properties with? e.g: background, foreground, border and box-shadow.
-$dialog-overrides: (
-  "background": null,
-  "foreground": null,
-  "border": null,
-  "border-radius": null,
-  "sep-border": null,
-  "box-shadow": null
+// Dialog override map
+// This is used to override `dialog` custom properties.
+// Applies to both inline and modal drawer dialogs.
+$dialog-override: () !default;
+
+// Only applies to inline drawer dialogs.
+$inline-dialog-override: (
+  "background": css.get("background-darker"),
+  "box-shadow": none
 ) !default;
 
-// TODO: Maybe provide an override method for specific modes (modal and inline).
+// Only applies to modal drawer dialogs.
+$modal-dialog-override: () !default;
 
 @include css.set("drawer", (
   "transition-duration": $transition-duration,

--- a/packages/drawer/src/scss/_variables.scss
+++ b/packages/drawer/src/scss/_variables.scss
@@ -31,8 +31,11 @@ $inline-dialog-override: (
 
 // Only applies to modal drawer dialogs.
 $modal-dialog-override: () !default;
+
+// drawer_modal
 $modal-z-index: 950 !default;
 
+// Custom properties
 @include css.set("drawer", (
   "transition-duration": $transition-duration,
   "transition-timing-function": $transition-timing-function

--- a/packages/drawer/src/scss/_variables.scss
+++ b/packages/drawer/src/scss/_variables.scss
@@ -4,6 +4,9 @@
 @use "@vrembem/core/css";
 @use "@vrembem/core/palette";
 
+// Register the dialog component since we will be providing overrides.
+@include css.register("dialog");
+
 $class-frame: "drawer-frame" !default;
 $class-main: "drawer-main" !default;
 
@@ -14,6 +17,19 @@ $width: 18em !default;
 $max-width: 80% !default;
 $transition-duration: css.get("dialog", "transition-duration", css.get("transition-duration")) !default;
 $transition-timing-function: css.get("dialog", "transition-timing-function", css.get("transition-timing-function")) !default;
+
+// TODO: Maybe provide an "override" map with the properties to override dialog
+// custom properties with? e.g: background, foreground, border and box-shadow.
+$dialog-overrides: (
+  "background": null,
+  "foreground": null,
+  "border": null,
+  "border-radius": null,
+  "sep-border": null,
+  "box-shadow": null
+) !default;
+
+// TODO: Maybe provide an override method for specific modes (modal and inline).
 
 @include css.set("drawer", (
   "transition-duration": $transition-duration,

--- a/packages/drawer/src/scss/_variables.scss
+++ b/packages/drawer/src/scss/_variables.scss
@@ -25,7 +25,7 @@ $modal-max-width: 80% !default;
 $modal-background: css.get("background") !default;
 $modal-foreground: css.get("foreground") !default;
 $modal-border: none !default;
-$modal-sep-border-color: null !default;
+$modal-sep-border-color: css.get("border-color") !default;
 $modal-box-shadow: css.get("box-shadow-5") !default;
 $modal-screen-background: palette.get("neutral", 10) !default;
 $modal-screen-opacity: 0.8 !default;

--- a/packages/drawer/src/scss/_variables.scss
+++ b/packages/drawer/src/scss/_variables.scss
@@ -27,8 +27,6 @@ $modal-foreground: css.get("foreground") !default;
 $modal-border: none !default;
 $modal-sep-border-color: css.get("border-color") !default;
 $modal-box-shadow: css.get("box-shadow-5") !default;
-$modal-screen-background: palette.get("neutral", 10) !default;
-$modal-screen-opacity: 0.8 !default;
 
 @include css.set("drawer", (
   "transition-duration": $transition-duration,

--- a/packages/modal/src/scss/_modal.scss
+++ b/packages/modal/src/scss/_modal.scss
@@ -37,9 +37,8 @@
   max-width: css.get("modal", "max-width", var.$max-width);
   overflow: auto;
   transform: translateY(calc(css.get("modal", "travel", var.$travel) * -1));
-  transition-property: outline;
-  transition-duration: css.get("modal", "transition-duration");
-  transition-timing-function: css.get("modal", "transition-timing-function");
+  transition-duration: css.get("modal", "transition-duration", var.$transition-duration);
+  transition-timing-function: css.get("modal", "transition-timing-function", var.$transition-timing-function);
   opacity: 0;
 }
 

--- a/packages/modal/src/scss/_modal.scss
+++ b/packages/modal/src/scss/_modal.scss
@@ -33,6 +33,7 @@
 }
 
 #{core.bem("modal", "dialog")} {
+  @include css.override("dialog", var.$dialog-overrides);
   width: css.get("modal", "width", var.$width);
   max-width: css.get("modal", "max-width", var.$max-width);
   overflow: auto;

--- a/packages/modal/src/scss/_modal.scss
+++ b/packages/modal/src/scss/_modal.scss
@@ -40,7 +40,6 @@
   transition-property: outline;
   transition-duration: css.get("modal", "transition-duration");
   transition-timing-function: css.get("modal", "transition-timing-function");
-  box-shadow: css.get("modal", "shadow", var.$shadow);
   opacity: 0;
 }
 

--- a/packages/modal/src/scss/_modal.scss
+++ b/packages/modal/src/scss/_modal.scss
@@ -27,13 +27,12 @@
     inset: 0;
     width: 100%;
     height: 100%;
-    background-color: css.get("modal", "screen-background", var.$screen-background);
+    background-color: css.get("modal", "screen-background", core.$screen-background);
     opacity: 0;
   }
 }
 
 #{core.bem("modal", "dialog")} {
-  @include core.focus-ring-base();
   width: css.get("modal", "width", var.$width);
   max-width: css.get("modal", "max-width", var.$max-width);
   overflow: auto;
@@ -43,14 +42,6 @@
   transition-timing-function: css.get("modal", "transition-timing-function");
   box-shadow: css.get("modal", "shadow", var.$shadow);
   opacity: 0;
-
-  &:focus-visible {
-    @include core.focus-ring("modal", var.$focus-ring-color, var.$focus-ring-opacity);
-  }
-
-  &[role="alertdialog"]:focus {
-    @include core.focus-ring("modal", var.$focus-ring-color-alert, var.$focus-ring-opacity);
-  }
 }
 
 /**
@@ -67,7 +58,7 @@
   visibility: visible;
   width: 100%;
   height: 100%;
-  padding: css.get("modal", "screen-padding", var.$screen-padding);
+  padding: css.get("modal", "screen-padding", core.$screen-padding);
 }
 
 #{core.bem("modal")}.is-opening,
@@ -86,7 +77,7 @@
 #{core.bem("modal")}.is-opening,
 #{core.bem("modal")}.is-opened {
   &::before {
-    opacity: css.get("modal", "screen-opacity", var.$screen-opacity);
+    opacity: css.get("modal", "screen-opacity", core.$screen-opacity);
   }
 
   #{core.bem("modal", "dialog")} {

--- a/packages/modal/src/scss/_modal.scss
+++ b/packages/modal/src/scss/_modal.scss
@@ -27,7 +27,7 @@
     inset: 0;
     width: 100%;
     height: 100%;
-    background-color: css.get("modal", "screen-background", core.$screen-background);
+    background-color: css.get("modal", "screen-color", core.$screen-color);
     opacity: 0;
   }
 }

--- a/packages/modal/src/scss/_modal.scss
+++ b/packages/modal/src/scss/_modal.scss
@@ -33,7 +33,7 @@
 }
 
 #{core.bem("modal", "dialog")} {
-  @include css.override("dialog", var.$dialog-overrides);
+  @include css.override("dialog", var.$dialog-override);
   width: css.get("modal", "width", var.$width);
   max-width: css.get("modal", "max-width", var.$max-width);
   overflow: auto;

--- a/packages/modal/src/scss/_variables.scss
+++ b/packages/modal/src/scss/_variables.scss
@@ -34,6 +34,7 @@ $size-scale: (
   "xl": 60em  // 960px
 ) !default;
 
+// Custom properties
 @include css.set("modal", (
   "transition-duration": $transition-duration,
   "transition-timing-function": $transition-timing-function

--- a/packages/modal/src/scss/_variables.scss
+++ b/packages/modal/src/scss/_variables.scss
@@ -8,8 +8,8 @@ $z-index: 1000 !default;
 $width: 36em !default;
 $max-width: 100% !default;
 $travel: 5em !default;
-$transition-duration: css.get("transition-duration") !default;
-$transition-timing-function: css.get("transition-timing-function") !default;
+$transition-duration: css.get("dialog", "transition-duration", css.get("transition-duration")) !default;
+$transition-timing-function: css.get("dialog", "transition-timing-function", css.get("transition-timing-function")) !default;
 
 // modal_pos_[value]
 $aside-width: 16em !default;

--- a/packages/modal/src/scss/_variables.scss
+++ b/packages/modal/src/scss/_variables.scss
@@ -4,12 +4,26 @@
 @use "@vrembem/core/css";
 @use "@vrembem/core/palette";
 
+// Register the dialog component since we will be providing overrides.
+@include css.register("dialog");
+
 $z-index: 1000 !default;
 $width: 36em !default;
 $max-width: 100% !default;
 $travel: 5em !default;
 $transition-duration: css.get("dialog", "transition-duration", css.get("transition-duration")) !default;
 $transition-timing-function: css.get("dialog", "transition-timing-function", css.get("transition-timing-function")) !default;
+
+// TODO: Maybe provide an "override" map with the properties to override dialog
+// custom properties with? e.g: background, foreground, border and box-shadow.
+$dialog-overrides: (
+  "background": null,
+  "foreground": null,
+  "border": null,
+  "border-radius": null,
+  "sep-border": null,
+  "box-shadow": null
+) !default;
 
 // modal_pos_[value]
 $aside-width: 16em !default;

--- a/packages/modal/src/scss/_variables.scss
+++ b/packages/modal/src/scss/_variables.scss
@@ -4,7 +4,7 @@
 @use "@vrembem/core/css";
 @use "@vrembem/core/palette";
 
-// Register the dialog component since we will be providing overrides.
+// Register the dialog component for overrides later.
 @include css.register("dialog");
 
 $z-index: 1000 !default;
@@ -14,16 +14,9 @@ $travel: 5em !default;
 $transition-duration: css.get("dialog", "transition-duration", css.get("transition-duration")) !default;
 $transition-timing-function: css.get("dialog", "transition-timing-function", css.get("transition-timing-function")) !default;
 
-// TODO: Maybe provide an "override" map with the properties to override dialog
-// custom properties with? e.g: background, foreground, border and box-shadow.
-$dialog-overrides: (
-  "background": null,
-  "foreground": null,
-  "border": null,
-  "border-radius": null,
-  "sep-border": null,
-  "box-shadow": null
-) !default;
+// Dialog override map
+// This is used to override `dialog` custom properties.
+$dialog-override: () !default;
 
 // modal_pos_[value]
 $aside-width: 16em !default;

--- a/packages/modal/src/scss/_variables.scss
+++ b/packages/modal/src/scss/_variables.scss
@@ -10,7 +10,6 @@ $max-width: 100% !default;
 $travel: 5em !default;
 $transition-duration: css.get("transition-duration") !default;
 $transition-timing-function: css.get("transition-timing-function") !default;
-$shadow: css.get("box-shadow-5") !default;
 
 // modal_pos_[value]
 $aside-width: 16em !default;

--- a/packages/modal/src/scss/_variables.scss
+++ b/packages/modal/src/scss/_variables.scss
@@ -12,14 +12,6 @@ $transition-duration: css.get("transition-duration") !default;
 $transition-timing-function: css.get("transition-timing-function") !default;
 $shadow: css.get("box-shadow-5") !default;
 
-$screen-background: palette.get("neutral", 10) !default;
-$screen-opacity: 0.8 !default;
-$screen-padding: 1em !default;
-
-$focus-ring-color: palette.get("primary") !default;
-$focus-ring-color-alert: palette.get("important") !default;
-$focus-ring-opacity: 1 !default;
-
 // modal_pos_[value]
 $aside-width: 16em !default;
 $aside-max-width: 90% !default;

--- a/packages/vrembem/index.html
+++ b/packages/vrembem/index.html
@@ -185,23 +185,6 @@
           </li>
         </ul>
 
-        <div id="modal-dialog" class="modal">
-          <div class="modal__dialog dialog" role="dialog" aria-modal="true" aria-labelledby="modal-dialog-title" aria-describedby="modal-dialog-description">
-            <div class="dialog__header">
-              <h2 class="dialog__title" id="modal-dialog-title">Modal title</h2>
-              <button data-modal-close class="button button_icon button_size_sm">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon_size_sm" role="img"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
-              </button>
-            </div>
-            <div class="dialog__body">
-              <p id="modal-dialog-description">...</p>
-            </div>
-            <div class="dialog__footer">
-              ...
-            </div>
-          </div>
-        </div><!-- .modal -->
-
         <!-- Form Controls (SM) -->
 
         <div class="flex align-items-center">
@@ -380,6 +363,27 @@
 
   </div><!-- .drawer-main -->
 </div><!-- .drawer-frame -->
+
+<div class="modals">
+  
+  <div id="modal-dialog" class="modal">
+    <div class="modal__dialog dialog" role="dialog" aria-modal="true" aria-labelledby="modal-dialog-title" aria-describedby="modal-dialog-description">
+      <div class="dialog__header">
+        <h2 class="dialog__title" id="modal-dialog-title">Modal title</h2>
+        <button data-modal-close class="button button_icon button_size_sm">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon_size_sm" role="img"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+        </button>
+      </div>
+      <div class="dialog__body">
+        <p id="modal-dialog-description">...</p>
+      </div>
+      <div class="dialog__footer">
+        ...
+      </div>
+    </div>
+  </div><!-- .modal -->
+
+</div><!-- .modals -->
 
 </body>
 </html>

--- a/packages/vrembem/index.html
+++ b/packages/vrembem/index.html
@@ -53,228 +53,333 @@
     // Attach themeStore to window for testing purposes. 
     window["themeStore"] = themeStore;
     console.log("themeStore", themeStore);
+
+    /**
+     * Initialize Vrembem components
+     */
+    
+    const modal = await new vb.Modal({ autoMount: true });
+    const drawer = await new vb.Drawer({ autoMount: true });
+
+    window["modal"] = modal;
+    window["drawer"] = drawer;
+
+    // Toggle drawer mode using toggle switch.
+    const drawerEntry = drawer.get("drawer-dialog");
+    const input = document.getElementById("drawer-modal-mode-switch");
+    drawerEntry.mode = (input.checked) ? "modal" : "inline";
+    input.addEventListener("change", () => {
+      drawerEntry.mode = (input.checked) ? "modal" : "inline";
+    });
+
   </script>
 </head>
 <body>
 
-  <header class="section background-dark">
-    <div class="section__container max-width-xs spacing-sm">
-      <h1 class="text-size-lg">%VITE_NAME%</h1>
-      <p class="foreground-light">%VITE_DESCRIPTION%</p>
-      <ol class="foreground-lighter flex flex_gap flex_gap-y_sm margin-top-lg list-style-none">
-        <li class="flex flex_gap_sm align-items-center">
-          <svg class="icon icon_size_sm" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path></svg>
-          <a class="link" target="_blank" href="https://github.com/sebnitu/vrembem">%VITE_NAME%</a>
-        </li>
-        <li class="foreground-neutral-80">/</li>
-        <li class="flex flex_gap_sm align-items-center">
-          <svg class="icon icon_size_sm" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
-          <a class="link" target="_blank" href="https://github.com/sebnitu/vrembem/tree/main/packages/%VITE_NAME%#readme">%VITE_NAME%</a>
-        </li>
-      </ol>
+<div class="drawer-frame">
+
+  <aside id="drawer-dialog" class="drawer">
+    <div class="drawer__dialog dialog" role="dialog" aria-labelledby="drawer-dialog-title" aria-describedby="drawer-dialog-description">
+      <div class="dialog__header">
+        <h2 class="dialog__title" id="drawer-dialog-title">Drawer title</h2>
+        <button data-drawer-close class="button button_icon button_size_sm">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon_size_sm" role="img"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+        </button>
+      </div>
+      <div class="dialog__body">
+        <p id="drawer-dialog-description">...</p>
+      </div>
+      <div class="dialog__footer">
+        ...
+      </div>
     </div>
-  </header>
+  </aside><!-- .drawer -->
 
-  <aside class="section section_size_sm background-darker">
-    <div class="section__container max-width-xs">
-      <ul class="menu menu_inline menu_themes">
-        <li class="menu__item">
-          <span class="padding-right font-weight-bold">Themes</span>
-        </li>
-        <li class="menu__sep"></li>
-        <li class="menu__item">
-          <button type="button" data-set-theme="root" class="menu__action">
-            <span>Auto</span>
-          </button>
-        </li>
-        <li class="menu__item">
-          <button type="button" data-set-theme="light" class="menu__action">
-            <span>Light</span>
-          </button>
-        </li>
-        <li class="menu__item">
-          <button type="button" data-set-theme="dark" class="menu__action">
-            <span>Dark</span>
-          </button>
-        </li>
-      </ul>
-    </div>
-  </aside>
+  <div class="drawer-main">
 
-  <section class="section">
-    <div class="section__container max-width-xs spacing-xl">
+    <header class="section background-dark">
+      <div class="section__container max-width-xs spacing-sm">
+        <h1 class="text-size-lg">%VITE_NAME%</h1>
+        <p class="foreground-light">%VITE_DESCRIPTION%</p>
+        <ol class="foreground-lighter flex flex_gap flex_gap-y_sm margin-top-lg list-style-none">
+          <li class="flex flex_gap_sm align-items-center">
+            <svg class="icon icon_size_sm" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path></svg>
+            <a class="link" target="_blank" href="https://github.com/sebnitu/vrembem">%VITE_NAME%</a>
+          </li>
+          <li class="foreground-neutral-80">/</li>
+          <li class="flex flex_gap_sm align-items-center">
+            <svg class="icon icon_size_sm" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
+            <a class="link" target="_blank" href="https://github.com/sebnitu/vrembem/tree/main/packages/%VITE_NAME%#readme">%VITE_NAME%</a>
+          </li>
+        </ol>
+      </div>
+    </header><!-- .section -->
 
-      <!-- form-controls sm -->
-      <div class="flex align-items-center">
-        <label class="font-size-sm flex-full">Form control label</label>
-        <input class="input input_auto input_size_sm" type="text" value="35" />
-        <select class="input input_auto input_type_select input_size_sm">
-          <option>1. One</option>
-          <option>2. Two</option>
-          <option>3. Three</option>
-        </select>
-        <button class="button button_size_sm">Button</button>
-        <ul class="menu menu_inline menu_size_sm">
+    <aside class="section section_size_sm background-darker">
+      <div class="section__container max-width-xs">
+        <ul class="menu menu_inline menu_themes">
           <li class="menu__item">
-            <a class="menu__action" href="#">Menu Item</a>
+            <span class="padding-right font-weight-bold">Themes</span>
+          </li>
+          <li class="menu__sep"></li>
+          <li class="menu__item">
+            <button type="button" data-set-theme="root" class="menu__action">
+              <span>Auto</span>
+            </button>
+          </li>
+          <li class="menu__item">
+            <button type="button" data-set-theme="light" class="menu__action">
+              <span>Light</span>
+            </button>
+          </li>
+          <li class="menu__item">
+            <button type="button" data-set-theme="dark" class="menu__action">
+              <span>Dark</span>
+            </button>
           </li>
         </ul>
-        <span class="checkbox checkbox_size_sm">
-          <input class="checkbox__native" type="checkbox" checked />
-          <span class="checkbox__background">
-            <span class="checkbox__box">
-              <span class="checkbox__icon"></span>
-            </span>
-          </span>
-        </span>
-        <span class="radio radio_size_sm">
-          <input type="radio" class="radio__native" name="example-3" checked />
-          <span class="radio__background">
-            <span class="radio__circle">
-              <span class="radio__dot"></span>
-            </span>
-          </span>
-        </span>
-        <span class="radio radio_size_sm">
-          <input type="radio" class="radio__native" name="example-3" />
-          <span class="radio__background">
-            <span class="radio__circle">
-              <span class="radio__dot"></span>
-            </span>
-          </span>
-        </span>
-        <span class="switch switch_size_sm">
-          <input type="checkbox" class="switch__native" />
-          <span class="switch__background">
-            <span class="switch__track">
-              <span class="switch__thumb"></span>
-            </span>
-          </span>
-        </span>
-        <textarea class="input input_type_textarea input_size_sm"></textarea>
       </div>
+    </aside><!-- .section -->
 
-      <!-- form-controls -->
-      <div class="flex align-items-center">
-        <label class="flex-full">Form control label</label>
-        <input class="input input_auto" type="text" value="40" />
-        <select class="input input_auto input_type_select">
-          <option>1. One</option>
-          <option>2. Two</option>
-          <option>3. Three</option>
-        </select>
-        <button class="button">Button</button>
-        <ul class="menu menu_inline">
-          <li class="menu__item">
-            <a class="menu__action" href="#">Menu Item</a>
+    <section class="section">
+      <div class="section__container max-width-xs spacing-xl">
+
+        <!-- Dialog, Modal and Drawer -->
+
+        <div class="dialog" role="dialog" aria-labelledby="dialog-title" aria-describedby="dialog-description">
+          <div class="dialog__header">
+            <h2 class="dialog__title" id="dialog-title">Dialog title</h2>
+            <button class="button button_icon button_size_sm">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon_size_sm" role="img"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+            </button>
+          </div>
+          <div class="dialog__body">
+            <p id="dialog-description">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed libero nulla, suscipit consectetur lectus eu, rhoncus eleifend erat. Suspendisse neque dui, ornare non molestie in, rhoncus id lectus.</p>
+          </div>
+          <div class="dialog__footer">
+            <button class="button button_color_primary">Submit</button>
+            <button class="button">Cancel</button>
+          </div>
+        </div><!-- .dialog -->
+
+        <ul class="list">
+          <li>
+            <button class="link" data-modal-open="modal-dialog">Modal dialog</button>
+          </li>
+          <li>
+            <div class="flex align-items-center">
+              <button class="link" data-drawer-toggle="drawer-dialog">Drawer dialog</button>
+              <div class="flex flex_gap_sm align-items-center">
+                <span>Inline</span>
+                <span class="switch switch_size_sm">
+                  <input id="drawer-modal-mode-switch" type="checkbox" class="switch__native" name="drawer-modal-mode" checked>
+                  <span class="switch__background">
+                    <span class="switch__track">
+                      <span class="switch__thumb"></span>
+                    </span>
+                  </span>
+                </span>
+                <span>Modal</span>
+              </div>
+            </div>
           </li>
         </ul>
-        <span class="checkbox">
-          <input class="checkbox__native" type="checkbox" checked />
-          <span class="checkbox__background">
-            <span class="checkbox__box">
-              <span class="checkbox__icon"></span>
-            </span>
-          </span>
-        </span>
-        <span class="radio">
-          <input type="radio" class="radio__native" name="example-4" checked />
-          <span class="radio__background">
-            <span class="radio__circle">
-              <span class="radio__dot"></span>
-            </span>
-          </span>
-        </span>
-        <span class="radio">
-          <input type="radio" class="radio__native" name="example-4" />
-          <span class="radio__background">
-            <span class="radio__circle">
-              <span class="radio__dot"></span>
-            </span>
-          </span>
-        </span>
-        <span class="switch">
-          <input type="checkbox" class="switch__native" />
-          <span class="switch__background">
-            <span class="switch__track">
-              <span class="switch__thumb"></span>
-            </span>
-          </span>
-        </span>
-        <textarea class="input input_type_textarea"></textarea>
-      </div>
 
-      <!-- form-controls lg -->
-      <div class="flex align-items-center">
-        <label class="font-size-lg flex-full">Form control label</label>
-        <input class="input input_auto input_size_lg" type="text" value="45" />
-        <select class="input input_auto input_type_select input_size_lg">
-          <option>1. One</option>
-          <option>2. Two</option>
-          <option>3. Three</option>
-        </select>
-        <button class="button button_size_lg">Button</button>
-        <ul class="menu menu_inline menu_size_lg">
-          <li class="menu__item">
-            <a class="menu__action" href="#">Menu Item</a>
-          </li>
-        </ul>
-        <span class="checkbox checkbox_size_lg">
-          <input class="checkbox__native" type="checkbox" checked />
-          <span class="checkbox__background">
-            <span class="checkbox__box">
-              <span class="checkbox__icon"></span>
-            </span>
-          </span>
-        </span>
-        <span class="radio radio_size_lg">
-          <input type="radio" class="radio__native" name="example-5" checked />
-          <span class="radio__background">
-            <span class="radio__circle">
-              <span class="radio__dot"></span>
-            </span>
-          </span>
-        </span>
-        <span class="radio radio_size_lg">
-          <input type="radio" class="radio__native" name="example-5" />
-          <span class="radio__background">
-            <span class="radio__circle">
-              <span class="radio__dot"></span>
-            </span>
-          </span>
-        </span>
-        <span class="switch switch_size_lg">
-          <input type="checkbox" class="switch__native" />
-          <span class="switch__background">
-            <span class="switch__track">
-              <span class="switch__thumb"></span>
-            </span>
-          </span>
-        </span>
-        <textarea class="input input_type_textarea input_size_lg"></textarea>
-      </div>
+        <div id="modal-dialog" class="modal">
+          <div class="modal__dialog dialog" role="dialog" aria-modal="true" aria-labelledby="modal-dialog-title" aria-describedby="modal-dialog-description">
+            <div class="dialog__header">
+              <h2 class="dialog__title" id="modal-dialog-title">Modal title</h2>
+              <button data-modal-close class="button button_icon button_size_sm">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon_size_sm" role="img"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+              </button>
+            </div>
+            <div class="dialog__body">
+              <p id="modal-dialog-description">...</p>
+            </div>
+            <div class="dialog__footer">
+              ...
+            </div>
+          </div>
+        </div><!-- .modal -->
 
-      <!-- Typography -->
-      <div class="flex align-items-center">
-        <p class="font-size-sm">This is some text.</p>
-        <p>This is some text.</p>
-        <p class="font-size-lg">This is some text.</p>
-      </div>
-      
-      <div class="spacing">
-        <p class="font-size-sm">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eget urna in justo consectetur suscipit cursus vel lectus. Sed semper elementum semper. Etiam eget venenatis orci. Morbi hendrerit magna sed purus porta dictum. In accumsan, leo et ultrices auctor, felis augue blandit arcu, a consequat nunc nisi vel lorem.
-        </p>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eget urna in justo consectetur suscipit cursus vel lectus. Sed semper elementum semper. Etiam eget venenatis orci. Morbi hendrerit magna sed purus porta dictum. In accumsan, leo et ultrices auctor, felis augue blandit arcu, a consequat nunc nisi vel lorem.
-        </p>
-        <p class="font-size-lg">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eget urna in justo consectetur suscipit cursus vel lectus. Sed semper elementum semper. Etiam eget venenatis orci. Morbi hendrerit magna sed purus porta dictum. In accumsan, leo et ultrices auctor, felis augue blandit arcu, a consequat nunc nisi vel lorem.
-        </p>
-      </div>
+        <!-- Form Controls (SM) -->
 
-    </div>
-  </section>
+        <div class="flex align-items-center">
+          <label class="font-size-sm flex-full">Form control label</label>
+          <input class="input input_auto input_size_sm" type="text" value="35" />
+          <select class="input input_auto input_type_select input_size_sm">
+            <option>1. One</option>
+            <option>2. Two</option>
+            <option>3. Three</option>
+          </select>
+          <button class="button button_size_sm">Button</button>
+          <ul class="menu menu_inline menu_size_sm">
+            <li class="menu__item">
+              <a class="menu__action" href="#">Menu Item</a>
+            </li>
+          </ul>
+          <span class="checkbox checkbox_size_sm">
+            <input class="checkbox__native" type="checkbox" checked />
+            <span class="checkbox__background">
+              <span class="checkbox__box">
+                <span class="checkbox__icon"></span>
+              </span>
+            </span>
+          </span>
+          <span class="radio radio_size_sm">
+            <input type="radio" class="radio__native" name="example-3" checked />
+            <span class="radio__background">
+              <span class="radio__circle">
+                <span class="radio__dot"></span>
+              </span>
+            </span>
+          </span>
+          <span class="radio radio_size_sm">
+            <input type="radio" class="radio__native" name="example-3" />
+            <span class="radio__background">
+              <span class="radio__circle">
+                <span class="radio__dot"></span>
+              </span>
+            </span>
+          </span>
+          <span class="switch switch_size_sm">
+            <input type="checkbox" class="switch__native" />
+            <span class="switch__background">
+              <span class="switch__track">
+                <span class="switch__thumb"></span>
+              </span>
+            </span>
+          </span>
+          <textarea class="input input_type_textarea input_size_sm"></textarea>
+        </div>
+
+        <!-- Form Controls -->
+
+        <div class="flex align-items-center">
+          <label class="flex-full">Form control label</label>
+          <input class="input input_auto" type="text" value="40" />
+          <select class="input input_auto input_type_select">
+            <option>1. One</option>
+            <option>2. Two</option>
+            <option>3. Three</option>
+          </select>
+          <button class="button">Button</button>
+          <ul class="menu menu_inline">
+            <li class="menu__item">
+              <a class="menu__action" href="#">Menu Item</a>
+            </li>
+          </ul>
+          <span class="checkbox">
+            <input class="checkbox__native" type="checkbox" checked />
+            <span class="checkbox__background">
+              <span class="checkbox__box">
+                <span class="checkbox__icon"></span>
+              </span>
+            </span>
+          </span>
+          <span class="radio">
+            <input type="radio" class="radio__native" name="example-4" checked />
+            <span class="radio__background">
+              <span class="radio__circle">
+                <span class="radio__dot"></span>
+              </span>
+            </span>
+          </span>
+          <span class="radio">
+            <input type="radio" class="radio__native" name="example-4" />
+            <span class="radio__background">
+              <span class="radio__circle">
+                <span class="radio__dot"></span>
+              </span>
+            </span>
+          </span>
+          <span class="switch">
+            <input type="checkbox" class="switch__native" />
+            <span class="switch__background">
+              <span class="switch__track">
+                <span class="switch__thumb"></span>
+              </span>
+            </span>
+          </span>
+          <textarea class="input input_type_textarea"></textarea>
+        </div>
+
+        <!-- Form Controls (LG) -->
+
+        <div class="flex align-items-center">
+          <label class="font-size-lg flex-full">Form control label</label>
+          <input class="input input_auto input_size_lg" type="text" value="45" />
+          <select class="input input_auto input_type_select input_size_lg">
+            <option>1. One</option>
+            <option>2. Two</option>
+            <option>3. Three</option>
+          </select>
+          <button class="button button_size_lg">Button</button>
+          <ul class="menu menu_inline menu_size_lg">
+            <li class="menu__item">
+              <a class="menu__action" href="#">Menu Item</a>
+            </li>
+          </ul>
+          <span class="checkbox checkbox_size_lg">
+            <input class="checkbox__native" type="checkbox" checked />
+            <span class="checkbox__background">
+              <span class="checkbox__box">
+                <span class="checkbox__icon"></span>
+              </span>
+            </span>
+          </span>
+          <span class="radio radio_size_lg">
+            <input type="radio" class="radio__native" name="example-5" checked />
+            <span class="radio__background">
+              <span class="radio__circle">
+                <span class="radio__dot"></span>
+              </span>
+            </span>
+          </span>
+          <span class="radio radio_size_lg">
+            <input type="radio" class="radio__native" name="example-5" />
+            <span class="radio__background">
+              <span class="radio__circle">
+                <span class="radio__dot"></span>
+              </span>
+            </span>
+          </span>
+          <span class="switch switch_size_lg">
+            <input type="checkbox" class="switch__native" />
+            <span class="switch__background">
+              <span class="switch__track">
+                <span class="switch__thumb"></span>
+              </span>
+            </span>
+          </span>
+          <textarea class="input input_type_textarea input_size_lg"></textarea>
+        </div>
+
+        <!-- Typography -->
+
+        <div class="flex align-items-center">
+          <p class="font-size-sm">This is some text.</p>
+          <p>This is some text.</p>
+          <p class="font-size-lg">This is some text.</p>
+        </div>
+        
+        <div class="spacing">
+          <p class="font-size-sm">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eget urna in justo consectetur suscipit cursus vel lectus. Sed semper elementum semper. Etiam eget venenatis orci. Morbi hendrerit magna sed purus porta dictum. In accumsan, leo et ultrices auctor, felis augue blandit arcu, a consequat nunc nisi vel lorem.
+          </p>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eget urna in justo consectetur suscipit cursus vel lectus. Sed semper elementum semper. Etiam eget venenatis orci. Morbi hendrerit magna sed purus porta dictum. In accumsan, leo et ultrices auctor, felis augue blandit arcu, a consequat nunc nisi vel lorem.
+          </p>
+          <p class="font-size-lg">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eget urna in justo consectetur suscipit cursus vel lectus. Sed semper elementum semper. Etiam eget venenatis orci. Morbi hendrerit magna sed purus porta dictum. In accumsan, leo et ultrices auctor, felis augue blandit arcu, a consequat nunc nisi vel lorem.
+          </p>
+        </div>
+
+      </div>
+    </section><!-- .section -->
+
+  </div><!-- .drawer-main -->
+</div><!-- .drawer-frame -->
 
 </body>
 </html>

--- a/packages/vrembem/index.html
+++ b/packages/vrembem/index.html
@@ -64,13 +64,25 @@
     window["modal"] = modal;
     window["drawer"] = drawer;
 
-    // Toggle drawer mode using toggle switch.
+    // Get the drawer entry and drawer from.
     const drawerEntry = drawer.get("drawer-dialog");
-    const input = document.getElementById("drawer-modal-mode-switch");
-    drawerEntry.mode = (input.checked) ? "modal" : "inline";
-    input.addEventListener("change", () => {
-      drawerEntry.mode = (input.checked) ? "modal" : "inline";
-    });
+    const drawerForm = document.getElementById("form-drawer-state");
+
+    // Function to handle the form data of drawer state form.
+    function updateDrawerState() {
+      // Get the form data.
+      const formData = new FormData(drawerForm);
+      // Update the drawer mode state.
+      drawerEntry.mode = (formData.get("toggle-drawer-modal")) ? "modal" : "inline";
+      // Update the drawer switch state.
+      (formData.get("toggle-drawer-switch")) ?
+        drawerEntry.el.classList.add("drawer_switch"):
+        drawerEntry.el.classList.remove("drawer_switch");
+    }
+
+    // Run update drawer state and also run it any time the form changes.
+    updateDrawerState();
+    drawerForm.addEventListener("change", updateDrawerState);
 
   </script>
 </head>
@@ -169,18 +181,30 @@
           <li>
             <div class="flex align-items-center">
               <button class="link" data-drawer-toggle="drawer-dialog">Drawer dialog</button>
-              <div class="flex flex_gap_sm align-items-center">
-                <span>Inline</span>
-                <span class="switch switch_size_sm">
-                  <input id="drawer-modal-mode-switch" type="checkbox" class="switch__native" name="drawer-modal-mode" checked>
-                  <span class="switch__background">
-                    <span class="switch__track">
-                      <span class="switch__thumb"></span>
+              <form id="form-drawer-state" class="flex align-items-center">
+                <label class="flex flex_gap_xs align-items-center">
+                  <span class="checkbox">
+                    <input name="toggle-drawer-modal" class="checkbox__native" type="checkbox" />
+                    <span class="checkbox__background">
+                      <span class="checkbox__box">
+                        <span class="checkbox__icon"></span>
+                      </span>
                     </span>
                   </span>
-                </span>
-                <span>Modal</span>
-              </div>
+                  <span>Modal</span>
+                </label>
+                <label class="flex flex_gap_xs align-items-center">
+                  <span class="checkbox">
+                    <input name="toggle-drawer-switch" class="checkbox__native" type="checkbox" />
+                    <span class="checkbox__background">
+                      <span class="checkbox__box">
+                        <span class="checkbox__icon"></span>
+                      </span>
+                    </span>
+                  </span>
+                  <span>Switch</span>
+                </label>
+              </form>
             </div>
           </li>
         </ul>
@@ -365,7 +389,7 @@
 </div><!-- .drawer-frame -->
 
 <div class="modals">
-  
+
   <div id="modal-dialog" class="modal">
     <div class="modal__dialog dialog" role="dialog" aria-modal="true" aria-labelledby="modal-dialog-title" aria-describedby="modal-dialog-description">
       <div class="dialog__header">

--- a/packages/vrembem/index.html
+++ b/packages/vrembem/index.html
@@ -146,7 +146,7 @@
 
         <!-- Dialog, Modal and Drawer -->
 
-        <div class="dialog" role="dialog" aria-labelledby="dialog-title" aria-describedby="dialog-description">
+        <div class="dialog" role="dialog" aria-labelledby="dialog-title" aria-describedby="dialog-description" tabindex="-1">
           <div class="dialog__header">
             <h2 class="dialog__title" id="dialog-title">Dialog title</h2>
             <button class="button button_icon button_size_sm">


### PR DESCRIPTION
## What changed?

This PR primarily refactors how the dialog component's custom properties are used within the context of the modal and drawer components. This removes the need to apply component specific dialog styles and properties for modal and drawer and instead only pass a property map to the CSS override mixin for when default dialog styles need to be changed.

To achieve this, new `$dialog-override` maps have been added to modal and drawer components along with `$inline-dialog-override` and `$modal-dialog-override` for drawer to override dialog styles based on the drawer's mode. These maps are then passed to `css.override("dialog", $map...)` to help give more control over dialog styles without having to create redundant dialog properties.

**Additional Changes**
- Modal and drawer SCSS and custom property variables have been greatly simplified.
- Create core screen variables that are shared between modal and modal drawer styles.
- Create focus-ring property function calls for color and opacity. This returns a custom property with the module, core and css value fallback stack.
- Applied focus-ring styles to the dialog component.
- Update modal and drawer documentation examples.
- Vrembem vite demo markup now includes dialog, modal and drawer examples.