### PR TITLE
Fix hover event on non-tooltip popovers by tracking hover state

### DIFF
--- a/packages/core/tests/themeStore.test.js
+++ b/packages/core/tests/themeStore.test.js
@@ -1,4 +1,3 @@
-import { expect } from "vitest";
 import { themeStore } from "../index";
 
 let result;

--- a/packages/popover/src/js/handlers.js
+++ b/packages/popover/src/js/handlers.js
@@ -20,6 +20,9 @@ export function handleTooltipClick(popover) {
 }
 
 export function handleMouseEnter(popover, event) {
+  // Store our hover state.
+  popover.isHovered = event;
+
   // Guard to ensure only focus-visible triggers the tooltip on focus events.
   if (event.type == "focus" && !popover.trigger.matches(":focus-visible")) {
     return;
@@ -27,9 +30,7 @@ export function handleMouseEnter(popover, event) {
 
   // Guard to ensure a popover is not already open for this trigger.
   const isExpanded = popover.trigger.getAttribute("aria-expanded");
-  if (isExpanded && isExpanded == "true") {
-    return;
-  }
+  if (isExpanded && isExpanded == "true") return;
 
   // Clear any existing toggle delays.
   if (popover.toggleDelayId) {
@@ -49,16 +50,25 @@ export function handleMouseEnter(popover, event) {
   }, delay);
 }
 
-export function handleMouseLeave(popover) {
-  // Clear any existing toggle delays.
-  if (popover.toggleDelayId) {
-    clearTimeout(popover.toggleDelayId);
-  }
+export function handleMouseLeave(popover, event) {
+  // Add a tiny delay to ensure hover isn't being moved to the popover element.
+  setTimeout(() => {
+    // Update our hover state.
+    popover.isHovered = event;
 
-  // Set the toggle delay before closing the popover.
-  popover.toggleDelayId = setTimeout(() => {
-    closeCheck.call(this, popover);
-  }, popover.settings["toggle-delay"]);
+    // Guard to prevent closing popover if either elements are being hovered.
+    if (popover.isHovered) return;
+  
+    // Clear any existing toggle delays.
+    if (popover.toggleDelayId) {
+      clearTimeout(popover.toggleDelayId);
+    }
+
+    // Set the toggle delay before closing the popover.
+    popover.toggleDelayId = setTimeout(() => {
+      closeCheck.call(this, popover);
+    }, popover.settings["toggle-delay"]);
+  }, 1);
 }
 
 export function handleKeydown(event) {

--- a/packages/popover/tests/handlers.test.js
+++ b/packages/popover/tests/handlers.test.js
@@ -2,7 +2,6 @@ import "@testing-library/jest-dom/vitest";
 import { delay } from "./helpers/delay";
 import Popover from "../index";
 import { handleClick, handleMouseEnter, handleMouseLeave } from "../src/js/handlers";
-import { expect } from "vitest";
 
 const keyEsc = new KeyboardEvent("keydown", {
   key: "Escape"

--- a/packages/popover/tests/handlers.test.js
+++ b/packages/popover/tests/handlers.test.js
@@ -140,7 +140,8 @@ describe("handleMouseEnter() & handleMouseLeave()", () => {
     entry.open();
     expect(entry.state).toBe("opened");
 
-    handleMouseLeave.bind(popover, entry)();
+    const eventLeave = new Event("mouseleave");
+    handleMouseLeave.bind(popover, entry, eventLeave)();
     await delay(100); // Not sure why this is needed.
     expect(entry.state).toBe("closed");
   });
@@ -153,19 +154,20 @@ describe("handleMouseEnter() & handleMouseLeave()", () => {
     const entry1 = popover.get("tooltip-1");
     const entry2 = popover.get("tooltip-2");
 
-    const event = new Event("mouseenter");
-    handleMouseEnter.bind(popover, entry1, event)();
-    handleMouseEnter.bind(popover, entry2, event)();
+    const eventEnter = new Event("mouseenter");
+    handleMouseEnter.bind(popover, entry1, eventEnter)();
+    handleMouseEnter.bind(popover, entry2, eventEnter)();
     await delay();
-    handleMouseLeave.bind(popover, entry1, event)();
+    handleMouseLeave.bind(popover, entry1, eventEnter)();
     await delay();
-    handleMouseEnter.bind(popover, entry2, event)();
+    handleMouseEnter.bind(popover, entry2, eventEnter)();
     await delay();
 
     expect(entry1.state).toBe("closed");
     expect(entry2.state).toBe("opened");
 
-    handleMouseLeave.bind(popover, entry2)();
+    const eventLeave = new Event("mouseleave");
+    handleMouseLeave.bind(popover, entry2, eventLeave)();
     await delay(100);
 
     expect(entry2.state).toBe("closed");

--- a/packages/popover/tests/helpers.test.js
+++ b/packages/popover/tests/helpers.test.js
@@ -8,7 +8,6 @@ import {
   getPopoverID,
   getPopoverElements
 } from "../src/js/helpers";
-import { describe, expect } from "vitest";
 
 let popover;
 

--- a/packages/popover/tests/helpers.test.js
+++ b/packages/popover/tests/helpers.test.js
@@ -44,7 +44,6 @@ describe("applyPositionStyle()", () => {
   it("Should apply both x and y position values.", () => {
     document.body.innerHTML = simpleMarkup;
     const el = document.getElementById("asdf");
-    console.log(el);
     applyPositionStyle(el, 10, 20);
     expect(el.style.left).toBe("10px");
     expect(el.style.top).toBe("20px");
@@ -53,7 +52,6 @@ describe("applyPositionStyle()", () => {
   it("Should apply both the y position values.", () => {
     document.body.innerHTML = simpleMarkup;
     const el = document.getElementById("asdf");
-    console.log(el);
     applyPositionStyle(el, undefined, 15);
     expect(el.style.left).toBe("");
     expect(el.style.top).toBe("15px");
@@ -62,7 +60,6 @@ describe("applyPositionStyle()", () => {
   it("Should apply both the x position values.", () => {
     document.body.innerHTML = simpleMarkup;
     const el = document.getElementById("asdf");
-    console.log(el);
     applyPositionStyle(el, 15, undefined);
     expect(el.style.left).toBe("15px");
     expect(el.style.top).toBe("");


### PR DESCRIPTION
## What changed?

This PR fixes the hover event on non-tooltip popovers by preventing the popover from closing when the trigger loses hover state. This is done by tracking the hover state on both the popover element and the trigger.

We're doing this using a new getter/setter on collection entries called `isHovered` which takes the event object as a parameter. This is then used to test if the event type is one of the mouse events for the hover state ("mouseenter" or "mouseleave") and if the event target matches either the popover trigger or popover element.

The mouse enter and leave handlers pass the event object to the setter and the mouse leave handler uses the getter to check if the popover should be closed or not.