### PR TITLE
Fix code block copy button popover

### DIFF
--- a/docs/src/components/CodeBlock.astro
+++ b/docs/src/components/CodeBlock.astro
@@ -21,7 +21,6 @@ const { inline = false } = Astro.props;
   }
   <Popover
     triggerClass="code-block__copy-button"
-    popoverClass="popover_tooltip"
     aria-label="Copy code example"
     arrow
   >
@@ -42,7 +41,7 @@ const { inline = false } = Astro.props;
     const text = code.innerText;
     const icons = trigger.querySelectorAll(".icon");
     navigator.clipboard.writeText(text)
-      .then((result) => {
+      .then(() => {
         trigger.disabled = true;
         icons.forEach((icon) => icon.classList.toggle("display-none"));
         setTimeout(() => {

--- a/docs/src/styles/_code-block.scss
+++ b/docs/src/styles/_code-block.scss
@@ -16,10 +16,13 @@
   }
   
   .popover {
-    @include css.override("popover", "event", click);
-    @include css.override("popover", "placement", left);
-    @include css.override("core", "background", palette.get("primary", 100));
-    @include css.override("core", "foreground", palette.get("primary"));
+    @include css.override("popover", (
+      "placement": left,
+      "width": auto,
+      "padding": 0.5rem 0.75rem,
+      "background": palette.get("primary"),
+      "foreground": white
+    ));
   }
 
   @include core.media-max(var.$bp-code) {
@@ -76,8 +79,10 @@
   }
 
   .popover {
-    @include css.override("popover", "offset", 24);
-    @include css.override("popover", "placement", bottom);
+    @include css.override("popover", (
+      "offset": 24,
+      "placement": bottom,
+    ));
   }
 
   @include core.media-max(var.$bp-code) {

--- a/docs/src/styles/_code-example.scss
+++ b/docs/src/styles/_code-example.scss
@@ -42,7 +42,7 @@
   }
 
   .code-block__copy-button {
-    top: calc(-2.5rem + 1px);
+    top: calc(-2.5rem + 2px);
     right: 0.5rem;
     background-color: transparent;
 


### PR DESCRIPTION
## What changed?

With recent changes to popover tooltip styles, this PR addresses the copy button popover which displays the "Copied!" text. Since this text should only appear on click, we make it a normal popover instead of a tooltip. We then pass the appropriate styles as css overrides and also adjust the spacing of code example copy buttons to better align in the toolbar area.