### PR TITLE
Fix base position styles for popover

### DIFF
--- a/packages/popover/src/scss/_popover.scss
+++ b/packages/popover/src/scss/_popover.scss
@@ -7,7 +7,7 @@ $_offset: calc(calc(css.get("popover", "offset") + 1) * 1px);
 #{core.bem("popover")} {
   position: absolute;
   z-index: css.get("popover", "z-index", var.$z-index);
-  top: 100%;
+  top: 0;
   left: 0;
   display: block;
   width: css.get("popover", "width", var.$width);


### PR DESCRIPTION
## What changed?

Our base popover styles were providing the property `top` with a value of `100%`. This was causing some scroll issues as the hidden popovers were positioned outside of the viewport. This PR sets the default `top` value of popovers to `0` which fixes this issue.