### PR TITLE
Add a get method to pluginsArray

### DIFF
--- a/packages/core/src/js/helpers/pluginsArray.js
+++ b/packages/core/src/js/helpers/pluginsArray.js
@@ -25,6 +25,10 @@ export class pluginsArray extends Array {
     return true;
   }
 
+  get(name) {
+    return this.find((plugin) => plugin.name === name);
+  }
+
   add(plugin) {
     if (Array.isArray(plugin)) {
       plugin.forEach((plugin) => this.add(plugin));

--- a/packages/core/src/js/plugins/mediaQuery.js
+++ b/packages/core/src/js/plugins/mediaQuery.js
@@ -1,18 +1,26 @@
 import { getPrefix } from "../helpers/getPrefix";
 
 const defaults = {
-  // The data attributes to query media query and breakpoint values from.
+  // The data attributes to get the breakpoint values from.
   dataBreakpoint: "breakpoint",
+  // The data attributes to get the media query value from.
   dataMediaQuery: "media-query",
-  // The string to replace in mediaQueries.
+  // The string token to replace in the media query string.
   token: "{{BP}}",
-  // Sets a global breakpoint. Should be overrode by presence of dataBreakpoint.
+  // Sets a global breakpoint. Can be overridden by setting a data attribute
+  // value. Notice: setting this option will enable a media query breakpoint on all entries.
   breakpoint: null,
+  // The default media query string to use. Can be overridden by setting a data
+  // attribute value.
   mediaQuery: "(min-width: {{BP}})",
-  // Map entry ID or breakpoint key to breakpoint values.
+  // Maps entry ID or breakpoint key to breakpoint values. This is referenced
+  // when getting an entries breakpoint value.
   breakpoints: {},
-  // Map entry ID's to a media query strings. Media query may contain a token.
+  // Maps entry ID's to a media query strings. Media query may contain a token.
+  // This is referenced when getting an entries media query string.
   mediaQueries: {},
+  // The function to run when the MediaQueryList triggers a "change" event.
+  // This is run once on initial mount.
   onChange: () => {}
 };
 

--- a/packages/core/tests/helpers/pluginsArray.test.js
+++ b/packages/core/tests/helpers/pluginsArray.test.js
@@ -20,10 +20,16 @@ test("should remove a plugin from the plugins array", async () => {
 test("should add an array of plugins at once", () => {
   expect(plugins.length).toBe(0);
   plugins.add([
-    { name: "one" },
-    { name: "two" }
+    { name: "one", settings: { a: "a" } },
+    { name: "two", settings: { b: "b" } }
   ]);
   expect(plugins.length).toBe(2);
+});
+
+test("should return a specific plugin when using the get method", () => {
+  expect(plugins.get("one")).toStrictEqual({ name: "one", settings: { a: "a" } });
+  expect(plugins.get("two")).toStrictEqual({ name: "two", settings: { b: "b" } });
+  expect(plugins.get("three")).toBe(undefined);
 });
 
 test("should log a console error if the plugin is not a valid object", () => {


### PR DESCRIPTION
## What changed?

This PR adds a `get` method to the `pluginsArray` class that will return a registered plugin from the array if provided a valid name.

```js
// Returns the registered teleport plugin.
modal.plugins.get("teleport");
```