### PR TITLE
Refactor collection and entry props

### DIFF
--- a/packages/core/src/js/Collection.js
+++ b/packages/core/src/js/Collection.js
@@ -2,6 +2,7 @@ import { CollectionEntry, lifecycleHook } from "@vrembem/core";
 
 export class Collection {
   constructor(options = {}) {
+    // TODO: This gets lost in minified builds which cause be unexpected.
     this.module = this.constructor.name;
     this.collection = [];
     this.settings = Object.assign({ 

--- a/packages/core/src/js/Collection.js
+++ b/packages/core/src/js/Collection.js
@@ -2,7 +2,6 @@ import { CollectionEntry, lifecycleHook } from "@vrembem/core";
 
 export class Collection {
   constructor(options = {}) {
-    // TODO: This gets lost in minified builds which cause be unexpected.
     this.module = this.constructor.name;
     this.collection = [];
     this.settings = Object.assign({ 

--- a/packages/core/src/js/CollectionEntry.js
+++ b/packages/core/src/js/CollectionEntry.js
@@ -8,8 +8,8 @@ import {
 } from "@vrembem/core";
 
 export class CollectionEntry {
-  constructor(context, query, options = {}) {
-    this.context = context;
+  constructor(parent, query, options = {}) {
+    this.parent = parent;
     this.id = query?.id || query;
     this.el = getElement(query);
     this.settings = Object.assign({}, options);
@@ -37,7 +37,7 @@ export class CollectionEntry {
   async mount(options = {}) {
     // Throw an error if the element for this entry was not found.
     if (this.el === null) {
-      throw new Error(`${this.context.module} element was not found with ID: "${this.id}"`);
+      throw new Error(`${this.parent.module} element was not found with ID: "${this.id}"`);
     }
 
     // Apply settings with passed options.

--- a/packages/core/src/js/helpers/getCustomProps.js
+++ b/packages/core/src/js/helpers/getCustomProps.js
@@ -14,7 +14,7 @@ export function getCustomProps(entry) {
   for (let i = 0; i < keys.length; i++) {
     // Get the custom property value.
     const prefix = getPrefix();
-    const module = entry.context.module.toLowerCase();
+    const module = entry.parent.module.toLowerCase();
     const key = toKebab(keys[i]);
     const value = styles.getPropertyValue(`--${prefix}${module}-${key}`).trim();
     // If a value was found, add it to our results object.

--- a/packages/core/src/js/helpers/getSetting.js
+++ b/packages/core/src/js/helpers/getSetting.js
@@ -11,7 +11,7 @@ export function getSetting(key, options = {}) {
   // Get the initial props to query and the fallback if provided.
   const {
     fallback,
-    props = ["dataConfig", "customProps", "settings", "context.settings"],
+    props = ["dataConfig", "customProps", "settings", "parent.settings"],
   } = options;
 
   // Loop through the props for the setting and return if found.
@@ -29,5 +29,5 @@ export function getSetting(key, options = {}) {
   }
 
   // Otherwise, throw an error.
-  throw new Error(`${this.context.module} setting does not exist: ${key}`);
+  throw new Error(`${this.parent.module} setting does not exist: ${key}`);
 }

--- a/packages/core/tests/Collection.test.js
+++ b/packages/core/tests/Collection.test.js
@@ -67,7 +67,7 @@ describe("createEntry()", () => {
     const obj = new Collection();
     const entry = await obj.createEntry("asdf");
     expect(entry.id).toBe("asdf");
-    expect(entry.context.module).toBe("Collection");
+    expect(entry.parent.module).toBe("Collection");
     expect(entry.getSetting("dataConfig")).toBe("config");
   });
 
@@ -75,7 +75,7 @@ describe("createEntry()", () => {
     const obj = new Collection();
     const entry = await obj.createEntry("fdsa", { dataConfig: "test" });
     expect(entry.id).toBe("fdsa");
-    expect(entry.context.module).toBe("Collection");
+    expect(entry.parent.module).toBe("Collection");
     expect(entry.getSetting("dataConfig")).toBe("test");
   });
 });

--- a/packages/core/tests/CollectionEntry.test.js
+++ b/packages/core/tests/CollectionEntry.test.js
@@ -17,7 +17,7 @@ describe("constructor()", () => {
     const entry = new CollectionEntry(obj, "one");
     expect(entry.id).toBe("one");
     expect(entry.el).toBe(document.getElementById("one"));
-    expect(entry.context.module).toBe("Collection");
+    expect(entry.parent.module).toBe("Collection");
   });
 
   it("should be able to pass options through the instantiation", () => {
@@ -59,7 +59,7 @@ describe("getCustomProps()", () => {
 });
 
 describe("getSetting()", () => {
-  it("should get a settings value from the entry context", () => {
+  it("should get a settings value from the entry parent", () => {
     const entry = new CollectionEntry(obj, "one");
     expect(entry.getSetting("test")).toBe("asdf");
   });

--- a/packages/core/tests/getCustomProps.test.js
+++ b/packages/core/tests/getCustomProps.test.js
@@ -12,7 +12,7 @@ const mockEntry = {
   settings: {
     customProps: ["background", "foreground"],
   },
-  context: { 
+  parent: { 
     module: "asdf",
     settings: {
       background: "black",

--- a/packages/core/tests/getSettings.test.js
+++ b/packages/core/tests/getSettings.test.js
@@ -18,11 +18,11 @@ const settings = {
   }
 };
 
-const contextSettings = {
-  context: {
+const parentSettings = {
+  parent: {
     module: "MyModule",
     settings: {
-      someSetting: "context-123"
+      someSetting: "parent-123"
     }
   }
 };
@@ -33,10 +33,10 @@ test("should return a settings value from settings", () => {
   expect(result).toBe("1234");
 });
 
-test("should return a settings value from context settings", () => {
-  const mockData = contextSettings;
+test("should return a settings value from parent settings", () => {
+  const mockData = parentSettings;
   const result = getSetting.call(mockData, "someSetting");
-  expect(result).toBe("context-123");
+  expect(result).toBe("parent-123");
 });
 
 test("should return a settings value from dataConfig", () => {
@@ -51,14 +51,14 @@ test("should return a settings value from customProps", () => {
   expect(result).toBe("fdsa");
 });
 
-test("should prioritize settings over context settings", () => {
-  const mockData = { ...settings, ...contextSettings };
+test("should prioritize settings over parent settings", () => {
+  const mockData = { ...settings, ...parentSettings };
   const result = getSetting.call(mockData, "someSetting");
   expect(result).toBe("1234");
 });
 
 test("should prioritize customProps over settings", () => {
-  const mockData = { ...customProps, ...settings, ...contextSettings };
+  const mockData = { ...customProps, ...settings, ...parentSettings };
   const result = getSetting.call(mockData, "someSetting");
   expect(result).toBe("fdsa");
 });
@@ -68,7 +68,7 @@ test("should prioritize dataConfig over customProps", () => {
     ...dataConfig, 
     ...customProps, 
     ...settings, 
-    ...contextSettings
+    ...parentSettings
   };
   const result = getSetting.call(mockData, "someSetting");
   expect(result).toBe("asdf");
@@ -79,7 +79,7 @@ test("should throw an error if a setting doesn't exist anywhere", () => {
     ...dataConfig, 
     ...customProps, 
     ...settings, 
-    ...contextSettings
+    ...parentSettings
   };
   expect(() => getSetting.call(mockData, "asdf")).toThrow("MyModule setting does not exist: asdf");
 });
@@ -89,7 +89,7 @@ test("should be able to provide a fallback if a setting isn't found", () => {
     ...dataConfig, 
     ...customProps, 
     ...settings, 
-    ...contextSettings
+    ...parentSettings
   };
   const result = getSetting.call(mockData, "color", {
     fallback: "blue"
@@ -102,7 +102,7 @@ test("should be able to change the properties and the order they are checked", (
     ...dataConfig, 
     ...customProps, 
     ...settings, 
-    ...contextSettings
+    ...parentSettings
   };
   const result = getSetting.call(mockData, "someSetting", {
     props: ["customProps", "settings"]

--- a/packages/drawer/src/js/Drawer.js
+++ b/packages/drawer/src/js/Drawer.js
@@ -13,6 +13,7 @@ export class Drawer extends Collection {
 
   constructor(options) {
     super({ ...defaults, ...options});
+    this.module = "Drawer";
     this.focusTrap = new FocusTrap();
     this.#handleClick = handleClick.bind(this);
     this.#handleKeydown = handleKeydown.bind(this);

--- a/packages/drawer/src/js/DrawerEntry.js
+++ b/packages/drawer/src/js/DrawerEntry.js
@@ -8,8 +8,8 @@ export class DrawerEntry extends CollectionEntry {
   #state;
   #breakpoint;
 
-  constructor(context, query, options = {}) {
-    super(context, query, options);
+  constructor(parent, query, options = {}) {
+    super(parent, query, options);
     this.dialog = null;
     this.trigger = null;
     // Create an instance of the Breakpoint class.
@@ -21,11 +21,11 @@ export class DrawerEntry extends CollectionEntry {
   }
 
   get breakpoint() {
-    return getBreakpoint.call(this.context, this.el);
+    return getBreakpoint.call(this.parent, this.el);
   }
 
   get store() {
-    return this.context.store.get(this.id);
+    return this.parent.store.get(this.id);
   }
 
   get mode() {
@@ -34,7 +34,7 @@ export class DrawerEntry extends CollectionEntry {
 
   set mode(value) {
     this.#mode = value;
-    switchMode.call(this.context, this);
+    switchMode.call(this.parent, this);
   }
 
   get state() {
@@ -51,7 +51,7 @@ export class DrawerEntry extends CollectionEntry {
 
       // Save the store state if enabled.
       if (this.getSetting("store")) {
-        this.context.store.set(this.id, value);
+        this.parent.store.set(this.id, value);
       }
     }
 
@@ -65,19 +65,19 @@ export class DrawerEntry extends CollectionEntry {
   }
 
   async open(transition, focus) {
-    return this.context.open(this, transition, focus);
+    return this.parent.open(this, transition, focus);
   }
 
   async close(transition, focus) {
-    return this.context.close(this, transition, focus);
+    return this.parent.close(this, transition, focus);
   }
 
   async toggle(transition, focus) {
-    return this.context.toggle(this, transition, focus);
+    return this.parent.toggle(this, transition, focus);
   }
 
   async deregister() {
-    return this.context.deregister(this.id);
+    return this.parent.deregister(this.id);
   }
 
   mountBreakpoint() {
@@ -128,7 +128,7 @@ export class DrawerEntry extends CollectionEntry {
     }
 
     // Remove entry from local store.
-    this.context.store.set(this.id);
+    this.parent.store.set(this.id);
 
     // Unmount the MatchMedia functionality.
     this.unmountBreakpoint();

--- a/packages/modal/src/js/Modal.js
+++ b/packages/modal/src/js/Modal.js
@@ -16,6 +16,7 @@ export class Modal extends Collection {
 
   constructor(options) {
     super({ ...defaults, ...options});
+    this.module = "Modal";
     this.trigger = null;
     this.focusTrap = new FocusTrap();
     this.#handleClick = handleClick.bind(this);

--- a/packages/modal/src/js/ModalEntry.js
+++ b/packages/modal/src/js/ModalEntry.js
@@ -1,8 +1,8 @@
 import { CollectionEntry } from "@vrembem/core";
 
 export class ModalEntry extends CollectionEntry {
-  constructor(context, query, options = {}) {
-    super(context, query, options);
+  constructor(parent, query, options = {}) {
+    super(parent, query, options);
     this.state = "closed";
     this.dialog = null;
   }
@@ -12,19 +12,19 @@ export class ModalEntry extends CollectionEntry {
   }
 
   async open(transition, focus) {
-    return this.context.open(this, transition, focus);
+    return this.parent.open(this, transition, focus);
   }
 
   async close(transition, focus) {
-    return this.context.close(this, transition, focus);
+    return this.parent.close(this, transition, focus);
   }
 
   async replace(transition, focus) {
-    return this.context.replace(this, transition, focus);
+    return this.parent.replace(this, transition, focus);
   }
 
   async deregister() {
-    return this.context.deregister(this.id);
+    return this.parent.deregister(this.id);
   }
 
   async beforeMount() {
@@ -66,7 +66,7 @@ export class ModalEntry extends CollectionEntry {
       await this.close(false);
     } else {
       // Remove modal from stack.
-      this.context.stack.remove(this);
+      this.parent.stack.remove(this);
     }
   }
 }

--- a/packages/popover/src/js/Popover.js
+++ b/packages/popover/src/js/Popover.js
@@ -11,6 +11,7 @@ export class Popover extends Collection {
 
   constructor(options = {}) {
     super({ ...defaults, ...options});
+    this.module = "Popover";
     this.trigger = null;
     this.#handleKeydown = handleKeydown.bind(this);
   }

--- a/packages/popover/src/js/PopoverEntry.js
+++ b/packages/popover/src/js/PopoverEntry.js
@@ -11,8 +11,8 @@ export class PopoverEntry extends CollectionEntry {
   #eventListeners;
   #isHovered;
 
-  constructor(context, query, options = {}) {
-    super(context, query, options);
+  constructor(parent, query, options = {}) {
+    super(parent, query, options);
     this.state = "closed";
     this.toggleDelayId = null;
     this.trigger = null;
@@ -49,15 +49,15 @@ export class PopoverEntry extends CollectionEntry {
   }
   
   async open() {
-    return this.context.open(this);
+    return this.parent.open(this);
   }
 
   async close() {
-    return this.context.close(this);
+    return this.parent.close(this);
   }
   
   async deregister() {
-    return this.context.deregister(this.id);
+    return this.parent.deregister(this.id);
   }
 
   registerEventListeners() {
@@ -72,15 +72,15 @@ export class PopoverEntry extends CollectionEntry {
         this.#eventListeners = [{
           el: ["el", "trigger"],
           type: ["mouseenter", "focus"],
-          listener: handleMouseEnter.bind(this.context, this)
+          listener: handleMouseEnter.bind(this.parent, this)
         }, {
           el: ["el", "trigger"],
           type: ["mouseleave", "focusout"],
-          listener: handleMouseLeave.bind(this.context, this)
+          listener: handleMouseLeave.bind(this.parent, this)
         }, {
           el: ["trigger"],
           type: ["click"],
-          listener: handleTooltipClick.bind(this.context, this)
+          listener: handleTooltipClick.bind(this.parent, this)
         }];
   
         // Loop through listeners and apply to the appropriate elements.
@@ -99,7 +99,7 @@ export class PopoverEntry extends CollectionEntry {
         this.#eventListeners = [{
           el: ["trigger"],
           type: ["click"],
-          listener: handleClick.bind(this.context, this)
+          listener: handleClick.bind(this.parent, this)
         }];
   
         // Loop through listeners and apply to the appropriate elements.


### PR DESCRIPTION
## What changed?

This PR refactors the following properties of collection and collection entry objects:

- Collection > `module` value is now explicitly set in popover, modal and drawer components.
- CollectionEntry > `context` has been renamed to `parent` so it's more clear what the context is of.