### PR TITLE
Move entry destroy logic into collection entry class

### DIFF
--- a/packages/core/src/js/Collection.js
+++ b/packages/core/src/js/Collection.js
@@ -50,16 +50,9 @@ export class Collection {
     await dispatchLifecycleHook("onDestroyEntry", this, entry);
 
     // Run the entry destroy() method if it exists.
-    if (typeof entry.init === "function") {
+    if (typeof entry.destroy === "function") {
       await entry.destroy();
     }
-
-    // Remove all the owned properties from the entry.
-    Object.getOwnPropertyNames(entry).forEach((prop) => {
-      if (!["id", "afterUnmount"].includes(prop)) {
-        delete entry[prop];
-      }
-    });
 
     // Return the entry.
     return entry;
@@ -102,11 +95,11 @@ export class Collection {
   async deregister(id) {
     const index = this.collection.findIndex((entry) => entry.id === id);
     if (~index) {
-      // Dispatch onDeregisterEntry lifecycle hooks.
-      await dispatchLifecycleHook("onDeregisterEntry", this, this.collection[index]);
-
       // Get the collection entry object from the collection and destroy it.
       const entry = await this.destroyEntry(this.collection[index]);
+
+      // Dispatch onDeregisterEntry lifecycle hooks.
+      await dispatchLifecycleHook("onDeregisterEntry", this, this.collection[index]);
 
       // Remove the entry from the collection.
       this.collection.splice(index, 1);

--- a/packages/core/src/js/CollectionEntry.js
+++ b/packages/core/src/js/CollectionEntry.js
@@ -42,6 +42,11 @@ export class CollectionEntry {
   }
 
   async destroy() {
-    // Teardown function to run on `destroyEntry()`.
+    // Remove all the owned properties from the entry except for the id.
+    Object.getOwnPropertyNames(this).forEach((prop) => {
+      if (prop !== "id") {
+        delete this[prop];
+      }
+    });
   }
 }


### PR DESCRIPTION
## What changed?

This PR refactors where entry destroy logic is run by moving it into the collection entry class itself instead of having that logic in the parent collection. This allows the collection to only be concerned with running the appropriate methods and lifecycle hooks instead of also removing owned properties of the entry. This PR also ensures that `onDeregisterEntry` is run after `destroyEntry` instead of before.