### PR TITLE
Refactor which custom properties are queried for in collection entries

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -7,6 +7,7 @@ export * from "./src/js/helpers/getConfig";
 export * from "./src/js/helpers/getCustomProps";
 export * from "./src/js/helpers/getElement";
 export * from "./src/js/helpers/getPrefix";
+export * from "./src/js/helpers/getSetting";
 export * from "./src/js/helpers/lifecycleHook";
 export * from "./src/js/helpers/transition";
 export * from "./src/js/helpers/setGlobalState";

--- a/packages/core/src/js/Collection.js
+++ b/packages/core/src/js/Collection.js
@@ -6,6 +6,7 @@ export class Collection {
     this.collection = [];
     this.settings = Object.assign({ 
       dataConfig: "config",
+      customProps: [],
       teleport: null,
       teleportMethod: "append"
     }, options);

--- a/packages/core/src/js/CollectionEntry.js
+++ b/packages/core/src/js/CollectionEntry.js
@@ -31,6 +31,7 @@ export class CollectionEntry {
     return Object.assign(this.customProps, getCustomProps(this));
   }
 
+  // TODO: Move this into a helper function.
   getSetting(key) {
     // Store our key in both camel and kebab naming conventions.
     const camel = toCamel(key);

--- a/packages/core/src/js/CollectionEntry.js
+++ b/packages/core/src/js/CollectionEntry.js
@@ -4,8 +4,7 @@ import {
   getElement,
   lifecycleHook,
   teleport,
-  toCamel,
-  toKebab,
+  getSetting,
 } from "@vrembem/core";
 
 export class CollectionEntry {
@@ -31,34 +30,8 @@ export class CollectionEntry {
     return Object.assign(this.customProps, getCustomProps(this));
   }
 
-  // TODO: Move this into a helper function.
-  getSetting(key) {
-    // Store our key in both camel and kebab naming conventions.
-    const camel = toCamel(key);
-    const kebab = toKebab(key);
-
-    // Check the data config object.
-    if ("dataConfig" in this && camel in this.dataConfig) {
-      return this.dataConfig[camel];
-    }
-
-    // Check the custom properties object.
-    if ("customProps" in this && kebab in this.customProps) {
-      return this.customProps[kebab];
-    }
-
-    // Check the entry settings.
-    if ("settings" in this && camel in this.settings) {
-      return this.settings[camel];
-    }
-
-    // Check the context settings.
-    if ("settings" in this.context && camel in this.context.settings) {
-      return this.context.settings[camel];
-    }
-
-    // Throw error if setting does not exist.
-    throw(new Error(`${this.context.module} setting does not exist: ${key}`));
+  getSetting(key, options = {}) {
+    return getSetting.call(this, key, options);
   }
 
   async mount(options = {}) {

--- a/packages/core/src/js/helpers/getCustomProps.js
+++ b/packages/core/src/js/helpers/getCustomProps.js
@@ -8,7 +8,6 @@ export function getCustomProps(entry) {
   const result = {};
 
   // Get the custom property keys.
-  // const keys = Object.keys(entry.context.settings);
   const keys = entry.getSetting("custom-props");
 
   // Loop through the custom properties object.

--- a/packages/core/src/js/helpers/getCustomProps.js
+++ b/packages/core/src/js/helpers/getCustomProps.js
@@ -8,7 +8,7 @@ export function getCustomProps(entry) {
   const result = {};
 
   // Get the custom property keys.
-  const keys = entry.getSetting("custom-props");
+  const keys = entry.getSetting("customProps");
 
   // Loop through the custom properties object.
   for (let i = 0; i < keys.length; i++) {

--- a/packages/core/src/js/helpers/getCustomProps.js
+++ b/packages/core/src/js/helpers/getCustomProps.js
@@ -8,7 +8,8 @@ export function getCustomProps(entry) {
   const result = {};
 
   // Get the custom property keys.
-  const keys = Object.keys(entry.context.settings);
+  // const keys = Object.keys(entry.context.settings);
+  const keys = entry.getSetting("custom-props");
 
   // Loop through the custom properties object.
   for (let i = 0; i < keys.length; i++) {

--- a/packages/core/src/js/helpers/getSetting.js
+++ b/packages/core/src/js/helpers/getSetting.js
@@ -1,0 +1,42 @@
+import { toCamel, toKebab } from "@vrembem/core";
+
+function maybeReturnSetting(prop, key, type = "camel") {
+  let context = this;
+  const parts = prop.split(".");
+
+  // Check if multiple props were passed (supports max 2).
+  if (parts.length > 1) {
+    context = this[parts[0]];
+    prop = parts[1];
+  }
+
+  // Convert the key case based on provided type.
+  key = (type === "camel") ? toCamel(key) : toKebab(key);
+
+  // Return the setting if it exists, otherwise return undefined.
+  return context?.[prop]?.[key];
+}
+
+export function getSetting(key, options = {}) {
+  const {
+    fallback,
+    props = ["dataConfig", "customProps", "settings", "context.settings"],
+  } = options;
+
+  // Loop through the props for the setting and return if found.
+  for (const prop of props) {
+    const type = (prop !== "customProps") ? "camel" : "kebab";
+    const result = maybeReturnSetting.call(this, prop, key, type);
+    if (result !== undefined) {
+      return result;
+    }
+  }
+
+  // Return fallback if one was provided.
+  if (fallback !== undefined) {
+    return fallback;
+  }
+
+  // Otherwise, throw an error.
+  throw new Error(`${this.context.module} setting does not exist: ${key}`);
+}

--- a/packages/core/src/js/helpers/getSetting.js
+++ b/packages/core/src/js/helpers/getSetting.js
@@ -8,6 +8,7 @@ function maybeReturnSetting(prop, key, type = "camel") {
 }
 
 export function getSetting(key, options = {}) {
+  // Get the initial props to query and the fallback if provided.
   const {
     fallback,
     props = ["dataConfig", "customProps", "settings", "context.settings"],

--- a/packages/core/src/js/helpers/getSetting.js
+++ b/packages/core/src/js/helpers/getSetting.js
@@ -1,20 +1,10 @@
 import { toCamel, toKebab } from "@vrembem/core";
 
 function maybeReturnSetting(prop, key, type = "camel") {
-  let context = this;
-  const parts = prop.split(".");
-
-  // Check if multiple props were passed (supports max 2).
-  if (parts.length > 1) {
-    context = this[parts[0]];
-    prop = parts[1];
-  }
-
   // Convert the key case based on provided type.
   key = (type === "camel") ? toCamel(key) : toKebab(key);
-
   // Return the setting if it exists, otherwise return undefined.
-  return context?.[prop]?.[key];
+  return prop.split(".").concat(key).reduce((obj, key) => obj?.[key], this);
 }
 
 export function getSetting(key, options = {}) {

--- a/packages/core/tests/Collection.test.js
+++ b/packages/core/tests/Collection.test.js
@@ -7,6 +7,7 @@ document.body.innerHTML = `
 
 const defaultSettings = {
   dataConfig: "config",
+  customProps: [],
   teleport: null,
   teleportMethod: "append"
 };

--- a/packages/core/tests/CollectionEntry.test.js
+++ b/packages/core/tests/CollectionEntry.test.js
@@ -7,7 +7,10 @@ document.body.innerHTML = `
   <div id="four" data-config="{ 'data': 111 }" style="--collection-test: fdsa;">...</div>
 `;
 
-const obj = new Collection({ test: "asdf" });
+const obj = new Collection({
+  customProps: ["test"],
+  test: "asdf" 
+});
 
 describe("constructor()", () => {
   it("should setup the collections entry object on instantiation", () => {

--- a/packages/core/tests/getCustomProps.test.js
+++ b/packages/core/tests/getCustomProps.test.js
@@ -1,4 +1,4 @@
-import { getCustomProps } from "../index";
+import { getCustomProps, toCamel, toKebab } from "../index";
 
 document.body.innerHTML = `
   <div id="asdf">asdf</div>
@@ -9,12 +9,43 @@ document.getElementById("asdf").style.setProperty("--vb-asdf-foreground", "green
 
 const mockEntry = {
   el: document.getElementById("asdf"),
+  settings: {
+    customProps: ["background", "foreground"],
+  },
   context: { 
     module: "asdf",
     settings: {
       background: "black",
       foreground: "white"
     }
+  },
+  getSetting(key) {
+    // Store our key in both camel and kebab naming conventions.
+    const camel = toCamel(key);
+    const kebab = toKebab(key);
+
+    // Check the data config object.
+    if ("dataConfig" in this && camel in this.dataConfig) {
+      return this.dataConfig[camel];
+    }
+
+    // Check the custom properties object.
+    if ("customProps" in this && kebab in this.customProps) {
+      return this.customProps[kebab];
+    }
+
+    // Check the entry settings.
+    if ("settings" in this && camel in this.settings) {
+      return this.settings[camel];
+    }
+
+    // Check the context settings.
+    if ("settings" in this.context && camel in this.context.settings) {
+      return this.context.settings[camel];
+    }
+
+    // Throw error if setting does not exist.
+    throw(new Error(`${this.context.module} setting does not exist: ${key}`));
   }
 };
 

--- a/packages/core/tests/getCustomProps.test.js
+++ b/packages/core/tests/getCustomProps.test.js
@@ -1,4 +1,4 @@
-import { getCustomProps, toCamel, toKebab } from "../index";
+import { getCustomProps, getSetting } from "../index";
 
 document.body.innerHTML = `
   <div id="asdf">asdf</div>
@@ -20,32 +20,7 @@ const mockEntry = {
     }
   },
   getSetting(key) {
-    // Store our key in both camel and kebab naming conventions.
-    const camel = toCamel(key);
-    const kebab = toKebab(key);
-
-    // Check the data config object.
-    if ("dataConfig" in this && camel in this.dataConfig) {
-      return this.dataConfig[camel];
-    }
-
-    // Check the custom properties object.
-    if ("customProps" in this && kebab in this.customProps) {
-      return this.customProps[kebab];
-    }
-
-    // Check the entry settings.
-    if ("settings" in this && camel in this.settings) {
-      return this.settings[camel];
-    }
-
-    // Check the context settings.
-    if ("settings" in this.context && camel in this.context.settings) {
-      return this.context.settings[camel];
-    }
-
-    // Throw error if setting does not exist.
-    throw(new Error(`${this.context.module} setting does not exist: ${key}`));
+    return getSetting.call(this, key);
   }
 };
 

--- a/packages/core/tests/getSettings.test.js
+++ b/packages/core/tests/getSettings.test.js
@@ -20,6 +20,7 @@ const settings = {
 
 const contextSettings = {
   context: {
+    module: "MyModule",
     settings: {
       someSetting: "context-123"
     }
@@ -80,7 +81,7 @@ test("should throw an error if a setting doesn't exist anywhere", () => {
     ...settings, 
     ...contextSettings
   };
-  expect(() => getSetting.call(mockData, "asdf")).toThrow("undefined setting does not exist: asdf");
+  expect(() => getSetting.call(mockData, "asdf")).toThrow("MyModule setting does not exist: asdf");
 });
 
 test("should be able to provide a fallback if a setting isn't found", () => {

--- a/packages/core/tests/getSettings.test.js
+++ b/packages/core/tests/getSettings.test.js
@@ -1,0 +1,110 @@
+import { getSetting } from "../src/js/helpers/getSetting";
+
+const dataConfig = {
+  dataConfig: {
+    someSetting: "asdf"
+  }
+};
+
+const customProps = {
+  customProps: {
+    "some-setting": "fdsa"
+  }
+};
+
+const settings = {
+  settings: {
+    someSetting: "1234"
+  }
+};
+
+const contextSettings = {
+  context: {
+    settings: {
+      someSetting: "context-123"
+    }
+  }
+};
+
+test("should return a settings value from settings", () => {
+  const mockData = settings;
+  const result = getSetting.call(mockData, "someSetting");
+  expect(result).toBe("1234");
+});
+
+test("should return a settings value from context settings", () => {
+  const mockData = contextSettings;
+  const result = getSetting.call(mockData, "someSetting");
+  expect(result).toBe("context-123");
+});
+
+test("should return a settings value from dataConfig", () => {
+  const mockData = dataConfig;
+  const result = getSetting.call(mockData, "someSetting");
+  expect(result).toBe("asdf");
+});
+
+test("should return a settings value from customProps", () => {
+  const mockData = customProps;
+  const result = getSetting.call(mockData, "someSetting");
+  expect(result).toBe("fdsa");
+});
+
+test("should prioritize settings over context settings", () => {
+  const mockData = { ...settings, ...contextSettings };
+  const result = getSetting.call(mockData, "someSetting");
+  expect(result).toBe("1234");
+});
+
+test("should prioritize customProps over settings", () => {
+  const mockData = { ...customProps, ...settings, ...contextSettings };
+  const result = getSetting.call(mockData, "someSetting");
+  expect(result).toBe("fdsa");
+});
+
+test("should prioritize dataConfig over customProps", () => {
+  const mockData = {
+    ...dataConfig, 
+    ...customProps, 
+    ...settings, 
+    ...contextSettings
+  };
+  const result = getSetting.call(mockData, "someSetting");
+  expect(result).toBe("asdf");
+});
+
+test("should throw an error if a setting doesn't exist anywhere", () => {
+  const mockData = {
+    ...dataConfig, 
+    ...customProps, 
+    ...settings, 
+    ...contextSettings
+  };
+  expect(() => getSetting.call(mockData, "asdf")).toThrow("undefined setting does not exist: asdf");
+});
+
+test("should be able to provide a fallback if a setting isn't found", () => {
+  const mockData = {
+    ...dataConfig, 
+    ...customProps, 
+    ...settings, 
+    ...contextSettings
+  };
+  const result = getSetting.call(mockData, "color", {
+    fallback: "blue"
+  });
+  expect(result).toBe("blue");
+});
+
+test("should be able to change the properties and the order they are checked", () => {
+  const mockData = {
+    ...dataConfig, 
+    ...customProps, 
+    ...settings, 
+    ...contextSettings
+  };
+  const result = getSetting.call(mockData, "someSetting", {
+    props: ["customProps", "settings"]
+  });
+  expect(result).toBe("fdsa");
+});

--- a/packages/drawer/src/js/defaults.js
+++ b/packages/drawer/src/js/defaults.js
@@ -23,6 +23,9 @@ export default {
   classModal: "drawer_modal",
 
   // Feature toggles
+  customProps: [
+    "transition-duration"
+  ],
   breakpoints: null,
   customEventPrefix: "drawer:",
   store: true,
@@ -31,5 +34,5 @@ export default {
   teleport: null,
   teleportMethod: "prepend",
   transition: true,
-  transitionDuration: "drawer-transition-duration"
+  transitionDuration: 500
 };

--- a/packages/drawer/src/js/defaults.js
+++ b/packages/drawer/src/js/defaults.js
@@ -34,5 +34,5 @@ export default {
   teleport: null,
   teleportMethod: "prepend",
   transition: true,
-  transitionDuration: 500
+  transitionDuration: 300
 };

--- a/packages/modal/src/js/defaults.js
+++ b/packages/modal/src/js/defaults.js
@@ -20,10 +20,13 @@ export default {
   stateClosed: "is-closed",
 
   // Feature settings
+  customProps: [
+    "transition-duration"
+  ],
   customEventPrefix: "modal:",
   setTabindex: true,
   teleport: null,
   teleportMethod: "append",
   transition: true,
-  transitionDuration: "modal-transition-duration"
+  transitionDuration: 500
 };

--- a/packages/modal/src/js/defaults.js
+++ b/packages/modal/src/js/defaults.js
@@ -28,5 +28,5 @@ export default {
   teleport: null,
   teleportMethod: "append",
   transition: true,
-  transitionDuration: 500
+  transitionDuration: 300
 };

--- a/packages/popover/src/js/defaults.js
+++ b/packages/popover/src/js/defaults.js
@@ -8,6 +8,15 @@ export default {
   stateActive: "is-active",
 
   // Custom properties and their defaults
+  customProps: [
+    "placement",
+    "event",
+    "offset",
+    "flip-padding",
+    "shift-padding",
+    "arrow-padding",
+    "toggle-delay"
+  ],
   placement: "bottom",
   event: "click",
   offset: 0,


### PR DESCRIPTION
## What changed?

This PR refactors which custom properties are queried when `getCustomProps` is called. Instead of searching every key in the `entry.context.settings` object, we now use the `entry.getSetting("customProps")` method to return an array of all the props to query custom properties for.

As part of this update, `getSetting` has also been refactored into a modular helper function which is then imported and applied as the entry method `getSetting`. It can now take an options object for setting a fallback value in cases where a setting doesn't exist as well as a props array with the order of properties to check for the setting. This allows for adjusting the order or adding on to the settings query.