### PR TITLE
Remove the option to auto mount on component constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,6 @@ const modal = new Modal();
 modal.mount();
 ```
 
-Alternatively, you can use the `autoMount` option to auto mount and optionally omit saving the instance to a variable if the returned API won't be needed later.
-
-```js
-new Modal({ autoMount: true });
-```
-
 #### HTML
 
 Include the component's markup into your project. Use the [online docs](https://vrembem.com) for information and code examples such as markup and available modifiers for each component.
@@ -175,11 +169,13 @@ Via your project's JavaScript manifest file:
 ```js
 // Import all under the vb namespace
 import * as vb from "vrembem";
-const drawer = new vb.Drawer({ autoMount: true });
+const drawer = new vb.Drawer();
+await drawer.mount();
 
 // Or import individual components
 import { Drawer } from "vrembem";
-const drawer = new Drawer({ autoMount: true });
+const drawer = new Drawer();
+await drawer.mount();
 ```
 
 ## Copyright and License

--- a/packages/drawer/README.md
+++ b/packages/drawer/README.md
@@ -20,5 +20,6 @@ npm install @vrembem/drawer
 
 ```js
 import Drawer from '@vrembem/drawer';
-const drawer = new Drawer({ autoMount: true });
+const drawer = new Drawer();
+await drawer.mount();
 ```

--- a/packages/drawer/src/js/defaults.js
+++ b/packages/drawer/src/js/defaults.js
@@ -1,6 +1,4 @@
 export default {
-  autoMount: false,
-
   // Data attributes
   dataOpen: "drawer-open",
   dataClose: "drawer-close",

--- a/packages/drawer/src/js/index.js
+++ b/packages/drawer/src/js/index.js
@@ -23,7 +23,6 @@ export default class Drawer extends Collection {
 
     this.#handleClick = handleClick.bind(this);
     this.#handleKeydown = handleKeydown.bind(this);
-    if (this.settings.autoMount) this.mount();
   }
 
   get activeModal() {

--- a/packages/drawer/tests/api.test.js
+++ b/packages/drawer/tests/api.test.js
@@ -49,7 +49,6 @@ const markupConfig = `
 document.body.innerHTML = markup;
 
 const drawer = new Drawer({ transitionDuration: 300 });
-const drawerAuto = new Drawer({ autoMount: true, transitionDuration: 300 });
 
 describe("mount() & unmount()", () => {
   it("should correctly register all drawers on mount()", async () => {
@@ -69,10 +68,6 @@ describe("mount() & unmount()", () => {
     expect(drawer.settings.eventListeners).toBe(false);
     await drawer.unmount();
     expect(drawer.collection.length).toBe(0);
-  });
-
-  it("should automatically mount when autoMount option set to true", () => {
-    expect(drawerAuto.collection.length).toBe(2);
   });
 });
 

--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -20,5 +20,6 @@ npm install @vrembem/modal
 
 ```js
 import Modal from '@vrembem/modal';
-const modal = new Modal({ autoMount: true });
+const modal = new Modal();
+await modal.mount();
 ```

--- a/packages/modal/src/js/defaults.js
+++ b/packages/modal/src/js/defaults.js
@@ -1,6 +1,4 @@
 export default {
-  autoMount: false,
-
   // Data attributes
   dataOpen: "modal-open",
   dataClose: "modal-close",

--- a/packages/modal/src/js/index.js
+++ b/packages/modal/src/js/index.js
@@ -27,7 +27,6 @@ export default class Modal extends Collection {
 
     this.#handleClick = handleClick.bind(this);
     this.#handleKeydown = handleKeydown.bind(this);
-    if (this.settings.autoMount) this.mount();
   }
 
   get active() {

--- a/packages/modal/tests/inert.test.js
+++ b/packages/modal/tests/inert.test.js
@@ -14,12 +14,12 @@ const markup = `
 describe("when selectorInert is set:", () => {
   let main, el;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     document.body.innerHTML = markup;
-    new Modal({
-      autoMount: true,
+    const modal = new Modal({
       selectorInert: "main"
     });
+    await modal.mount();
     main = document.querySelector("main");
     el = document.querySelector("#modal-default");
     el.style.setProperty("--modal-transition-duration", "0.3s");

--- a/packages/popover/README.md
+++ b/packages/popover/README.md
@@ -20,5 +20,6 @@ npm install @vrembem/popover
 
 ```js
 import Popover from '@vrembem/popover';
-const popover = new Popover({ autoMount: true });
+const popover = new Popover();
+await popover.mount();
 ```

--- a/packages/popover/src/js/defaults.js
+++ b/packages/popover/src/js/defaults.js
@@ -1,6 +1,4 @@
 export default {
-  autoMount: false,
-
   // Data attributes
   dataConfig: "popover-config",
 

--- a/packages/popover/src/js/index.js
+++ b/packages/popover/src/js/index.js
@@ -17,8 +17,6 @@ export default class Popover extends Collection {
     this.settings = { ...this.defaults, ...options };
     this.trigger = null;
     this.#handleKeydown = handleKeydown.bind(this);
-    // TODO: Find a better solution for auto mounting and using await, maybe remove?
-    this.autoMount = (this.settings.autoMount) ? this.mount() : Promise.resolve();
   }
 
   get active() {

--- a/packages/popover/tests/api.test.js
+++ b/packages/popover/tests/api.test.js
@@ -17,21 +17,7 @@ const markup = `
 `;
 
 describe("mount() & unmount()", () => {
-  it("should auto mount if autoMount is set to true", async () => {
-    document.body.innerHTML = markup;
-    const popover = new Popover({ autoMount: true });
-    await popover.autoMount;
-    expect(popover.collection.length).toBe(3);
-  });
-
   it("should mount the popover module when mount is run", async () => {
-    document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
-    expect(popover.collection.length).toBe(3);
-  });
-
-  it("should auto mount the popover module autoMount is set to true", async () => {
     document.body.innerHTML = markup;
     const popover = new Popover();
     await popover.mount();

--- a/packages/vrembem/README.md
+++ b/packages/vrembem/README.md
@@ -58,11 +58,13 @@ Import and mount the components you'll need:
 ```js
 // Import all under the vb namespace
 import * as vb from 'vrembem';
-const drawer = new vb.Drawer({ autoMount: true });
+const drawer = new vb.Drawer();
+await drawer.mount();
 
 // Or import individual components
 import { Drawer } from 'vrembem';
-const drawer = new Drawer({ autoMount: true });
+const drawer = new Drawer();
+await drawer.mount();
 ```
 
 ## Markup

--- a/packages/vrembem/index.html
+++ b/packages/vrembem/index.html
@@ -55,11 +55,14 @@
     console.log("themeStore", themeStore);
 
     /**
-     * Initialize Vrembem components
+     * Instantiate and mount Vrembem components
      */
     
-    const modal = await new vb.Modal({ autoMount: true });
-    const drawer = await new vb.Drawer({ autoMount: true });
+    const modal = new vb.Modal();
+    await modal.mount();
+
+    const drawer = new vb.Drawer();
+    await drawer.mount();
 
     window["modal"] = modal;
     window["drawer"] = drawer;


### PR DESCRIPTION
## What changed?

This PR removes the ability to auto mount components on their constructor calls. Mount now must be run explicitly after a component has been instantiated. This helps manage async operations effectively while keeping the constructor clean and synchronous.

**Migration**

To incorporate this breaking change, ensure that all uses of `autoMount` are removed and `mount` calls are run explicitly.

```js
// Uses of auto mount
const modal = new Modal({ autoMount: true });

// Should be converted to this
const modal = new Modal();
await modal.mount();
```