### PR TITLE
Apply getSetting changes to modal and drawer components

### DIFF
--- a/packages/core/src/js/updateGlobalState.js
+++ b/packages/core/src/js/updateGlobalState.js
@@ -26,7 +26,8 @@ function setInert(state, selector) {
   }
 }
 
-export function updateGlobalState(state, config) {
-  setInert(!!state, config.selectorInert);
-  setOverflowHidden(!!state, config.selectorOverflow);
+// TODO: This needs to be updated
+export function updateGlobalState(state, selectorInert, selectorOverflow) {
+  setInert(!!state, selectorInert);
+  setOverflowHidden(!!state, selectorOverflow);
 }

--- a/packages/core/src/js/updateGlobalState.js
+++ b/packages/core/src/js/updateGlobalState.js
@@ -26,7 +26,7 @@ function setInert(state, selector) {
   }
 }
 
-// TODO: This needs to be updated
+// TODO: Look into refactoring how this works.
 export function updateGlobalState(state, selectorInert, selectorOverflow) {
   setInert(!!state, selectorInert);
   setOverflowHidden(!!state, selectorOverflow);

--- a/packages/core/tests/updateGlobalState.test.js
+++ b/packages/core/tests/updateGlobalState.test.js
@@ -10,14 +10,6 @@ document.body.innerHTML = `
 
 const header = document.querySelector(".header");
 const main = document.querySelector(".main");
-const config = {
-  selectorInert: ".main, .header",
-  selectorOverflow: "body, .main"
-};
-const configEmpty = {
-  selectorInert: null,
-  selectorOverflow: null
-};
 
 describe("updateGlobalState()", () => {
   it("should apply inert and aria hidden to passed selectors", () => {
@@ -26,7 +18,7 @@ describe("updateGlobalState()", () => {
     expect(main).not.toHaveAttribute("aria-hidden");
     expect(header).not.toHaveAttribute("aria-hidden");
 
-    updateGlobalState(true, config);
+    updateGlobalState(true, ".main, .header", "body, .main");
     expect(main.inert).toBe(true);
     expect(header.inert).toBe(true);
     expect(main).toHaveAttribute("aria-hidden", "true");
@@ -34,7 +26,7 @@ describe("updateGlobalState()", () => {
   });
 
   it("should remove inert and aria hidden when set to false", () => {
-    updateGlobalState(false, config);
+    updateGlobalState(false, ".main, .header", "body, .main");
     expect(main.inert).not.toBe(true);
     expect(header.inert).not.toBe(true);
     expect(main).not.toHaveAttribute("aria-hidden");
@@ -42,7 +34,7 @@ describe("updateGlobalState()", () => {
   });
 
   it("should do nothing if selector is not passed", () => {
-    updateGlobalState(true, configEmpty);
+    updateGlobalState(true, null, null);
     expect(main.inert).not.toBe(true);
     expect(header.inert).not.toBe(true);
     expect(main).not.toHaveAttribute("aria-hidden");
@@ -52,19 +44,19 @@ describe("updateGlobalState()", () => {
   it("should apply overflow hidden to passed selectors", () => {
     expect(document.body).not.toHaveStyle("overflow: hidden");
     expect(main).not.toHaveStyle("overflow: hidden");
-    updateGlobalState(true, config);
+    updateGlobalState(true, ".main, .header", "body, .main");
     expect(document.body).toHaveStyle("overflow: hidden");
     expect(main).toHaveStyle("overflow: hidden");
   });
 
   it("should remove overflow hidden when set to false", () => {
-    updateGlobalState(false, config);
+    updateGlobalState(false, ".main, .header", "body, .main");
     expect(document.body).not.toHaveStyle("overflow: hidden");
     expect(main).not.toHaveStyle("overflow: hidden");
   });
 
   it("should do nothing if selector is not passed", () => {
-    updateGlobalState(true, configEmpty);
+    updateGlobalState(true, null, null);
     expect(document.body).not.toHaveStyle("overflow: hidden");
     expect(main).not.toHaveStyle("overflow: hidden");
   });

--- a/packages/drawer/src/js/close.js
+++ b/packages/drawer/src/js/close.js
@@ -1,15 +1,9 @@
 import { transition, updateGlobalState } from "@vrembem/core";
 import { updateFocusState, getDrawer } from "./helpers";
 
-export async function close(query, enableTransition, focus = true) {
+export async function close(query, transitionOverride, focus = true) {
   // Get the drawer from collection.
   const entry = getDrawer.call(this, query);
-
-  // Get the modal configuration.
-  const config = { ...this.settings, ...entry.settings };
-
-  // Add transition parameter to configuration.
-  if (enableTransition !== undefined) config.transition = enableTransition;
 
   // If drawer is opened or indeterminate.
   if (entry.state === "opened" || entry.state === "indeterminate") {
@@ -20,24 +14,24 @@ export async function close(query, enableTransition, focus = true) {
     document.activeElement.blur();
 
     // Run the close transition.
-    if (config.transition) {
+    if ((transitionOverride != undefined) ? transitionOverride : entry.getSetting("transition")) {
       await transition(entry.el, {
-        start: config.stateOpening,
-        finish: config.stateOpened
+        start: entry.getSetting("stateOpening"),
+        finish: entry.getSetting("stateOpened")
       }, {
-        start: config.stateClosing,
-        finish: config.stateClosed
-      }, config.transitionDuration);
+        start: entry.getSetting("stateClosing"),
+        finish: entry.getSetting("stateClosed")
+      }, entry.getSetting("transitionDuration"));
     } else {
-      entry.el.classList.add(config.stateClosed);
-      entry.el.classList.remove(config.stateOpened);
+      entry.el.classList.add(entry.getSetting("stateClosed"));
+      entry.el.classList.remove(entry.getSetting("stateOpened"));
     }
 
     // Update drawer state.
     entry.state = "closed";
 
     // Update the global state if mode is modal.
-    if (entry.mode === "modal") updateGlobalState(false, config);
+    if (entry.mode === "modal") updateGlobalState(false, entry.getSetting("selectorInert"), entry.getSetting("selectorOverflow"));
 
     // Set focus to the trigger element if the focus param is true.
     if (focus) {
@@ -45,7 +39,7 @@ export async function close(query, enableTransition, focus = true) {
     }
 
     // Dispatch custom closed event.
-    entry.el.dispatchEvent(new CustomEvent(config.customEventPrefix + "closed", {
+    entry.el.dispatchEvent(new CustomEvent(entry.getSetting("customEventPrefix") + "closed", {
       detail: this,
       bubbles: true
     }));

--- a/packages/drawer/src/js/open.js
+++ b/packages/drawer/src/js/open.js
@@ -1,15 +1,9 @@
 import { transition, updateGlobalState } from "@vrembem/core";
 import { updateFocusState, getDrawer } from "./helpers";
 
-export async function open(query, enableTransition, focus = true) {
+export async function open(query, transitionOverride, focus = true) {
   // Get the drawer from collection.
   const entry = getDrawer.call(this, query);
-
-  // Get the modal configuration.
-  const config = { ...this.settings, ...entry.settings };
-
-  // Add transition parameter to configuration.
-  if (enableTransition !== undefined) config.transition = enableTransition;
 
   // If drawer is closed or indeterminate.
   if (entry.state === "closed" || entry.state === "indeterminate") {
@@ -17,24 +11,24 @@ export async function open(query, enableTransition, focus = true) {
     entry.state = "opening";
 
     // Run the open transition.
-    if (config.transition) {
+    if ((transitionOverride != undefined) ? transitionOverride : entry.getSetting("transition")) {
       await transition(entry.el, {
-        start: config.stateClosing,
-        finish: config.stateClosed
+        start: entry.getSetting("stateClosing"),
+        finish: entry.getSetting("stateClosed")
       }, {
-        start: config.stateOpening,
-        finish: config.stateOpened
-      }, config.transitionDuration);
+        start: entry.getSetting("stateOpening"),
+        finish: entry.getSetting("stateOpened")
+      }, entry.getSetting("transitionDuration"));
     } else {
-      entry.el.classList.add(config.stateOpened);
-      entry.el.classList.remove(config.stateClosed);
+      entry.el.classList.add(entry.getSetting("stateOpened"));
+      entry.el.classList.remove(entry.getSetting("stateClosed"));
     }
 
     // Update drawer state.
     entry.state = "opened";
 
     // Update the global state if mode is modal.
-    if (entry.mode === "modal") updateGlobalState(true, config);
+    if (entry.mode === "modal") updateGlobalState(true, entry.getSetting("selectorInert"), entry.getSetting("selectorOverflow"));
 
     // Set focus to the drawer element if the focus param is true.
     if (focus) {
@@ -42,7 +36,7 @@ export async function open(query, enableTransition, focus = true) {
     }
 
     // Dispatch custom opened event.
-    entry.el.dispatchEvent(new CustomEvent(config.customEventPrefix + "opened", {
+    entry.el.dispatchEvent(new CustomEvent(entry.getSetting("customEventPrefix") + "opened", {
       detail: this,
       bubbles: true
     }));

--- a/packages/drawer/src/js/register.js
+++ b/packages/drawer/src/js/register.js
@@ -121,7 +121,7 @@ export async function register(el, config = {}) {
       }
 
       // Throw error if setting does not exist.
-      throw(new Error(`Modal setting does not exist: ${key}`));
+      throw(new Error(`Drawer setting does not exist: ${key}`));
     }
   };
 

--- a/packages/drawer/src/js/switchMode.js
+++ b/packages/drawer/src/js/switchMode.js
@@ -21,7 +21,7 @@ async function toInline(entry) {
   entry.dialog.removeAttribute("aria-modal");
 
   // Update the global state.
-  updateGlobalState(false, { ...this.settings, ...entry.settings });
+  updateGlobalState(false, entry.getSetting("selectorInert"), entry.getSetting("selectorOverflow"));
 
   // Remove any focus traps.
   this.focusTrap.unmount();

--- a/packages/drawer/tests/api.test.js
+++ b/packages/drawer/tests/api.test.js
@@ -266,3 +266,24 @@ describe("data-drawer-config", () => {
     expect(entry2.getSetting("selectorOverflow")).toBe("main");
   });
 });
+
+describe("getSetting()", () => {
+  it("should return a setting value from wherever it was set", async () => {
+    document.body.innerHTML = markup;
+    const drawer = new Drawer();
+    await drawer.mount();
+    const entry = drawer.get("drawer-1");
+    expect(entry.id).toBe("drawer-1");
+    expect(entry.getSetting("dataConfig")).toBe("drawer-config");
+    entry.settings["dataConfig"] = "asdf";
+    expect(entry.getSetting("dataConfig")).toBe("asdf");
+  });
+
+  it("should throw an error if searching for a setting that doesn't exist", async () => {
+    document.body.innerHTML = markup;
+    const drawer = new Drawer();
+    await drawer.mount();
+    const entry = drawer.get("drawer-1");
+    expect(() => entry.getSetting("asdf")).toThrow("Drawer setting does not exist: asdf");
+  });
+});

--- a/packages/modal/src/js/close.js
+++ b/packages/modal/src/js/close.js
@@ -1,7 +1,7 @@
 import { transition } from "@vrembem/core";
 import { updateFocusState, getModal } from "./helpers";
 
-export async function close(query, enableTransition, focus = true) {
+export async function close(query, transitionOverride, focus = true) {
   // Get the modal from collection, or top modal in stack if no query is provided.
   const entry = (query) ? getModal.call(this, query) : this.active;
 
@@ -10,27 +10,21 @@ export async function close(query, enableTransition, focus = true) {
     // Update modal state.
     entry.state = "closing";
 
-    // Get the modal configuration.
-    const config = { ...this.settings, ...entry.settings };
-
-    // Add transition parameter to configuration.
-    if (enableTransition !== undefined) config.transition = enableTransition;
-
     // Remove focus from active element.
     document.activeElement.blur();
 
     // Run the close transition.
-    if (config.transition) {
+    if ((transitionOverride != undefined) ? transitionOverride : entry.getSetting("transition")) {
       await transition(entry.el, {
-        start: config.stateOpening,
-        finish: config.stateOpened
+        start: entry.getSetting("stateOpening"),
+        finish: entry.getSetting("stateOpened")
       }, {
-        start: config.stateClosing,
-        finish: config.stateClosed
-      }, config.transitionDuration);
+        start: entry.getSetting("stateClosing"),
+        finish: entry.getSetting("stateClosed")
+      }, entry.getSetting("transitionDuration"));
     } else {
-      entry.el.classList.add(config.stateClosed);
-      entry.el.classList.remove(config.stateOpened);
+      entry.el.classList.add(entry.getSetting("stateClosed"));
+      entry.el.classList.remove(entry.getSetting("stateOpened"));
     }
 
     // Remove modal from stack.
@@ -45,7 +39,7 @@ export async function close(query, enableTransition, focus = true) {
     }
 
     // Dispatch custom closed event.
-    entry.el.dispatchEvent(new CustomEvent(config.customEventPrefix + "closed", {
+    entry.el.dispatchEvent(new CustomEvent(entry.getSetting("customEventPrefix") + "closed", {
       detail: this,
       bubbles: true
     }));

--- a/packages/modal/src/js/open.js
+++ b/packages/modal/src/js/open.js
@@ -1,16 +1,10 @@
 import { transition } from "@vrembem/core";
 import { updateFocusState, getModal } from "./helpers";
 
-export async function open(query, enableTransition, focus = true) {
+export async function open(query, transitionOverride = undefined, focus = true) {
   // Get the modal from collection.
   const entry = getModal.call(this, query);
-
-  // Get the modal configuration.
-  const config = { ...this.settings, ...entry.settings };
-
-  // Add transition parameter to configuration.
-  if (enableTransition !== undefined) config.transition = enableTransition;
-
+  
   // Maybe add modal to top of stack.
   this.stack.moveToTop(entry);
 
@@ -23,17 +17,17 @@ export async function open(query, enableTransition, focus = true) {
     this.stack.add(entry);
 
     // Run the open transition.
-    if (config.transition) {
+    if ((transitionOverride != undefined) ? transitionOverride : entry.getSetting("transition")) {
       await transition(entry.el, {
-        start: config.stateClosing,
-        finish: config.stateClosed
+        start: entry.getSetting("stateClosing"),
+        finish: entry.getSetting("stateClosed")
       }, {
-        start: config.stateOpening,
-        finish: config.stateOpened
-      }, config.transitionDuration);
+        start: entry.getSetting("stateOpening"),
+        finish: entry.getSetting("stateOpened")
+      }, entry.getSetting("transitionDuration"));
     } else {
-      entry.el.classList.add(config.stateOpened);
-      entry.el.classList.remove(config.stateClosed);
+      entry.el.classList.add(entry.getSetting("stateOpened"));
+      entry.el.classList.remove(entry.getSetting("stateClosed"));
     }
 
     // Update modal state.
@@ -46,11 +40,11 @@ export async function open(query, enableTransition, focus = true) {
   }
 
   // Dispatch custom opened event.
-  entry.el.dispatchEvent(new CustomEvent(config.customEventPrefix + "opened", {
+  entry.el.dispatchEvent(new CustomEvent(entry.getSetting("customEventPrefix") + "opened", {
     detail: this,
     bubbles: true
   }));
-
+  
   // Return the modal.
   return entry;
 }

--- a/packages/modal/src/js/stack.js
+++ b/packages/modal/src/js/stack.js
@@ -23,7 +23,7 @@ export function stack(settings) {
     },
 
     updateGlobalState() {
-      updateGlobalState(this.top, settings);
+      updateGlobalState(this.top, settings.selectorInert, settings.selectorOverflow);
       this.updateIndex();
     },
 

--- a/packages/modal/tests/api.test.js
+++ b/packages/modal/tests/api.test.js
@@ -455,3 +455,24 @@ describe("closeAll()", () => {
     expect(document.activeElement).toBe(document.body);
   });
 });
+
+describe("getSetting()", () => {
+  it("should return a setting value from wherever it was set", async () => {
+    document.body.innerHTML = markup;
+    const modal = new Modal();
+    await modal.mount();
+    const entry = modal.get("modal-default");
+    expect(entry.id).toBe("modal-default");
+    expect(entry.getSetting("dataConfig")).toBe("modal-config");
+    entry.settings["dataConfig"] = "asdf";
+    expect(entry.getSetting("dataConfig")).toBe("asdf");
+  });
+
+  it("should throw an error if searching for a setting that doesn't exist", async () => {
+    document.body.innerHTML = markup;
+    const modal = new Modal();
+    await modal.mount();
+    const entry = modal.get("modal-default");
+    expect(() => entry.getSetting("asdf")).toThrow("Modal setting does not exist: asdf");
+  });
+});

--- a/packages/modal/tests/transition.test.js
+++ b/packages/modal/tests/transition.test.js
@@ -1,6 +1,8 @@
 import "@testing-library/jest-dom/vitest";
 import Modal from "../index";
 
+vi.useFakeTimers();
+
 const markup = `
   <button data-modal-open="modal-default">Modal Default</button>
   <div id="modal-default" class="modal is-closed" style="--modal-transition-duration: 300ms">
@@ -25,10 +27,6 @@ const markupConfig = `
     <div class="modal__dialog">...</div>
   </div>
 `;
-
-beforeEach(() => {
-  vi.useFakeTimers();
-});
 
 test("should apply state classes on `click` and `transitionend` events", async () => {
   document.body.innerHTML = markup;
@@ -100,14 +98,14 @@ test("should open and close modal while using the data modal config attribute", 
   const modal = new Modal();
   await modal.mount();
 
-  const modalObj = modal.get("modal-default");
-  await modalObj.open();
-  expect(modalObj.el).toHaveClass("is-opened");
-  expect(modalObj.state).toBe("opened");
+  const entry = modal.get("modal-default");
+  await entry.open();
+  expect(entry.el).toHaveClass("is-opened");
+  expect(entry.state).toBe("opened");
 
-  await modalObj.close();
-  expect(modalObj.el).toHaveClass("is-closed");
-  expect(modalObj.state).toBe("closed");
+  await entry.close();
+  expect(entry.el).toHaveClass("is-closed");
+  expect(entry.state).toBe("closed");
 });
 
 test("should return modal config if set, otherwise should return global settings", async () => {

--- a/packages/popover/src/js/index.js
+++ b/packages/popover/src/js/index.js
@@ -17,7 +17,8 @@ export default class Popover extends Collection {
     this.settings = { ...this.defaults, ...options };
     this.trigger = null;
     this.#handleKeydown = handleKeydown.bind(this);
-    if (this.settings.autoMount) this.mount();
+    // TODO: Find a better solution for auto mounting and using await, maybe remove?
+    this.autoMount = (this.settings.autoMount) ? this.mount() : Promise.resolve();
   }
 
   get active() {

--- a/packages/popover/src/js/register.js
+++ b/packages/popover/src/js/register.js
@@ -6,7 +6,7 @@ import { close } from "./close";
 
 export async function register(el, trigger, config = {}) {
   // Deregister entry incase it has already been registered.
-  deregister.call(this, el);
+  await deregister.call(this, el);
   
   // Save root this for use inside methods API.
   const root = this;

--- a/packages/popover/tests/api.test.js
+++ b/packages/popover/tests/api.test.js
@@ -17,6 +17,13 @@ const markup = `
 `;
 
 describe("mount() & unmount()", () => {
+  it("should auto mount if autoMount is set to true", async () => {
+    document.body.innerHTML = markup;
+    const popover = new Popover({ autoMount: true });
+    await popover.autoMount;
+    expect(popover.collection.length).toBe(3);
+  });
+
   it("should mount the popover module when mount is run", async () => {
     document.body.innerHTML = markup;
     const popover = new Popover();

--- a/packages/popover/tests/api.test.js
+++ b/packages/popover/tests/api.test.js
@@ -33,7 +33,8 @@ describe("mount() & unmount()", () => {
 
   it("running mount multiple times should not create duplicates in collection", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover({ autoMount: true });
+    const popover = new Popover();
+    await popover.mount();
     await popover.mount();
     expect(popover.collection.length).toBe(3);
   });


### PR DESCRIPTION
## What changed?

This PR applies changes made to popover's `setting` and `getSetting` entry properties to modal and drawer components (see #2033). It then refactors the open and close methods to use `getSetting` instead of unnecessarily building a config object to drawer settings from.

**Additional Changes**
- Temporary popover solution to autoMount and storing the promise.
- Renamed `enableTransition ` to `transitionOverride` since passing this param will override the stored setting.
- `updateGlobalState` now takes selectors as parameters instead of a settings object. A todo has been added for future changes/refactoring.