### PR TITLE
Create the ability to add plugin presets for specific modules

### DIFF
--- a/docs/src/modules/useDrawer.js
+++ b/docs/src/modules/useDrawer.js
@@ -7,17 +7,8 @@ if (typeof window !== "undefined") {
   drawer = new Drawer({
     selector: ".drawer",
     plugins: [
-      propStore({
-        prop: "inlineState",
-        value: ({ entry }) => entry.store,
-        condition: ({ entry }) => ["opened", "closed"].includes(entry.state),
-        onChange: ({ entry }) => entry.applyState()
-      }),
-      mediaQuery({
-        onChange(event, entry) {
-          entry.mode = (event.matches) ? "inline" : "modal";
-        }
-      })
+      propStore(),
+      mediaQuery()
     ]
   });
   window["drawer"] = await drawer.mount();

--- a/packages/core/src/js/Collection.js
+++ b/packages/core/src/js/Collection.js
@@ -114,7 +114,7 @@ export class Collection {
     // Apply settings with passed options.
     this.applySettings(options);
 
-    // Mount plugins.
+    // Run setup methods on plugins.
     for (const plugin of this.plugins) {
       await maybeRunMethod(plugin, "setup", { plugin, parent: this});
     }
@@ -146,7 +146,7 @@ export class Collection {
     // Dispatch afterUnmount lifecycle hooks.
     await dispatchLifecycleHook("afterUnmount", this);
 
-    // Unmount plugins.
+    // Run teardown methods on plugins.
     for (const plugin of this.plugins) {
       await maybeRunMethod(plugin, "teardown", { plugin, parent: this});
     }

--- a/packages/core/src/js/helpers/createPluginObject.js
+++ b/packages/core/src/js/helpers/createPluginObject.js
@@ -15,10 +15,12 @@ export function createPluginObject(plugin, module) {
   ];
 
   // Get the preset for this module if it exists. Otherwise set an empty object.
-  const preset = plugin.presets?.[module] || {};
+  const defaults = plugin?.defaults || {};
+  const preset = plugin?.presets?.[module] || {};
+  const config = plugin?.config || {};
 
   // Merge plugin config with the defaults and preset if it exists.
-  plugin.settings = {...plugin.defaults, ...preset, ...plugin.config};
+  plugin.settings = {...defaults, ...preset, ...config};
 
   // Apply new plugin name if one is provided.
   if (plugin.settings.name) {

--- a/packages/core/src/js/helpers/index.js
+++ b/packages/core/src/js/helpers/index.js
@@ -1,4 +1,3 @@
-export * from "./createPluginObject";
 export * from "./cssVar";
 export * from "./dispatchLifecycleHook";
 export * from "./buildCustomProps";
@@ -6,3 +5,4 @@ export * from "./getPrefix";
 export * from "./getSetting";
 export * from "./pluginsArray";
 export * from "./setGlobalState";
+export * from "./setupPluginObject";

--- a/packages/core/src/js/helpers/pluginsArray.js
+++ b/packages/core/src/js/helpers/pluginsArray.js
@@ -8,11 +8,6 @@ export class pluginsArray extends Array {
   }
 
   validate(plugin) {
-    if (typeof plugin != "object") {
-      console.error("Plugin is not a valid object!");
-      return false;
-    };
-
     if (!("name" in plugin) || typeof plugin.name !== "string") {
       console.error("Plugin requires a name!");
       return false;

--- a/packages/core/src/js/helpers/pluginsArray.js
+++ b/packages/core/src/js/helpers/pluginsArray.js
@@ -1,4 +1,5 @@
 import { maybeRunMethod } from "../utilities";
+import { createPluginObject } from "../helpers";
 
 export class pluginsArray extends Array {
   constructor(parent) {
@@ -32,8 +33,13 @@ export class pluginsArray extends Array {
   add(plugin) {
     if (Array.isArray(plugin)) {
       plugin.forEach((plugin) => this.add(plugin));
-    } else if (this.validate(plugin)) {
-      this.push(plugin);
+    } else {
+      // Create the plugin object.
+      plugin = createPluginObject(plugin, this.parent.module.toLowerCase());
+      // Push to the array if the plugin is valid.
+      if (this.validate(plugin)) {
+        this.push(plugin);
+      }
     }
   }
 

--- a/packages/core/src/js/helpers/pluginsArray.js
+++ b/packages/core/src/js/helpers/pluginsArray.js
@@ -1,5 +1,5 @@
 import { maybeRunMethod } from "../utilities";
-import { createPluginObject } from "../helpers";
+import { setupPluginObject } from "../helpers";
 
 export class pluginsArray extends Array {
   constructor(parent) {
@@ -30,7 +30,7 @@ export class pluginsArray extends Array {
       plugin.forEach((plugin) => this.add(plugin));
     } else {
       // Create the plugin object.
-      plugin = createPluginObject(plugin, this.parent.module.toLowerCase());
+      plugin = setupPluginObject(plugin, this.parent.module.toLowerCase());
       // Push to the array if the plugin is valid.
       if (this.validate(plugin)) {
         this.push(plugin);

--- a/packages/core/src/js/plugins/debug.js
+++ b/packages/core/src/js/plugins/debug.js
@@ -1,5 +1,3 @@
-import { createPluginObject } from "../helpers";
-
 const defaults = {
   condition: true
 };
@@ -11,10 +9,11 @@ const colors = {
   important: "hsl(0deg 80% 50%)"
 };
 
-export function debug(options = {}) {
+export function debug(config = {}) {
   const props = {
     name: "debug",
-    settings: {...defaults, ...options}
+    defaults,
+    config
   };
 
   function log(name, args = [], colorKeys = ["primary", "secondary"]) {
@@ -142,5 +141,5 @@ export function debug(options = {}) {
     
   };
 
-  return createPluginObject(props, methods);
+  return {...props, ...methods};
 }

--- a/packages/core/src/js/plugins/propStore.js
+++ b/packages/core/src/js/plugins/propStore.js
@@ -1,5 +1,4 @@
 import { localStore } from "../utilities";
-import { createPluginObject } from "../helpers";
 
 const defaults = {
   // The property on entry objects to watch.
@@ -17,16 +16,27 @@ const defaults = {
   onChange() {}
 };
 
-export function propStore(options = {}) {
+const presets = {
+  drawer: {
+    prop: "inlineState",
+    value: ({ entry }) => entry.store,
+    condition: ({ entry }) => ["opened", "closed", "indeterminate"].includes(entry.state),
+    onChange: ({ entry }) => entry.applyState()
+  }
+};
+
+export function propStore(config = {}) {
   const props = {
     name: "propStore",
-    settings: {...defaults, ...options},
+    defaults,
+    presets,
+    config,
     store: null,
   };
 
   const methods = {
     setup({ parent }) {
-      this.store = localStore(getKey(parent.module));
+      this.store = localStore(getKey.call(this, parent.module));
     },
 
     teardown({ parent }) {
@@ -100,10 +110,10 @@ export function propStore(options = {}) {
   }
 
   function getKey(moduleName) {
-    const prop = props.settings.prop.charAt(0).toUpperCase() + props.settings.prop.slice(1);
-    const key = (props.settings.key || moduleName + prop);
-    return props.settings.keyPrefix + key;
+    const prop = this.settings.prop.charAt(0).toUpperCase() + this.settings.prop.slice(1);
+    const key = (this.settings.key || moduleName + prop);
+    return this.settings.keyPrefix + key;
   }
 
-  return createPluginObject(props, methods);
+  return {...props, ...methods};
 }

--- a/packages/core/src/js/plugins/teleport.js
+++ b/packages/core/src/js/plugins/teleport.js
@@ -1,15 +1,15 @@
 import { teleportElement } from "../utilities";
-import { createPluginObject } from "../helpers";
 
 const defaults = {
   where: null,
   how: "append"
 };
 
-export function teleport(options = {}) {
+export function teleport(config = {}) {
   const props = {
     name: "teleport",
-    settings: {...defaults, ...options}
+    defaults,
+    config
   };
 
   const methods = {
@@ -62,5 +62,5 @@ export function teleport(options = {}) {
     entry.parent.emit("teleportReturn", { plugin, parent, entry });
   }
 
-  return createPluginObject(props, methods);
+  return {...props, ...methods};
 };

--- a/packages/core/tests/helpers/createPluginObject.test.js
+++ b/packages/core/tests/helpers/createPluginObject.test.js
@@ -2,55 +2,51 @@ import { createPluginObject } from "../../index";
 
 console.error = vi.fn();
 
-const props = {
+const obj = {
   name: "example",
-  settings: {
+  config: {
     value: true,
     string: "asdf"
-  }
-};
-
-const methods = {
+  },
   beforeMount() {},
   beforeUnmount() {}
 };
 
-test("should create and return a plugin object", () => {
-  const plugin = createPluginObject(props, methods);
-  expect(plugin.name).toBe("example");
-  expect(typeof plugin.beforeMount).toBe("function");
-  expect(typeof plugin.beforeUnmount).toBe("function");
-  expect(plugin.settings.string).toBe("asdf");
-  expect(plugin.settings.value).toBe(true);
-});
-
-test("should be able to pass lifecycle hooks and name through settings", () => {
-  const settings = {
-    name: "newExample",
-    onRegisterEntry() {}
-  };
-  props.settings = {...props.settings, ...settings};
-  const plugin = createPluginObject(props, methods);
-  expect(plugin.name).toBe("newExample");
-  expect(typeof plugin.onRegisterEntry).toBe("function");
-});
-
-test("should allow overriding lifecycle hooks that have already been defined if override is set to true", () => {
-  const settings = {
-    override: true,
-    onMount() {}
-  };
-  props.settings = {...props.settings, ...settings};
-  createPluginObject(props, methods);
-  expect(console.error).not.toHaveBeenCalled();
-});
-
-test("should log console error if setting a lifecycle hook that has already been defined", () => {
-  const settings = {
-    override: false,
-    beforeMount() {}
-  };
-  props.settings = {...props.settings, ...settings};
-  createPluginObject(props, methods);
-  expect(console.error).toBeCalledWith("newExample plugin already has \"beforeMount\" lifecycle hook defined!");
+describe("createPluginObject", () => {
+  it("should create and return a plugin object", () => {
+    const plugin = createPluginObject(obj);
+    expect(plugin.name).toBe("example");
+    expect(typeof plugin.beforeMount).toBe("function");
+    expect(typeof plugin.beforeUnmount).toBe("function");
+    expect(plugin.settings.string).toBe("asdf");
+    expect(plugin.settings.value).toBe(true);
+  });
+  
+  it("should be able to pass lifecycle hooks and name through settings", () => {
+    obj.config = {
+      name: "newExample",
+      onRegisterEntry() {}
+    };
+    const plugin = createPluginObject(obj);
+    expect(plugin.name).toBe("newExample");
+    expect(typeof plugin.onRegisterEntry).toBe("function");
+  });
+  
+  it("should allow overriding lifecycle hooks that have already been defined if override is set to true", () => {
+    obj.config = {
+      override: true,
+      onMount() {}
+    };
+    createPluginObject(obj);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+  
+  it("should log console error if setting a lifecycle hook that has already been defined", () => {
+    obj.config = {
+      override: false,
+      beforeMount() {}
+    };
+    createPluginObject(obj);
+    expect(console.error).toBeCalledWith("newExample plugin already has \"beforeMount\" lifecycle hook defined!");
+  });  
 });

--- a/packages/core/tests/helpers/pluginsArray.test.js
+++ b/packages/core/tests/helpers/pluginsArray.test.js
@@ -1,48 +1,51 @@
 import { pluginsArray } from "../../src/js/helpers/pluginsArray";
 
-const plugins = new pluginsArray({});
-
 console.error = vi.fn();
 
-test("should add a plugin to the plugins array", () => {
-  expect(plugins.length).toBe(0);
-  plugins.add({ name: "asdf" });
-  expect(plugins.length).toBe(1);
+const plugins = new pluginsArray({
+  module: "Example"
 });
 
-test("should remove a plugin from the plugins array", async () => {
-  expect(plugins.length).toBe(1);
-  await plugins.remove("asdf");
-  expect(plugins.length).toBe(0);
-});
+describe("pluginsArray", () => {
+  it("should add a plugin to the plugins array", () => {
+    expect(plugins.length).toBe(0);
+    plugins.add({ name: "asdf" });
+    expect(plugins.length).toBe(1);
+  });
+  
+  it("should remove a plugin from the plugins array", async () => {
+    expect(plugins.length).toBe(1);
+    await plugins.remove("asdf");
+    expect(plugins.length).toBe(0);
+  });
+  
+  it("should add an array of plugins at once", () => {
+    expect(plugins.length).toBe(0);
+    plugins.add([
+      { name: "one", config: { a: "a" } },
+      { name: "two", config: { b: "b" } }
+    ]);
+    expect(plugins.length).toBe(2);
+  });
+  
+  it("should return a specific plugin when using the get method", () => {
+    const pluginOne = plugins.get("one");
+    expect(pluginOne.settings).toStrictEqual({ a: "a" });
 
-test("should add an array of plugins at once", () => {
-  expect(plugins.length).toBe(0);
-  plugins.add([
-    { name: "one", settings: { a: "a" } },
-    { name: "two", settings: { b: "b" } }
-  ]);
-  expect(plugins.length).toBe(2);
-});
+    const pluginTwo = plugins.get("two");
+    expect(pluginTwo.settings).toStrictEqual({ b: "b" });
 
-test("should return a specific plugin when using the get method", () => {
-  expect(plugins.get("one")).toStrictEqual({ name: "one", settings: { a: "a" } });
-  expect(plugins.get("two")).toStrictEqual({ name: "two", settings: { b: "b" } });
-  expect(plugins.get("three")).toBe(undefined);
-});
-
-test("should log a console error if the plugin is not a valid object", () => {
-  plugins.add("asdf");
-  expect(console.error).toBeCalledWith("Plugin is not a valid object!");
-});
-
-test("should log a console error if the plugin is missing a name property", () => {
-  plugins.add({});
-  expect(console.error).toBeCalledWith("Plugin requires a name!");
-});
-
-test("should log a console error if the plugin name is already used", () => {
-  plugins.add({ name: "asdf" });
-  plugins.add({ name: "asdf" });
-  expect(console.error).toBeCalledWith("Plugin with the name \"asdf\" is already being used!");
+    expect(plugins.get("three")).toBe(undefined);
+  });
+  
+  it("should log a console error if the plugin is missing a name property", () => {
+    plugins.add({});
+    expect(console.error).toBeCalledWith("Plugin requires a name!");
+  });
+  
+  it("should log a console error if the plugin name is already used", () => {
+    plugins.add({ name: "asdf" });
+    plugins.add({ name: "asdf" });
+    expect(console.error).toBeCalledWith("Plugin with the name \"asdf\" is already being used!");
+  });  
 });

--- a/packages/core/tests/helpers/setupPluginObject.test.js
+++ b/packages/core/tests/helpers/setupPluginObject.test.js
@@ -1,4 +1,4 @@
-import { createPluginObject } from "../../index";
+import { setupPluginObject } from "../../index";
 
 console.error = vi.fn();
 
@@ -12,9 +12,9 @@ const obj = {
   beforeUnmount() {}
 };
 
-describe("createPluginObject", () => {
+describe("setupPluginObject", () => {
   it("should create and return a plugin object", () => {
-    const plugin = createPluginObject(obj);
+    const plugin = setupPluginObject(obj);
     expect(plugin.name).toBe("example");
     expect(typeof plugin.beforeMount).toBe("function");
     expect(typeof plugin.beforeUnmount).toBe("function");
@@ -27,7 +27,7 @@ describe("createPluginObject", () => {
       name: "newExample",
       onRegisterEntry() {}
     };
-    const plugin = createPluginObject(obj);
+    const plugin = setupPluginObject(obj);
     expect(plugin.name).toBe("newExample");
     expect(typeof plugin.onRegisterEntry).toBe("function");
   });
@@ -37,7 +37,7 @@ describe("createPluginObject", () => {
       override: true,
       onMount() {}
     };
-    createPluginObject(obj);
+    setupPluginObject(obj);
     expect(console.error).not.toHaveBeenCalled();
   });
   
@@ -46,7 +46,7 @@ describe("createPluginObject", () => {
       override: false,
       beforeMount() {}
     };
-    createPluginObject(obj);
+    setupPluginObject(obj);
     expect(console.error).toBeCalledWith("newExample plugin already has \"beforeMount\" lifecycle hook defined!");
   });  
 });

--- a/packages/core/tests/plugins/debug.test.js
+++ b/packages/core/tests/plugins/debug.test.js
@@ -1,6 +1,8 @@
 import { Collection } from "../../src/js/Collection";
 import { debug } from "../../src/js/plugins";
 
+console.log = vi.fn();
+
 document.body.innerHTML = `
   <div class="entry" id="entry-1">One</div>
   <div class="entry" id="entry-2">Two</div>
@@ -12,43 +14,43 @@ const collection = new Collection({
   selector: ".entry"
 });
 
-console.log = vi.fn();
-
-test("should return a plugin object with custom settings", () => {
-  expect(debugPlugin.name).toBe("debug");
-  expect(debugPlugin.settings.asdf).toBe("fdsa");
-});
-
-test("should log all the mount lifecycle hooks when collection is mounted", async () => {
-  expect(collection.plugins.length).toBe(0);
-  await collection.mount({
-    plugins: [
-      debug({ asdf: "fdsa" })
-    ]
+describe("debug", () => {
+  it("should return a plugin object with custom configuration", () => {
+    expect(debugPlugin.name).toBe("debug");
+    expect(debugPlugin.config.asdf).toBe("fdsa");
   });
-  expect(collection.plugins.length).toBe(1);
-  expect(console.log).toHaveBeenCalledTimes(17);
-});
-
-test("should log all the unmount lifecycle hooks when collection is unmounted", async () => {
-  expect(collection.plugins.length).toBe(1);
-  await collection.unmount();
-  expect(collection.plugins.length).toBe(1);
-  expect(console.log).toHaveBeenCalledTimes(34);
-});
-
-test("should be able to pass a condition function for console logging", async () => {
-  await collection.plugins.remove("debug");
-  expect(collection.plugins.length).toBe(0);
-  const conditionSpy = vi.fn();
-  await collection.mount({
-    plugins: [
-      debug({ 
-        condition: conditionSpy 
-      })
-    ]
+  
+  it("should log all the mount lifecycle hooks when collection is mounted", async () => {
+    expect(collection.plugins.length).toBe(0);
+    await collection.mount({
+      plugins: [
+        debug({ asdf: "fdsa" })
+      ]
+    });
+    expect(collection.plugins.length).toBe(1);
+    expect(console.log).toHaveBeenCalledTimes(17);
   });
-  expect(conditionSpy).toHaveBeenCalledTimes(12);
-  await collection.unmount();
-  expect(conditionSpy).toHaveBeenCalledTimes(24);
+  
+  it("should log all the unmount lifecycle hooks when collection is unmounted", async () => {
+    expect(collection.plugins.length).toBe(1);
+    await collection.unmount();
+    expect(collection.plugins.length).toBe(1);
+    expect(console.log).toHaveBeenCalledTimes(34);
+  });
+  
+  it("should be able to pass a condition function for console logging", async () => {
+    await collection.plugins.remove("debug");
+    expect(collection.plugins.length).toBe(0);
+    const conditionSpy = vi.fn();
+    await collection.mount({
+      plugins: [
+        debug({ 
+          condition: conditionSpy 
+        })
+      ]
+    });
+    expect(conditionSpy).toHaveBeenCalledTimes(12);
+    await collection.unmount();
+    expect(conditionSpy).toHaveBeenCalledTimes(24);
+  });  
 });

--- a/packages/core/tests/plugins/mediaQuery.test.js
+++ b/packages/core/tests/plugins/mediaQuery.test.js
@@ -48,104 +48,100 @@ const collection = new Collection({
   selector: ".entry"
 });
 
-test("should register and setup the mediaQuery plugin on collection mount", async () => {
-  window.innerWidth = 800;
-  const spyFunction = vi.fn();
-  expect(collection.plugins.length).toBe(0);
-  await collection.mount({
-    plugins: [
-      mediaQuery({
-        onChange: spyFunction
-      })
-    ]
+describe("mediaQuery", () => {
+  it("should register and setup the mediaQuery plugin on collection mount", async () => {
+    window.innerWidth = 800;
+    const spyFunction = vi.fn();
+    expect(collection.plugins.length).toBe(0);
+    await collection.mount({
+      plugins: [
+        mediaQuery({
+          onChange: spyFunction
+        })
+      ]
+    });
+    expect(collection.plugins.length).toBe(1);
+    expect(typeof collection.get("entry-1").mql).toBe("undefined");
+  
+    expect(collection.get("entry-2").mql.media).toBe("(min-width: 900px)");
+    expect(typeof collection.get("entry-2").mql.onchange).toBe("function");
+    expect(collection.get("entry-2").mql.matches).toBe(false);
+  
+    expect(collection.get("entry-3").mql.media).toBe("(max-width: 600px)");
+    expect(typeof collection.get("entry-3").mql.onchange).toBe("function");
+    expect(collection.get("entry-3").mql.matches).toBe(false);
+  
+    expect(spyFunction).toBeCalledTimes(2);
+  
+    resizeWindow(960, collection.collection);
+    expect(collection.get("entry-2").mql.matches).toBe(true);
+    expect(collection.get("entry-3").mql.matches).toBe(false);
+  
+    expect(spyFunction).toBeCalledTimes(3);
+  
+    resizeWindow(340, collection.collection);
+    expect(collection.get("entry-2").mql.matches).toBe(false);
+    expect(collection.get("entry-3").mql.matches).toBe(true);
+  
+    expect(spyFunction).toBeCalledTimes(5);
   });
-  expect(collection.plugins.length).toBe(1);
-  expect(typeof collection.get("entry-1").mql).toBe("undefined");
-
-  expect(collection.get("entry-2").mql.media).toBe("(min-width: 900px)");
-  expect(typeof collection.get("entry-2").mql.onchange).toBe("function");
-  expect(collection.get("entry-2").mql.matches).toBe(false);
-
-  expect(collection.get("entry-3").mql.media).toBe("(max-width: 600px)");
-  expect(typeof collection.get("entry-3").mql.onchange).toBe("function");
-  expect(collection.get("entry-3").mql.matches).toBe(false);
-
-  expect(spyFunction).toBeCalledTimes(2);
-
-  resizeWindow(960, collection.collection);
-  expect(collection.get("entry-2").mql.matches).toBe(true);
-  expect(collection.get("entry-3").mql.matches).toBe(false);
-
-  expect(spyFunction).toBeCalledTimes(3);
-
-  resizeWindow(340, collection.collection);
-  expect(collection.get("entry-2").mql.matches).toBe(false);
-  expect(collection.get("entry-3").mql.matches).toBe(true);
-
-  expect(spyFunction).toBeCalledTimes(5);
-});
-
-test("should undo the mediaQuery setup on collection unmount", async () => {
-  const mql_1 = collection.get("entry-2").mql;
-  const mql_2 = collection.get("entry-3").mql;
-  await collection.unmount();
-  expect(mql_1.onchange).toBe(null);
-  expect(mql_2.onchange).toBe(null);  
-});
-
-test("should remove the mediaQuery plugin when the remove method is called", async () => {
-  expect(collection.plugins.length).toBe(1);
-  await collection.plugins.remove("mediaQuery");
-  expect(collection.plugins.length).toBe(0);
-});
-
-test("should be able to apply settings in various ways", async () => {
-  window.innerWidth = 500;
-  const spyFunction = vi.fn();
-  await collection.mount({
-    plugins: [
-      mediaQuery({
-        breakpoints: {
-          "entry-1": "333px",
-          "md": "444px"
-        },
-        mediaQueries: {
-          "entry-2": "(max-width: {{BP}})"
-        },
-        onChange: spyFunction
-      })
-    ]
+  
+  it("should undo the mediaQuery setup on collection unmount", async () => {
+    const mql_1 = collection.get("entry-2").mql;
+    const mql_2 = collection.get("entry-3").mql;
+    await collection.unmount();
+    expect(mql_1.onchange).toBe(null);
+    expect(mql_2.onchange).toBe(null);  
   });
-
-  expect(spyFunction).toBeCalledTimes(3);
-  expect(collection.get("entry-1").mql.media).toBe("(min-width: 333px)");
-  expect(collection.get("entry-2").mql.media).toBe("(max-width: 900px)");
-  expect(collection.get("entry-3").mql.media).toBe("(max-width: 444px)");
-
-  expect(collection.get("entry-1").mql.matches).toBe(true);
-  expect(collection.get("entry-2").mql.matches).toBe(true);
-  expect(collection.get("entry-3").mql.matches).toBe(false);
-
-  resizeWindow(200, collection.collection);
-  expect(collection.get("entry-1").mql.matches).toBe(false);
-  expect(collection.get("entry-2").mql.matches).toBe(true);
-  expect(collection.get("entry-3").mql.matches).toBe(true);
-
-  resizeWindow(1000, collection.collection);
-  expect(collection.get("entry-1").mql.matches).toBe(true);
-  expect(collection.get("entry-2").mql.matches).toBe(false);
-  expect(collection.get("entry-3").mql.matches).toBe(false);
-});
-
-test("should unmount the plugin when the unmount method is called", async () => {
-  await collection.plugins.remove("mediaQuery");
-  expect(collection.get("entry-1").mql).toBe(null);
-  expect(collection.get("entry-2").mql).toBe(null);
-  expect(collection.get("entry-3").mql).toBe(null);
-});
-
-test("Should setup a default anonymous function on instantiation", () => {
-  const plugin = mediaQuery();
-  plugin.settings.onChange();
-  expect(typeof plugin.settings.onChange).toBe("function");
+  
+  it("should remove the mediaQuery plugin when the remove method is called", async () => {
+    expect(collection.plugins.length).toBe(1);
+    await collection.plugins.remove("mediaQuery");
+    expect(collection.plugins.length).toBe(0);
+  });
+  
+  it("should be able to apply settings in various ways", async () => {
+    window.innerWidth = 500;
+    const spyFunction = vi.fn();
+    await collection.mount({
+      plugins: [
+        mediaQuery({
+          breakpoints: {
+            "entry-1": "333px",
+            "md": "444px"
+          },
+          mediaQueries: {
+            "entry-2": "(max-width: {{BP}})"
+          },
+          onChange: spyFunction
+        })
+      ]
+    });
+  
+    expect(spyFunction).toBeCalledTimes(3);
+    expect(collection.get("entry-1").mql.media).toBe("(min-width: 333px)");
+    expect(collection.get("entry-2").mql.media).toBe("(max-width: 900px)");
+    expect(collection.get("entry-3").mql.media).toBe("(max-width: 444px)");
+  
+    expect(collection.get("entry-1").mql.matches).toBe(true);
+    expect(collection.get("entry-2").mql.matches).toBe(true);
+    expect(collection.get("entry-3").mql.matches).toBe(false);
+  
+    resizeWindow(200, collection.collection);
+    expect(collection.get("entry-1").mql.matches).toBe(false);
+    expect(collection.get("entry-2").mql.matches).toBe(true);
+    expect(collection.get("entry-3").mql.matches).toBe(true);
+  
+    resizeWindow(1000, collection.collection);
+    expect(collection.get("entry-1").mql.matches).toBe(true);
+    expect(collection.get("entry-2").mql.matches).toBe(false);
+    expect(collection.get("entry-3").mql.matches).toBe(false);
+  });
+  
+  it("should unmount the plugin when the unmount method is called", async () => {
+    await collection.plugins.remove("mediaQuery");
+    expect(collection.get("entry-1").mql).toBe(null);
+    expect(collection.get("entry-2").mql).toBe(null);
+    expect(collection.get("entry-3").mql).toBe(null);
+  });
 });

--- a/packages/core/tests/plugins/propStore.test.js
+++ b/packages/core/tests/plugins/propStore.test.js
@@ -182,4 +182,49 @@ describe("propStore", () => {
     const entry = collection.get("entry-1");
     expect(entry.hello).toBe("my friend");
   });
+
+  it("should set an anonymous empty function by default", async () => {
+    await collection.mount({ plugins: propStore() });
+    // Get the plugin from the plugins array.
+    const plugin = collection.plugins.get("propStore");
+    // Ensure that onChange is a function.
+    expect(typeof plugin.settings.onChange).toBe("function");
+    // Ensure that onChange does not throw when called.
+    expect(() => plugin.settings.onChange()).not.toThrow();
+  });
+
+  it("should apply module preset", async () => {
+    // Initial setup.
+    collection.module = "Drawer";
+    
+    // Mount the collection with the propStore plugin and no configurations.
+    await collection.mount({
+      plugins: propStore()
+    });
+
+    // Initial setup of mock drawer entry.
+    const entry = collection.get("entry-1");
+    entry.applyState = vi.fn();
+
+    // Set conditions for onChange to be called which fires `applyState`.
+    entry.state = "indeterminate";
+    entry.inlineState = "indeterminate";
+    expect(entry.inlineState).toBe("indeterminate");
+    expect(entry.store).toBe("indeterminate");
+    expect(entry.applyState).toBeCalledTimes(1);
+
+    // Ensure that other valid state is also stored in local storage.
+    entry.state = "opened";
+    entry.inlineState = "opened";
+    expect(entry.inlineState).toBe("opened");
+    expect(entry.store).toBe("opened");
+    expect(entry.applyState).toBeCalledTimes(2);
+
+    // Ensure that a non-valid state is not stored in local storage.
+    entry.state = "closing";
+    entry.inlineState = "closing";
+    expect(entry.inlineState).toBe("closing");
+    expect(entry.store).toBe("opened");
+    expect(entry.applyState).toBeCalledTimes(3);
+  });
 });

--- a/packages/drawer/index.html
+++ b/packages/drawer/index.html
@@ -14,17 +14,8 @@
 
     const drawer = new Drawer({
       plugins: [
-        propStore({
-          prop: "inlineState",
-          value: ({ entry }) => entry.store,
-          condition: ({ entry }) => ["opened", "closed", "indeterminate"].includes(entry.state),
-          onChange: ({ entry }) => entry.applyState()
-        }),
-        mediaQuery({
-          onChange(event, entry) {
-            entry.mode = (event.matches) ? "inline" : "modal";
-          }
-        }),
+        propStore(),
+        mediaQuery(),
         teleport({
           where: ".drawer-main",
           how: "before"


### PR DESCRIPTION
## What changed?

With the new plugin system, there are some common configurations that are almost always applied depending on the module. For example, a drawer using `propStore` will most likely have this configuration:

```js
{
    prop: "inlineState",
    value: ({ entry }) => entry.store,
    condition: ({ entry }) => ["opened", "closed", "indeterminate"].includes(entry.state),
    onChange: ({ entry }) => entry.applyState()
}
```

This will set a prop watch on `inlineState` and store the state in local storage if a valid state is set. This PR adds these common configurations as module presets and a establishes a system for defining presets based on the module using the plugin.