### PR TITLE
Provide context object as an argument in lifecycle hooks

### DIFF
--- a/docs/src/modules/useDrawer.js
+++ b/docs/src/modules/useDrawer.js
@@ -9,9 +9,9 @@ if (typeof window !== "undefined") {
     plugins: [
       propStore({
         prop: "inlineState",
-        value: (entry) => entry.store,
-        condition: (entry) => ["opened", "closed"].includes(entry.state),
-        onChange: (entry) => entry.applyState()
+        value: ({ entry }) => entry.store,
+        condition: ({ entry }) => ["opened", "closed"].includes(entry.state),
+        onChange: ({ entry }) => entry.applyState()
       }),
       mediaQuery({
         onChange(event, entry) {

--- a/packages/core/src/js/Collection.js
+++ b/packages/core/src/js/Collection.js
@@ -41,20 +41,20 @@ export class Collection {
     await entry.mount();
 
     // beforeRegister lifecycle hooks.
-    await maybeRunMethod.call(this, "beforeRegister", entry);
-    await maybeRunMethod.call(entry, "beforeRegister");
+    await maybeRunMethod(this, "beforeRegister", entry);
+    await maybeRunMethod(entry, "beforeRegister");
     for (const plugin of this.plugins) {
-      await maybeRunMethod.call(plugin, "beforeRegister", entry);
+      await maybeRunMethod(plugin, "beforeRegister", entry);
     }
 
     // Add the entry to the collection.
     this.collection.push(entry);
 
     // afterRegister lifecycle hooks.
-    await maybeRunMethod.call(this, "afterRegister", entry);
-    await maybeRunMethod.call(entry, "afterRegister");
+    await maybeRunMethod(this, "afterRegister", entry);
+    await maybeRunMethod(entry, "afterRegister");
     for (const plugin of this.plugins) {
-      await maybeRunMethod.call(plugin, "afterRegister", entry);
+      await maybeRunMethod(plugin, "afterRegister", entry);
     }
 
     return entry;
@@ -68,10 +68,10 @@ export class Collection {
       await entry.unmount(reReg);
 
       // beforeDeregister lifecycle hooks.
-      await maybeRunMethod.call(this, "beforeDeregister", entry, reReg);
-      await maybeRunMethod.call(entry, "beforeDeregister", reReg);
+      await maybeRunMethod(this, "beforeDeregister", entry, reReg);
+      await maybeRunMethod(entry, "beforeDeregister", reReg);
       for (const plugin of this.plugins) {
-        await maybeRunMethod.call(plugin, "beforeDeregister", entry, reReg);
+        await maybeRunMethod(plugin, "beforeDeregister", entry, reReg);
       }
 
       // Remove all the owned properties from the entry.
@@ -85,10 +85,10 @@ export class Collection {
       this.collection.splice(index, 1);
 
       // afterDeregister lifecycle hooks.
-      await maybeRunMethod.call(this, "afterDeregister", entry, reReg);
-      await maybeRunMethod.call(entry, "afterDeregister", reReg);
+      await maybeRunMethod(this, "afterDeregister", entry, reReg);
+      await maybeRunMethod(entry, "afterDeregister", reReg);
       for (const plugin of this.plugins) {
-        await maybeRunMethod.call(plugin, "afterDeregister", entry, reReg);
+        await maybeRunMethod(plugin, "afterDeregister", entry, reReg);
       }
     }
 
@@ -101,14 +101,14 @@ export class Collection {
 
     // Mount plugins.
     for (const plugin of this.plugins) {
-      await maybeRunMethod.call(plugin, "mount", this);
+      await maybeRunMethod(plugin, "mount", this);
     }
 
     // beforeMount lifecycle hooks.
     
-    await maybeRunMethod.call(this, "beforeMount");
+    await maybeRunMethod(this, "beforeMount");
     for (const plugin of this.plugins) {
-      await maybeRunMethod.call(plugin, "beforeMount", this);
+      await maybeRunMethod(plugin, "beforeMount", this);
     }
 
     // Get all the selector elements and register them.
@@ -118,9 +118,9 @@ export class Collection {
     }
 
     // afterMount lifecycle hooks.
-    await maybeRunMethod.call(this, "afterMount");
+    await maybeRunMethod(this, "afterMount");
     for (const plugin of this.plugins) {
-      await maybeRunMethod.call(plugin, "afterMount", { plugin, parent: this});
+      await maybeRunMethod(plugin, "afterMount", { plugin, parent: this});
     }
 
     return this;
@@ -128,9 +128,9 @@ export class Collection {
 
   async unmount() {
     // beforeUnmount lifecycle hooks.
-    await maybeRunMethod.call(this, "beforeUnmount");
+    await maybeRunMethod(this, "beforeUnmount");
     for (const plugin of this.plugins) {
-      await maybeRunMethod.call(plugin, "beforeUnmount", this);
+      await maybeRunMethod(plugin, "beforeUnmount", this);
     }
 
     // Loop through the collection and deregister each entry.
@@ -139,14 +139,14 @@ export class Collection {
     }
 
     // afterUnmount lifecycle hooks.
-    await maybeRunMethod.call(this, "afterUnmount");
+    await maybeRunMethod(this, "afterUnmount");
     for (const plugin of this.plugins) {
-      await maybeRunMethod.call(plugin, "afterUnmount", this);
+      await maybeRunMethod(plugin, "afterUnmount", this);
     }
 
     // Unmount plugins.
     for (const plugin of this.plugins) {
-      await maybeRunMethod.call(plugin, "unmount", this);
+      await maybeRunMethod(plugin, "unmount", this);
     }
     
     return this;

--- a/packages/core/src/js/Collection.js
+++ b/packages/core/src/js/Collection.js
@@ -120,7 +120,7 @@ export class Collection {
     // afterMount lifecycle hooks.
     await maybeRunMethod.call(this, "afterMount");
     for (const plugin of this.plugins) {
-      await maybeRunMethod.call(plugin, "afterMount", this);
+      await maybeRunMethod.call(plugin, "afterMount", { plugin, parent: this});
     }
 
     return this;

--- a/packages/core/src/js/Collection.js
+++ b/packages/core/src/js/Collection.js
@@ -41,20 +41,20 @@ export class Collection {
     await entry.mount();
 
     // beforeRegister lifecycle hooks.
-    await maybeRunMethod(this, "beforeRegister", entry);
-    await maybeRunMethod(entry, "beforeRegister");
+    await maybeRunMethod(this, "beforeRegister", { parent: this, entry});
+    await maybeRunMethod(entry, "beforeRegister", { parent: this, entry});
     for (const plugin of this.plugins) {
-      await maybeRunMethod(plugin, "beforeRegister", entry);
+      await maybeRunMethod(plugin, "beforeRegister", { plugin, parent: this, entry});
     }
 
     // Add the entry to the collection.
     this.collection.push(entry);
 
     // afterRegister lifecycle hooks.
-    await maybeRunMethod(this, "afterRegister", entry);
-    await maybeRunMethod(entry, "afterRegister");
+    await maybeRunMethod(this, "afterRegister", { parent: this, entry});
+    await maybeRunMethod(entry, "afterRegister", { parent: this, entry});
     for (const plugin of this.plugins) {
-      await maybeRunMethod(plugin, "afterRegister", entry);
+      await maybeRunMethod(plugin, "afterRegister", { plugin, parent: this, entry});
     }
 
     return entry;
@@ -68,10 +68,10 @@ export class Collection {
       await entry.unmount(reReg);
 
       // beforeDeregister lifecycle hooks.
-      await maybeRunMethod(this, "beforeDeregister", entry, reReg);
-      await maybeRunMethod(entry, "beforeDeregister", reReg);
+      await maybeRunMethod(this, "beforeDeregister", { parent: this, entry}, reReg);
+      await maybeRunMethod(entry, "beforeDeregister", { parent: this, entry}, reReg);
       for (const plugin of this.plugins) {
-        await maybeRunMethod(plugin, "beforeDeregister", entry, reReg);
+        await maybeRunMethod(plugin, "beforeDeregister", { plugin, parent: this, entry}, reReg);
       }
 
       // Remove all the owned properties from the entry.
@@ -85,10 +85,10 @@ export class Collection {
       this.collection.splice(index, 1);
 
       // afterDeregister lifecycle hooks.
-      await maybeRunMethod(this, "afterDeregister", entry, reReg);
-      await maybeRunMethod(entry, "afterDeregister", reReg);
+      await maybeRunMethod(this, "afterDeregister", { parent: this, entry}, reReg);
+      await maybeRunMethod(entry, "afterDeregister", { parent: this, entry}, reReg);
       for (const plugin of this.plugins) {
-        await maybeRunMethod(plugin, "afterDeregister", entry, reReg);
+        await maybeRunMethod(plugin, "afterDeregister", { plugin, parent: this, entry}, reReg);
       }
     }
 
@@ -101,14 +101,14 @@ export class Collection {
 
     // Mount plugins.
     for (const plugin of this.plugins) {
-      await maybeRunMethod(plugin, "mount", this);
+      await maybeRunMethod(plugin, "mount", { plugin, parent: this});
     }
 
     // beforeMount lifecycle hooks.
     
     await maybeRunMethod(this, "beforeMount");
     for (const plugin of this.plugins) {
-      await maybeRunMethod(plugin, "beforeMount", this);
+      await maybeRunMethod(plugin, "beforeMount", { plugin, parent: this});
     }
 
     // Get all the selector elements and register them.
@@ -130,7 +130,7 @@ export class Collection {
     // beforeUnmount lifecycle hooks.
     await maybeRunMethod(this, "beforeUnmount");
     for (const plugin of this.plugins) {
-      await maybeRunMethod(plugin, "beforeUnmount", this);
+      await maybeRunMethod(plugin, "beforeUnmount", { plugin, parent: this});
     }
 
     // Loop through the collection and deregister each entry.
@@ -141,12 +141,12 @@ export class Collection {
     // afterUnmount lifecycle hooks.
     await maybeRunMethod(this, "afterUnmount");
     for (const plugin of this.plugins) {
-      await maybeRunMethod(plugin, "afterUnmount", this);
+      await maybeRunMethod(plugin, "afterUnmount", { plugin, parent: this});
     }
 
     // Unmount plugins.
     for (const plugin of this.plugins) {
-      await maybeRunMethod(plugin, "unmount", this);
+      await maybeRunMethod(plugin, "unmount", { plugin, parent: this});
     }
     
     return this;

--- a/packages/core/src/js/CollectionEntry.js
+++ b/packages/core/src/js/CollectionEntry.js
@@ -41,17 +41,17 @@ export class CollectionEntry {
     this.getCustomProps();
 
     // On mount lifecycle hooks.
-    await maybeRunMethod(this, "onMount");
+    await maybeRunMethod(this, "onMount", { parent: this.parent, entry: this });
     for (const plugin of this.parent.plugins) {
-      await maybeRunMethod(plugin, "onMount", this);
+      await maybeRunMethod(plugin, "onMount", { plugin, parent: this.parent, entry: this });
     }
   }
 
   async unmount(reMount = false) {
     // Before mount lifecycle hooks.
-    await maybeRunMethod(this, "onUnmount", reMount);
+    await maybeRunMethod(this, "onUnmount", { parent: this.parent, entry: this }, reMount);
     for (const plugin of this.parent.plugins) {
-      await maybeRunMethod(plugin, "onUnmount", this, reMount);
+      await maybeRunMethod(plugin, "onUnmount", { plugin, parent: this.parent, entry: this }, reMount);
     }
   }
 }

--- a/packages/core/src/js/CollectionEntry.js
+++ b/packages/core/src/js/CollectionEntry.js
@@ -41,17 +41,17 @@ export class CollectionEntry {
     this.getCustomProps();
 
     // On mount lifecycle hooks.
-    await maybeRunMethod.call(this, "onMount");
+    await maybeRunMethod(this, "onMount");
     for (const plugin of this.parent.plugins) {
-      await maybeRunMethod.call(plugin, "onMount", this);
+      await maybeRunMethod(plugin, "onMount", this);
     }
   }
 
   async unmount(reMount = false) {
     // Before mount lifecycle hooks.
-    await maybeRunMethod.call(this, "onUnmount", reMount);
+    await maybeRunMethod(this, "onUnmount", reMount);
     for (const plugin of this.parent.plugins) {
-      await maybeRunMethod.call(plugin, "onUnmount", this, reMount);
+      await maybeRunMethod(plugin, "onUnmount", this, reMount);
     }
   }
 }

--- a/packages/core/src/js/helpers/pluginsArray.js
+++ b/packages/core/src/js/helpers/pluginsArray.js
@@ -40,7 +40,7 @@ export class pluginsArray extends Array {
   async remove(name) {
     const index = this.findIndex((plugin) => plugin.name === name);
     if (~index) {
-      await maybeRunMethod(this[index], "unmount", this.parent);
+      await maybeRunMethod(this[index], "unmount", { parent: this.parent });
       this.splice(index, 1);
     }
   }

--- a/packages/core/src/js/helpers/pluginsArray.js
+++ b/packages/core/src/js/helpers/pluginsArray.js
@@ -40,7 +40,7 @@ export class pluginsArray extends Array {
   async remove(name) {
     const index = this.findIndex((plugin) => plugin.name === name);
     if (~index) {
-      await maybeRunMethod.call(this[index], "unmount", this.parent);
+      await maybeRunMethod(this[index], "unmount", this.parent);
       this.splice(index, 1);
     }
   }

--- a/packages/core/src/js/plugins/debug.js
+++ b/packages/core/src/js/plugins/debug.js
@@ -2,7 +2,8 @@ import { createPluginObject } from "../helpers";
 
 const defaults = {
   color1: "color: hsl(152deg 60% 40%)",
-  color2: "color: hsl(152deg 60% 50%)"
+  color2: "color: hsl(152deg 60% 50%)",
+  condition: true
 };
 
 export function debug(options = {}) {
@@ -13,11 +14,15 @@ export function debug(options = {}) {
 
   function log(string, args) {
     console.log(
-      `%c📡 DEBUG: %c${string} > Arguments:`,
+      `%c📡 DEBUG: %c${string}`,
       props.settings.color1,
       props.settings.color2,
       ...args
     );
+  }
+
+  function getValue(obj, ...args) {
+    return (typeof obj === "function") ? obj(...args) : obj;
   }
 
   const methods = {
@@ -28,14 +33,23 @@ export function debug(options = {}) {
     beforeMount() {
       log("beforeMount()", arguments);
     },
-    onMount() {
-      log("onMount()", arguments);
+    onMount({ parent, entry }) {
+      if (getValue(this.settings.condition, { parent, entry })) {
+        const count = parent.collection.length;
+        log(`onMount() > [${count}] #${entry.id}`, arguments);
+      }
     },
-    beforeRegister() {
-      log("beforeRegister()", arguments);
+    beforeRegister({ parent, entry }) {
+      if (getValue(this.settings.condition, { parent, entry })) {
+        const count = parent.collection.length;
+        log(`beforeRegister() > [${count}] #${entry.id}`, arguments);
+      }
     },
-    afterRegister() {
-      log("afterRegister()", arguments);
+    afterRegister({ parent, entry }) {
+      if (getValue(this.settings.condition, { parent, entry })) {
+        const count = parent.collection.length - 1;
+        log(`afterRegister() > [${count}] #${entry.id}`, arguments);
+      }
     },
     afterMount() {
       log("afterMount()", arguments);
@@ -45,14 +59,17 @@ export function debug(options = {}) {
     beforeUnmount() {
       log("beforeUnmount()", arguments);
     },
-    onUnmount() {
-      log("onUnmount()", arguments);
+    onUnmount({ parent, entry }) {
+      const count = parent.collection.length - 1;
+      log(`onUnmount() > [${count}] #${entry.id}`, arguments);
     },
-    beforeDeregister() {
-      log("beforeDeregister()", arguments);
+    beforeDeregister({ parent, entry }) {
+      const count = parent.collection.length - 1;
+      log(`beforeDeregister() > [${count}] #${entry.id}`, arguments);
     },
-    afterDeregister() {
-      log("afterDeregister()", arguments);
+    afterDeregister({ parent, entry }) {
+      const count = parent.collection.length;
+      log(`afterDeregister() > [${count}] #${entry.id}`, arguments);
     },
     afterUnmount() {
       log("afterUnmount()", arguments);

--- a/packages/core/src/js/plugins/debug.js
+++ b/packages/core/src/js/plugins/debug.js
@@ -11,53 +11,54 @@ export function debug(options = {}) {
     settings: {...defaults, ...options}
   };
 
-  function log(string) {
+  function log(string, args) {
     console.log(
-      `%cDEBUG: %c${string}`, 
+      `%c📡 DEBUG: %c${string} > Arguments:`,
       props.settings.color1,
       props.settings.color2,
+      ...args
     );
   }
 
   const methods = {
     // Mount lifecycle hooks...
     mount() {
-      log("mountPlugins()");
+      log("mountPlugins()", arguments);
     },
     beforeMount() {
-      log("beforeMount()");
+      log("beforeMount()", arguments);
     },
     onMount() {
-      log("onMount()");
+      log("onMount()", arguments);
     },
     beforeRegister() {
-      log("beforeRegister()");
+      log("beforeRegister()", arguments);
     },
     afterRegister() {
-      log("afterRegister()");
+      log("afterRegister()", arguments);
     },
     afterMount() {
-      log("afterMount()");
+      log("afterMount()", arguments);
     },
 
     // Unmount lifecycle hooks...
     beforeUnmount() {
-      log("beforeUnmount()");
+      log("beforeUnmount()", arguments);
     },
     onUnmount() {
-      log("onUnmount()");
+      log("onUnmount()", arguments);
     },
     beforeDeregister() {
-      log("beforeDeregister()");
+      log("beforeDeregister()", arguments);
     },
     afterDeregister() {
-      log("afterDeregister()");
+      log("afterDeregister()", arguments);
     },
     afterUnmount() {
-      log("afterUnmount()");
+      log("afterUnmount()", arguments);
     },
     unmount() {
-      log("unmountPlugins()");
+      log("unmountPlugins()", arguments);
     }
   };
 

--- a/packages/core/src/js/plugins/debug.js
+++ b/packages/core/src/js/plugins/debug.js
@@ -60,16 +60,22 @@ export function debug(options = {}) {
       log("beforeUnmount()", arguments);
     },
     onUnmount({ parent, entry }) {
-      const count = parent.collection.length - 1;
-      log(`onUnmount() > [${count}] #${entry.id}`, arguments);
+      if (getValue(this.settings.condition, { parent, entry })) {
+        const count = parent.collection.length - 1;
+        log(`onUnmount() > [${count}] #${entry.id}`, arguments);
+      }
     },
     beforeDeregister({ parent, entry }) {
-      const count = parent.collection.length - 1;
-      log(`beforeDeregister() > [${count}] #${entry.id}`, arguments);
+      if (getValue(this.settings.condition, { parent, entry })) {
+        const count = parent.collection.length - 1;
+        log(`beforeDeregister() > [${count}] #${entry.id}`, arguments);
+      }
     },
     afterDeregister({ parent, entry }) {
-      const count = parent.collection.length;
-      log(`afterDeregister() > [${count}] #${entry.id}`, arguments);
+      if (getValue(this.settings.condition, { parent, entry })) {
+        const count = parent.collection.length;
+        log(`afterDeregister() > [${count}] #${entry.id}`, arguments);
+      }
     },
     afterUnmount() {
       log("afterUnmount()", arguments);

--- a/packages/core/src/js/plugins/mediaQuery.js
+++ b/packages/core/src/js/plugins/mediaQuery.js
@@ -1,5 +1,4 @@
-import { getPrefix } from "../helpers/getPrefix";
-import { createPluginObject } from "../helpers";
+import { createPluginObject, getPrefix } from "../helpers";
 
 const defaults = {
   // The data attributes to get the breakpoint values from.

--- a/packages/core/src/js/plugins/mediaQuery.js
+++ b/packages/core/src/js/plugins/mediaQuery.js
@@ -31,17 +31,17 @@ export function mediaQuery(options = {}) {
   };
 
   const methods = {
-    unmount(context) {
-      context.collection.forEach((entry) => {
+    unmount({ parent }) {
+      parent.collection.forEach((entry) => {
         removeMediaQueryList(entry);
       });
     },
 
-    onMount(entry) {
+    onMount({ entry }) {
       setupMediaQueryList(entry);
     },
 
-    onUnmount(entry) {
+    onUnmount({ entry }) {
       removeMediaQueryList(entry);
     }
   };

--- a/packages/core/src/js/plugins/propStore.js
+++ b/packages/core/src/js/plugins/propStore.js
@@ -12,7 +12,7 @@ const defaults = {
   // will be used e.g: "VB:ModalState".
   key: null,
   // Condition to determine whether or not to store the value in local storage.
-  condition: () => false,
+  condition: false,
   // The function to run whenever the value changes.
   onChange() {}
 };
@@ -47,6 +47,7 @@ export function propStore(options = {}) {
   async function setupPropStore(entry) {
     // Store the initial property value. Set to null if property doesn't exist.
     let _value = entry[this.settings.prop] || null;
+    const contextObj = { plugin: this, parent: entry.parent, entry };
 
     // Define a getter and setter for the property.
     Object.defineProperty(entry, this.settings.prop, {
@@ -60,11 +61,12 @@ export function propStore(options = {}) {
         const oldValue = _value;
         _value = newValue;
         // Conditionally store the value in local storage.
-        if (this.settings.condition(entry, newValue, oldValue)) {
-          this.store.set(entry.id, _value);
+        const condition = await getValue(this.settings.condition, contextObj, newValue, oldValue);
+        if (condition) {
+          this.store.set(entry.id, newValue);
         }
         // Run the on change callback.
-        await this.settings.onChange.call(this, entry, newValue, oldValue);
+        await this.settings.onChange(contextObj, newValue, oldValue);
       },
     });
 
@@ -80,9 +82,11 @@ export function propStore(options = {}) {
     });
 
     // Conditionally set the initial value. Must be a truthy value.
-    entry[this.settings.prop] = (typeof this.settings.value === "function") ?
-      this.settings.value.call(this, entry) || entry[this.settings.prop] :
-      this.settings.value || entry[this.settings.prop];
+    entry[this.settings.prop] = await getValue(this.settings.value, contextObj) || entry[this.settings.prop];
+  }
+
+  async function getValue(obj, ...args) {
+    return (typeof obj === "function") ? await obj(...args) : obj;
   }
 
   async function removePropStore(entry) {

--- a/packages/core/src/js/plugins/propStore.js
+++ b/packages/core/src/js/plugins/propStore.js
@@ -31,7 +31,7 @@ export function propStore(options = {}) {
 
     unmount({ parent }) {
       parent.collection.forEach((entry) => {
-        this.onUnmount(entry);
+        removePropStore.call(this, entry);
       });
     },
 

--- a/packages/core/src/js/plugins/propStore.js
+++ b/packages/core/src/js/plugins/propStore.js
@@ -61,7 +61,7 @@ export function propStore(options = {}) {
         const oldValue = _value;
         _value = newValue;
         // Conditionally store the value in local storage.
-        const condition = await getValue(this.settings.condition, contextObj, newValue, oldValue);
+        const condition = getValue(this.settings.condition, contextObj, newValue, oldValue);
         if (condition) {
           this.store.set(entry.id, newValue);
         }
@@ -85,8 +85,8 @@ export function propStore(options = {}) {
     entry[this.settings.prop] = await getValue(this.settings.value, contextObj) || entry[this.settings.prop];
   }
 
-  async function getValue(obj, ...args) {
-    return (typeof obj === "function") ? await obj(...args) : obj;
+  function getValue(obj, ...args) {
+    return (typeof obj === "function") ? obj(...args) : obj;
   }
 
   async function removePropStore(entry) {

--- a/packages/core/src/js/plugins/propStore.js
+++ b/packages/core/src/js/plugins/propStore.js
@@ -25,21 +25,21 @@ export function propStore(options = {}) {
   };
 
   const methods = {
-    mount(parent) {
+    mount({ parent }) {
       this.store = localStore(getKey(parent.module));
     },
 
-    unmount(context) {
-      context.collection.forEach((entry) => {
+    unmount({ parent }) {
+      parent.collection.forEach((entry) => {
         this.onUnmount(entry);
       });
     },
 
-    async onMount(entry) {
+    async onMount({ entry }) {
       await setupPropStore.call(this, entry);
     },
 
-    onUnmount(entry) {
+    onUnmount({ entry }) {
       removePropStore.call(this, entry);
     }
   };

--- a/packages/core/src/js/plugins/teleport.js
+++ b/packages/core/src/js/plugins/teleport.js
@@ -13,8 +13,8 @@ export function teleport(options = {}) {
   };
 
   const methods = {
-    unmount(context) {
-      context.collection.forEach((entry) => {
+    unmount({ parent }) {
+      parent.collection.forEach((entry) => {
         if (typeof entry.teleportReturn === "function") {
           entry.teleportReturn();
           delete entry.teleport;
@@ -23,12 +23,12 @@ export function teleport(options = {}) {
       });
     },
 
-    onMount(entry) {
+    onMount({ entry }) {
       entry.teleport = teleport.bind(this, entry);
       entry.teleport();
     },
 
-    onUnmount(entry) {
+    onUnmount({ entry }) {
       teleportReturn(entry);
     }
   };

--- a/packages/core/src/js/utilities/maybeRunMethod.js
+++ b/packages/core/src/js/utilities/maybeRunMethod.js
@@ -1,5 +1,5 @@
-export async function maybeRunMethod(name, ...args) {
-  if (name in this && typeof this[name] === "function") {
-    await this[name](...args);
+export async function maybeRunMethod(obj, fun, ...args) {
+  if (fun in obj && typeof obj[fun] === "function") {
+    await obj[fun](...args);
   }
 }

--- a/packages/core/tests/plugins/debug.test.js
+++ b/packages/core/tests/plugins/debug.test.js
@@ -36,3 +36,19 @@ test("should log all the unmount lifecycle hooks when collection is unmounted", 
   expect(collection.plugins.length).toBe(1);
   expect(console.log).toHaveBeenCalledTimes(24);
 });
+
+test("should be able to pass a condition function for console logging", async () => {
+  await collection.plugins.remove("debug");
+  expect(collection.plugins.length).toBe(0);
+  const conditionSpy = vi.fn();
+  await collection.mount({
+    plugins: [
+      debug({ 
+        condition: conditionSpy 
+      })
+    ]
+  });
+  expect(conditionSpy).toHaveBeenCalledTimes(9);
+  await collection.unmount();
+  expect(conditionSpy).toHaveBeenCalledTimes(18);
+});

--- a/packages/core/tests/plugins/debug.test.js
+++ b/packages/core/tests/plugins/debug.test.js
@@ -11,7 +11,6 @@ const debugPlugin = debug({ asdf: "fdsa" });
 const collection = new Collection({
   selector: ".entry"
 });
-const colors = ["color: hsl(152deg 60% 40%)", "color: hsl(152deg 60% 50%)"];
 
 console.log = vi.fn();
 
@@ -29,12 +28,6 @@ test("should log all the mount lifecycle hooks when collection is mounted", asyn
   });
   expect(collection.plugins.length).toBe(1);
   expect(console.log).toHaveBeenCalledTimes(12);
-  expect(console.log).toBeCalledWith("%cDEBUG: %cmountPlugins()", ...colors);
-  expect(console.log).toBeCalledWith("%cDEBUG: %cbeforeMount()", ...colors);
-  expect(console.log).toBeCalledWith("%cDEBUG: %conMount()", ...colors);
-  expect(console.log).toBeCalledWith("%cDEBUG: %cbeforeRegister()", ...colors);
-  expect(console.log).toBeCalledWith("%cDEBUG: %cafterRegister()", ...colors);
-  expect(console.log).toBeCalledWith("%cDEBUG: %cafterMount()", ...colors);
 });
 
 test("should log all the unmount lifecycle hooks when collection is unmounted", async () => {
@@ -42,10 +35,4 @@ test("should log all the unmount lifecycle hooks when collection is unmounted", 
   await collection.unmount();
   expect(collection.plugins.length).toBe(1);
   expect(console.log).toHaveBeenCalledTimes(24);
-  expect(console.log).toBeCalledWith("%cDEBUG: %cbeforeUnmount()", ...colors);
-  expect(console.log).toBeCalledWith("%cDEBUG: %conUnmount()", ...colors);
-  expect(console.log).toBeCalledWith("%cDEBUG: %cbeforeDeregister()", ...colors);
-  expect(console.log).toBeCalledWith("%cDEBUG: %cafterDeregister()", ...colors);
-  expect(console.log).toBeCalledWith("%cDEBUG: %cafterUnmount()", ...colors);
-  expect(console.log).toBeCalledWith("%cDEBUG: %cunmountPlugins()", ...colors);
 });

--- a/packages/core/tests/plugins/mediaQuery.test.js
+++ b/packages/core/tests/plugins/mediaQuery.test.js
@@ -137,9 +137,8 @@ test("should be able to apply settings in various ways", async () => {
   expect(collection.get("entry-3").mql.matches).toBe(false);
 });
 
-test("should unmount the plugin when the unmount method is called", () => {
-  const plugin = collection.plugins.find((plugin) => plugin.name === "mediaQuery");
-  plugin.unmount(collection);
+test("should unmount the plugin when the unmount method is called", async () => {
+  await collection.plugins.remove("mediaQuery");
   expect(collection.get("entry-1").mql).toBe(null);
   expect(collection.get("entry-2").mql).toBe(null);
   expect(collection.get("entry-3").mql).toBe(null);

--- a/packages/core/tests/plugins/propStore.test.js
+++ b/packages/core/tests/plugins/propStore.test.js
@@ -25,9 +25,9 @@ test("should register and setup the propStore plugin on collection mount", async
   expect(typeof plugin.store.get).toBe("function");
   expect(typeof plugin.store.set).toBe("function");
   expect(typeof plugin.settings.onChange).toBe("function");
-  expect(typeof plugin.settings.condition).toBe("function");
+  expect(typeof plugin.settings.condition).toBe("boolean");
   plugin.settings.onChange();
-  expect(plugin.settings.condition()).toBe(false);
+  expect(plugin.settings.condition).toBe(false);
 });
 
 test("should remove the propStore plugin when the remove method is called", async () => {

--- a/packages/drawer/index.html
+++ b/packages/drawer/index.html
@@ -16,9 +16,9 @@
       plugins: [
         propStore({
           prop: "inlineState",
-          value: (entry) => entry.store,
-          condition: (entry) => ["opened", "closed"].includes(entry.state),
-          onChange: (entry) => entry.applyState()
+          value: ({ entry }) => entry.store,
+          condition: ({ entry }) => ["opened", "closed"].includes(entry.state),
+          onChange: ({ entry }) => entry.applyState()
         }),
         mediaQuery({
           onChange(event, entry) {

--- a/packages/drawer/index.html
+++ b/packages/drawer/index.html
@@ -10,10 +10,11 @@
   <script type="module">
     import "vrembem/dist/index.css";
     import Drawer from "./index.js";
-    import { propStore, mediaQuery, teleport } from "@vrembem/core";
+    import { debug, propStore, mediaQuery, teleport } from "@vrembem/core";
 
     const drawer = new Drawer({
       plugins: [
+        debug(),
         propStore({
           prop: "inlineState",
           value: ({ entry }) => entry.store,

--- a/packages/drawer/index.html
+++ b/packages/drawer/index.html
@@ -17,7 +17,7 @@
         propStore({
           prop: "inlineState",
           value: ({ entry }) => entry.store,
-          condition: ({ entry }) => ["opened", "closed"].includes(entry.state),
+          condition: ({ entry }) => ["opened", "closed", "indeterminate"].includes(entry.state),
           onChange: ({ entry }) => entry.applyState()
         }),
         mediaQuery({

--- a/packages/drawer/index.html
+++ b/packages/drawer/index.html
@@ -10,11 +10,10 @@
   <script type="module">
     import "vrembem/dist/index.css";
     import Drawer from "./index.js";
-    import { debug, propStore, mediaQuery, teleport } from "@vrembem/core";
+    import { propStore, mediaQuery, teleport } from "@vrembem/core";
 
     const drawer = new Drawer({
       plugins: [
-        debug(),
         propStore({
           prop: "inlineState",
           value: ({ entry }) => entry.store,

--- a/packages/drawer/src/js/DrawerEntry.js
+++ b/packages/drawer/src/js/DrawerEntry.js
@@ -105,7 +105,7 @@ export class DrawerEntry extends CollectionEntry {
     this.mode = (this.el.classList.contains(this.getSetting("classModal"))) ? "modal" : "inline";
   }
 
-  async onUnmount(reMount) {
+  async onUnmount(_, reMount) {
     // If entry is in the opened state, close it.
     if (!reMount && this.state === "opened") {
       await this.close(false);

--- a/packages/drawer/tests/switchMode.test.js
+++ b/packages/drawer/tests/switchMode.test.js
@@ -55,11 +55,11 @@ const drawer = new Drawer({
   plugins: [
     propStore({
       prop: "inlineState",
-      value: (entry) => entry.store,
-      condition(entry) {
+      value: ({ entry }) => entry.store,
+      condition({ entry }) {
         return ["opened", "closed", "indeterminate"].includes(entry.state);
       },
-      onChange: (entry) => entry.applyState()
+      onChange: ({ entry }) => entry.applyState()
     }),
     mediaQuery({
       onChange(event, entry) {
@@ -143,8 +143,8 @@ test("should return local store state when switching modes", async () => {
 
 test("should apply indeterminate state when going to inline mode", async () => {
   const entry = await drawer.get("drawer-1");
+  await entry.open();
   entry.setState("indeterminate");
-
   expect(entry.mode).toBe("inline");
   expect(entry.store).toBe("indeterminate");
   expect(entry.state).toBe("indeterminate");

--- a/packages/modal/index.html
+++ b/packages/modal/index.html
@@ -10,10 +10,11 @@
   <script type="module">
     import "vrembem/dist/index.css";
     import Modal from "./index.js";
-    import { propStore, teleport } from "@vrembem/core";
+    import { debug, propStore, teleport } from "@vrembem/core";
 
     const modal = new Modal({
       plugins: [
+        debug(),
         propStore({
           onChange({ plugin, parent, entry }) {
             if (["opening", "closing"].includes(entry.state)) return;

--- a/packages/modal/index.html
+++ b/packages/modal/index.html
@@ -10,11 +10,10 @@
   <script type="module">
     import "vrembem/dist/index.css";
     import Modal from "./index.js";
-    import { debug, propStore, teleport } from "@vrembem/core";
+    import { propStore, teleport } from "@vrembem/core";
 
     const modal = new Modal({
       plugins: [
-        debug(),
         propStore({
           onChange({ plugin, parent, entry }) {
             if (["opening", "closing"].includes(entry.state)) return;

--- a/packages/modal/index.html
+++ b/packages/modal/index.html
@@ -15,13 +15,13 @@
     const modal = new Modal({
       plugins: [
         propStore({
-          onChange(entry) {
+          onChange({ plugin, parent, entry }) {
             if (["opening", "closing"].includes(entry.state)) return;
-            const stackValue = entry.parent.stack.value.map((entry) => entry.id);
-            this.store.set("stackValue", stackValue);
+            const stackValue = parent.stack.value.map((item) => item.id);
+            plugin.store.set("stackValue", stackValue);
           },
-          afterMount(parent) {
-            for (const entry of this.store.get("stackValue", [])) {
+          afterMount({ plugin, parent}) {
+            for (const entry of plugin.store.get("stackValue", [])) {
               parent.open(entry, false);
             }
           }

--- a/packages/modal/src/js/ModalEntry.js
+++ b/packages/modal/src/js/ModalEntry.js
@@ -46,7 +46,7 @@ export class ModalEntry extends CollectionEntry {
     }
   }
 
-  async onUnmount(reMount) {
+  async onUnmount(_, reMount) {
     // If entry is in the opened state, close it.
     if (!reMount && this.state === "opened") {
       await this.close(false);

--- a/packages/popover/index.html
+++ b/packages/popover/index.html
@@ -10,11 +10,10 @@
   <script type="module">
     import "vrembem/dist/index.css";
     import Popover from "./index.js";
-    import { debug, teleport } from "@vrembem/core";
+    import { teleport } from "@vrembem/core";
 
     const popover = new Popover({
       plugins: [
-        debug(),
         teleport({
           where: ".popovers"
         })

--- a/packages/popover/index.html
+++ b/packages/popover/index.html
@@ -10,10 +10,11 @@
   <script type="module">
     import "vrembem/dist/index.css";
     import Popover from "./index.js";
-    import { teleport } from "@vrembem/core";
+    import { debug, teleport } from "@vrembem/core";
 
     const popover = new Popover({
       plugins: [
+        debug(),
         teleport({
           where: ".popovers"
         })


### PR DESCRIPTION
## What changed?

To help improve the API of lifecycle hooks, this PR updates arguments so that there is always a "context" object provided as the argument. This removes the need to call methods using `call(this)` or `bind(this)` since whatever you expect `this` to be, it can be more explicitly accessed via the context object. This takes the following form depending on which hook is being run:

```js
{ parent, entry, plugin }
```
- Parent: this is the root component class (Modal, Drawer, Popover, etc). It is always provided to all lifecycle hook calls.
- Entry: this is the current entry object being acted upon. This is provided only when an entry context is available, e.g: `onMount`, `beforeRegister`, `afterRegister`.
- Plugin: this is the plugin object that is running the hook. For example, any hook or `onChange` callbacks will have this context available.

**Additional changes**

- `maybeRunMethod` has been refactored to no longer set `this`, but instead takes an `obj` argument.
- `debug` has been expanded to provide more control and information of log output.
- `condition` options in both `propStore` and `debug` can now either be a boolean value or a function that returns a boolean.