### PR TITLE
Create new focusTrap plugin

### DIFF
--- a/docs/src/modules/useDrawer.js
+++ b/docs/src/modules/useDrawer.js
@@ -1,5 +1,5 @@
 import { Drawer } from "vrembem";
-import { propStore, mediaQuery } from "@vrembem/core";
+import { focusTrap, mediaQuery, propStore } from "@vrembem/core";
 
 let drawer = null;
 
@@ -7,8 +7,9 @@ if (typeof window !== "undefined") {
   drawer = new Drawer({
     selector: ".drawer",
     plugins: [
-      propStore(),
-      mediaQuery()
+      focusTrap(),
+      mediaQuery(),
+      propStore()
     ]
   });
   window["drawer"] = await drawer.mount();

--- a/docs/src/modules/useModal.js
+++ b/docs/src/modules/useModal.js
@@ -1,5 +1,5 @@
 import Modal from "@vrembem/modal";
-import { teleport } from "@vrembem/core";
+import { focusTrap, teleport } from "@vrembem/core";
 
 let modal = null;
 
@@ -7,6 +7,7 @@ if (typeof window !== "undefined") {
   modal = new Modal({
     selectorInert: "main",
     plugins: [
+      focusTrap(),
       teleport({
         where: ".modals",
         how: "append"

--- a/packages/core/src/js/Collection.js
+++ b/packages/core/src/js/Collection.js
@@ -155,7 +155,7 @@ export class Collection {
     }
 
     // Remove plugins.
-    for (const plugin of this.plugins) {
+    for (const plugin of [...this.plugins]) {
       this.plugins.remove(plugin.name);
     }
 

--- a/packages/core/src/js/modules/FocusTrap.js
+++ b/packages/core/src/js/modules/FocusTrap.js
@@ -68,34 +68,7 @@ export class FocusTrap {
   }
 
   getFocusable(el = this.el) {
-    // Create the focusable array.
-    const focusable = [];
-
-    // Store the initial focus and scroll position.
-    const initFocus = document.activeElement;
-    const initScrollTop = el.scrollTop;
-
-    // Query for all the focusable elements.
-    const selector = focusableSelectors.join(",");
-    const els = el.querySelectorAll(selector);
-
-    // Loop through all focusable elements.
-    els.forEach((el) => {
-      // Set them to focus and check 
-      el.focus();
-      // Test that the element took focus.
-      if (document.activeElement === el) {
-        // Add element to the focusable array.
-        focusable.push(el);
-      }
-    });
-
-    // Restore the initial scroll position and focus.
-    el.scrollTop = initScrollTop;
-    initFocus.focus();
-
-    // Return the focusable array.
-    return focusable;
+    return el.querySelectorAll(focusableSelectors.join(","));
   }
 }
 

--- a/packages/core/src/js/modules/FocusTrap.js
+++ b/packages/core/src/js/modules/FocusTrap.js
@@ -1,13 +1,12 @@
 import { FocusableArray } from "./";
 
 export class FocusTrap {
-  constructor(el = null, selectorFocus = "[data-focus]") {
+  constructor(el = null) {
     this.el = el;
-    this.selectorFocus = selectorFocus;
     this.handleFocusTrap = handleFocusTrap.bind(this);
   }
 
-  mount(el = this.el, selectorFocus = this.selectorFocus) {
+  mount(el = this.el) {
     // Get the focusable elements.
     this.focusable = new FocusableArray(el);
 
@@ -15,9 +14,6 @@ export class FocusTrap {
     (this.focusable.length) ?
       document.addEventListener("keydown", this.handleFocusTrap):
       document.addEventListener("keydown", handleFocusLock);
-
-    // Set focus on the initial element.
-    (el.querySelector(selectorFocus) || el).focus();
   }
 
   unmount() {
@@ -53,7 +49,7 @@ function handleFocusTrap(event) {
 
   if ((isShiftTab && isFirstOrRoot) || (!isShiftTab && isLastOrRoot)) {
     event.preventDefault();
-    // Loop next tab focus based on direction (shift).
+    // Loop to next tab focus based on direction (shift).
     (isShiftTab ? focusable.last : focusable.first).focus();
   }
 }

--- a/packages/core/src/js/modules/FocusTrap.js
+++ b/packages/core/src/js/modules/FocusTrap.js
@@ -7,26 +7,17 @@ export class FocusTrap {
     this.handleFocusTrap = handleFocusTrap.bind(this);
   }
 
-  mount(el, selectorFocus) {
-    // Update passed params.
-    if (el) this.el = el;
-    if (selectorFocus) this.selectorFocus = selectorFocus;
-
+  mount(el = this.el, selectorFocus = this.selectorFocus) {
     // Get the focusable elements.
-    this.focusable = new FocusableArray(this.el);
+    this.focusable = new FocusableArray(el);
 
-    if (this.focusable.length) {
-      document.removeEventListener("keydown", handleFocusLock);
-      document.addEventListener("keydown", this.handleFocusTrap);
-    } else {
-      document.removeEventListener("keydown", this.handleFocusTrap);
+    // Either focus trap or lock depending on focusable length.
+    (this.focusable.length) ?
+      document.addEventListener("keydown", this.handleFocusTrap):
       document.addEventListener("keydown", handleFocusLock);
-    }
 
-    // Query for the focus selector, otherwise return this element.
-    const result = this.el.querySelector(this.selectorFocus) || this.el;
-    // Give the returned element focus.
-    result.focus();
+    // Set focus on the initial element.
+    (el.querySelector(selectorFocus) || el).focus();
   }
 
   unmount() {

--- a/packages/core/src/js/modules/FocusTrap.js
+++ b/packages/core/src/js/modules/FocusTrap.js
@@ -1,3 +1,5 @@
+import { focusableSelectors } from "../utilities";
+
 export class FocusTrap {
   #focusable;
   #handleFocusTrap;
@@ -98,27 +100,6 @@ export class FocusTrap {
     return focusable;
   }
 }
-
-// This has been copied over from focusable-selectors package and modified.
-// https://github.com/KittyGiraudel/focusable-selectors
-const notInert = ":not([inert])"; // Previously `:not([inert]):not([inert] *)`
-const notNegTabIndex = ":not([tabindex^=\"-\"])";
-const notDisabled = ":not(:disabled)";
-const focusableSelectors = [
-  `a[href]${notInert}${notNegTabIndex}`,
-  `area[href]${notInert}${notNegTabIndex}`,
-  `input:not([type="hidden"]):not([type="radio"])${notInert}${notNegTabIndex}${notDisabled}`,
-  `input[type="radio"]${notInert}${notNegTabIndex}${notDisabled}`,
-  `select${notInert}${notNegTabIndex}${notDisabled}`,
-  `textarea${notInert}${notNegTabIndex}${notDisabled}`,
-  `button${notInert}${notNegTabIndex}${notDisabled}`,
-  `details${notInert} > summary:first-of-type${notNegTabIndex}`,
-  `iframe${notInert}${notNegTabIndex}`,
-  `audio[controls]${notInert}${notNegTabIndex}`,
-  `video[controls]${notInert}${notNegTabIndex}`,
-  `[contenteditable]${notInert}${notNegTabIndex}`,
-  `[tabindex]${notInert}${notNegTabIndex}`,
-];
 
 function handleFocusTrap(event) {
   // Check if the click was a tab and return if not.

--- a/packages/core/src/js/modules/FocusTrap.js
+++ b/packages/core/src/js/modules/FocusTrap.js
@@ -7,7 +7,7 @@ export class FocusTrap {
     this.handleFocusTrap = handleFocusTrap.bind(this);
   }
 
-  mount(el = this.el) {
+  on(el = this.el) {
     // Get the focusable elements.
     this.focusable.set(el);
 
@@ -17,7 +17,7 @@ export class FocusTrap {
       document.addEventListener("keydown", handleFocusLock);
   }
 
-  unmount() {
+  off() {
     // Clear the focusable elements.
     this.focusable.clear();
 

--- a/packages/core/src/js/modules/FocusTrap.js
+++ b/packages/core/src/js/modules/FocusTrap.js
@@ -3,12 +3,13 @@ import { FocusableArray } from "./";
 export class FocusTrap {
   constructor(el = null) {
     this.el = el;
+    this.focusable = new FocusableArray();
     this.handleFocusTrap = handleFocusTrap.bind(this);
   }
 
   mount(el = this.el) {
     // Get the focusable elements.
-    this.focusable = new FocusableArray(el);
+    this.focusable.set(el);
 
     // Either focus trap or lock depending on focusable length.
     (this.focusable.length) ?
@@ -17,11 +18,8 @@ export class FocusTrap {
   }
 
   unmount() {
-    // Set element to null.
-    this.el = null;
-
-    // Apply empty array to focusable.
-    this.focusable = [];
+    // Clear the focusable elements.
+    this.focusable.clear();
 
     // Remove event listeners
     document.removeEventListener("keydown", this.handleFocusTrap);

--- a/packages/core/src/js/modules/FocusTrap.js
+++ b/packages/core/src/js/modules/FocusTrap.js
@@ -3,13 +3,11 @@ import { focusableSelectors } from "../utilities";
 export class FocusTrap {
   #focusable;
   #handleFocusTrap;
-  #handleFocusLock;
 
   constructor(el = null, selectorFocus = "[data-focus]") {
     this.el = el;
     this.selectorFocus = selectorFocus;
     this.#handleFocusTrap = handleFocusTrap.bind(this);
-    this.#handleFocusLock = handleFocusLock.bind(this);
   }
 
   get focusable() {
@@ -22,11 +20,11 @@ export class FocusTrap {
 
     // Apply event listeners based on new focusable array length.
     if (this.#focusable.length) {
-      document.removeEventListener("keydown", this.#handleFocusLock);
+      document.removeEventListener("keydown", handleFocusLock);
       document.addEventListener("keydown", this.#handleFocusTrap);
     } else {
       document.removeEventListener("keydown", this.#handleFocusTrap);
-      document.addEventListener("keydown", this.#handleFocusLock);
+      document.addEventListener("keydown", handleFocusLock);
     }
   }
 
@@ -59,7 +57,7 @@ export class FocusTrap {
 
     // Remove event listeners
     document.removeEventListener("keydown", this.#handleFocusTrap);
-    document.removeEventListener("keydown", this.#handleFocusLock);
+    document.removeEventListener("keydown", handleFocusLock);
   }
 
   focus(el = this.el, selectorFocus = this.selectorFocus) {
@@ -101,37 +99,27 @@ export class FocusTrap {
   }
 }
 
-function handleFocusTrap(event) {
-  // Check if the click was a tab and return if not.
-  const isTab = (event.key === "Tab" || event.keyCode === 9);
-  if (!isTab) return;
-
-  // If the shift key is pressed.
-  if (event.shiftKey) {
-    // If the active element is either the root el or first focusable.
-    if (
-      document.activeElement === this.focusableFirst ||
-      document.activeElement === this.el
-    ) {
-      // Prevent default and focus the last focusable element instead.
-      event.preventDefault();
-      this.focusableLast.focus();
-    }
-  } else {
-    // If the active element is either the root el or last focusable.
-    if (
-      document.activeElement === this.focusableLast ||
-      document.activeElement === this.el
-    ) {
-      // Prevent default and focus the first focusable element instead.
-      event.preventDefault();
-      this.focusableFirst.focus();
-    }
-  }
-}
-
 function handleFocusLock(event) {
   // Ignore the tab key by preventing default.
-  const isTab = (event.key === "Tab" || event.keyCode === 9);
-  if (isTab) event.preventDefault();
+  if (event.key === "Tab" || event.keyCode === 9) event.preventDefault();
+}
+
+function handleFocusTrap(event) {  
+  // Check if the click was a tab and return if not.
+  if (event.key !== "Tab" && event.keyCode !== 9) return;
+
+  // Destructure variables for brevity.
+  const { activeElement } = document;
+  const { el, focusableFirst, focusableLast } = this;
+
+  // Set variables of conditionals.
+  const isShiftTab = event.shiftKey;
+  const isFirstOrRoot = activeElement === focusableFirst || activeElement === el;
+  const isLastOrRoot = activeElement === focusableLast || activeElement === el;
+
+  if ((isShiftTab && isFirstOrRoot) || (!isShiftTab && isLastOrRoot)) {
+    event.preventDefault();
+    // Loop next tab focus based on direction (shift).
+    (isShiftTab ? focusableLast : focusableFirst).focus();
+  }
 }

--- a/packages/core/src/js/modules/FocusableArray.js
+++ b/packages/core/src/js/modules/FocusableArray.js
@@ -1,0 +1,15 @@
+import { focusableSelectors } from "../utilities";
+
+export class FocusableArray extends Array {
+  constructor(el) {
+    super(...Array.from(el.querySelectorAll(focusableSelectors.join(","))));
+  }
+
+  get first() {
+    return this[0];
+  }
+
+  get last() {
+    return this[this.length - 1];
+  }
+}

--- a/packages/core/src/js/modules/FocusableArray.js
+++ b/packages/core/src/js/modules/FocusableArray.js
@@ -1,8 +1,9 @@
 import { focusableSelectors } from "../utilities";
 
 export class FocusableArray extends Array {
-  constructor(el) {
-    super(...Array.from(el.querySelectorAll(focusableSelectors.join(","))));
+  constructor(el = null) {
+    super();
+    if (el) this.set(el);
   }
 
   get first() {
@@ -11,5 +12,14 @@ export class FocusableArray extends Array {
 
   get last() {
     return this[this.length - 1];
+  }
+
+  set(el) {
+    this.length = 0;
+    this.push(...el.querySelectorAll(focusableSelectors.join(",")));
+  }
+
+  clear() {
+    this.length = 0;
   }
 }

--- a/packages/core/src/js/modules/FocusableArray.js
+++ b/packages/core/src/js/modules/FocusableArray.js
@@ -3,7 +3,8 @@ import { focusableSelectors } from "../utilities";
 export class FocusableArray extends Array {
   constructor(el = null) {
     super();
-    if (el) this.set(el);
+    this.el = el;
+    if (this.el) this.set();
   }
 
   get first() {
@@ -14,7 +15,7 @@ export class FocusableArray extends Array {
     return this[this.length - 1];
   }
 
-  set(el) {
+  set(el = this.el) {
     this.length = 0;
     this.push(...el.querySelectorAll(focusableSelectors.join(",")));
   }

--- a/packages/core/src/js/modules/index.js
+++ b/packages/core/src/js/modules/index.js
@@ -1,4 +1,5 @@
 export * from "./eventEmitter";
+export * from "./FocusableArray";
 export * from "./FocusTrap";
 export * from "./localStore";
 export * from "./PluginsArray";

--- a/packages/core/src/js/plugins/focusTrap.js
+++ b/packages/core/src/js/plugins/focusTrap.js
@@ -17,7 +17,7 @@ export function focusTrap(options = {}) {
       parent.on("closed", teardownFocusTrap, this);
     },
 
-    teardown() {
+    teardown({ parent }) {
       parent.off("opened", setupFocusTrap);
       parent.off("closed", teardownFocusTrap);
     },

--- a/packages/core/src/js/plugins/focusTrap.js
+++ b/packages/core/src/js/plugins/focusTrap.js
@@ -13,13 +13,13 @@ export function focusTrap(options = {}) {
 
   const methods = {
     setup({ parent }) {
-      parent.on("opened", setupFocusTrap, this);
-      parent.on("closed", teardownFocusTrap, this);
+      parent.on("opened", enableFocusTrap, this);
+      parent.on("closed", disableFocusTrap, this);
     },
 
     teardown({ parent }) {
-      parent.off("opened", setupFocusTrap);
-      parent.off("closed", teardownFocusTrap);
+      parent.off("opened", enableFocusTrap);
+      parent.off("closed", disableFocusTrap);
     },
 
     onCreateEntry({ entry }) {
@@ -31,17 +31,17 @@ export function focusTrap(options = {}) {
     return (typeof obj === "function") ? obj(...args) : obj;
   }
 
-  function setupFocusTrap(entry, plugin) {
+  function enableFocusTrap(entry, plugin) {
     const contextObj = { plugin, parent: entry.parent, entry };
     if (getValue(plugin.settings.condition, contextObj)) {
-      entry.focusTrap?.mount(entry.dialog);
+      entry.focusTrap?.on(entry.dialog);
     }
   }
 
-  function teardownFocusTrap(entry, plugin) {
+  function disableFocusTrap(entry, plugin) {
     const contextObj = { plugin, parent: entry.parent, entry };
     if (getValue(plugin.settings.condition, contextObj)) {
-      entry.focusTrap?.unmount();
+      entry.focusTrap?.off();
     }
   }
 

--- a/packages/core/src/js/plugins/focusTrap.js
+++ b/packages/core/src/js/plugins/focusTrap.js
@@ -1,0 +1,49 @@
+import { FocusTrap } from "../modules";
+
+const defaults = {
+  condition: true
+};
+
+export function focusTrap(options = {}) {
+  const props = {
+    name: "focusTrap",
+    defaults,
+    options
+  };
+
+  const methods = {
+    setup({ parent }) {
+      parent.on("opened", setupFocusTrap, this);
+      parent.on("closed", teardownFocusTrap, this);
+    },
+
+    teardown() {
+      parent.off("opened", setupFocusTrap);
+      parent.off("closed", teardownFocusTrap);
+    },
+
+    onCreateEntry({ entry }) {
+      entry.focusTrap = new FocusTrap();
+    }
+  };
+
+  function getValue(obj, ...args) {
+    return (typeof obj === "function") ? obj(...args) : obj;
+  }
+
+  function setupFocusTrap(entry, plugin) {
+    const contextObj = { plugin, parent: entry.parent, entry };
+    if (getValue(plugin.settings.condition, contextObj)) {
+      entry.focusTrap?.mount(entry.dialog);
+    }
+  }
+
+  function teardownFocusTrap(entry, plugin) {
+    const contextObj = { plugin, parent: entry.parent, entry };
+    if (getValue(plugin.settings.condition, contextObj)) {
+      entry.focusTrap?.unmount();
+    }
+  }
+
+  return {...props, ...methods};
+}

--- a/packages/core/src/js/plugins/index.js
+++ b/packages/core/src/js/plugins/index.js
@@ -1,4 +1,5 @@
 export * from "./debug";
+export * from "./focusTrap";
 export * from "./mediaQuery";
 export * from "./propStore";
 export * from "./teleport";

--- a/packages/core/src/js/utilities/focusableSelectors.js
+++ b/packages/core/src/js/utilities/focusableSelectors.js
@@ -1,0 +1,21 @@
+// This has been copied over from focusable-selectors package and modified.
+// https://github.com/KittyGiraudel/focusable-selectors
+const notInert = ":not([inert])"; // Previously `:not([inert]):not([inert] *)`
+const notNegTabIndex = ":not([tabindex^=\"-\"])";
+const notDisabled = ":not(:disabled)";
+
+export const focusableSelectors = [
+  `a[href]${notInert}${notNegTabIndex}`,
+  `area[href]${notInert}${notNegTabIndex}`,
+  `input:not([type="hidden"]):not([type="radio"])${notInert}${notNegTabIndex}${notDisabled}`,
+  `input[type="radio"]${notInert}${notNegTabIndex}${notDisabled}`,
+  `select${notInert}${notNegTabIndex}${notDisabled}`,
+  `textarea${notInert}${notNegTabIndex}${notDisabled}`,
+  `button${notInert}${notNegTabIndex}${notDisabled}`,
+  `details${notInert} > summary:first-of-type${notNegTabIndex}`,
+  `iframe${notInert}${notNegTabIndex}`,
+  `audio[controls]${notInert}${notNegTabIndex}`,
+  `video[controls]${notInert}${notNegTabIndex}`,
+  `[contenteditable]${notInert}${notNegTabIndex}`,
+  `[tabindex]${notInert}${notNegTabIndex}`,
+];

--- a/packages/core/src/js/utilities/index.js
+++ b/packages/core/src/js/utilities/index.js
@@ -1,3 +1,4 @@
+export * from "./focusableSelectors";
 export * from "./getConfig";
 export * from "./getElement";
 export * from "./maybeRunMethod";

--- a/packages/core/tests/modules/FocusTrap.test.js
+++ b/packages/core/tests/modules/FocusTrap.test.js
@@ -39,7 +39,7 @@ let child_2 = el.querySelector(".child-2");
 let child_3 = el.querySelector(".child-3");
 
 test("mount() should mount the focus trap setup", () => {
-  focusTrap.mount(el);
+  focusTrap.on(el);
   el.focus();
 
   expect(focusTrap.focusable.length).toBe(3);
@@ -48,7 +48,7 @@ test("mount() should mount the focus trap setup", () => {
 });
 
 test("should correctly cycle through focusable elements on tab", async () => {
-  focusTrap.mount(el);
+  focusTrap.on(el);
   el.focus();
 
   await user.keyboard("{Tab}");
@@ -79,7 +79,7 @@ test("should correctly cycle through focusable elements on shift-tab", async () 
 });
 
 test("unmount() should unmount the focus trap setup", () => {
-  focusTrap.unmount();
+  focusTrap.off();
 
   expect(focusTrap.focusable.length).toBe(0);
   expect(focusTrap.focusable.first).toBe(undefined);
@@ -89,7 +89,7 @@ test("unmount() should unmount the focus trap setup", () => {
 test("should correctly setup focus lock when there are no focusable elements", async () => {
   el = document.querySelector(".container-3");
   focusTrap = new FocusTrap(el);
-  focusTrap.mount();
+  focusTrap.on();
   el.focus();
 
   expect(focusTrap.focusable.length).toBe(0);

--- a/packages/core/tests/modules/FocusTrap.test.js
+++ b/packages/core/tests/modules/FocusTrap.test.js
@@ -40,8 +40,8 @@ let child_3 = el.querySelector(".child-3");
 
 test("mount() should mount the focus trap setup", () => {
   focusTrap.mount(el);
+  el.focus();
 
-  expect(el).toHaveFocus();
   expect(focusTrap.focusable.length).toBe(3);
   expect(focusTrap.focusable.first).toBe(child_1);
   expect(focusTrap.focusable.last).toBe(child_3);
@@ -49,8 +49,7 @@ test("mount() should mount the focus trap setup", () => {
 
 test("should correctly cycle through focusable elements on tab", async () => {
   focusTrap.mount(el);
-
-  expect(el).toHaveFocus();
+  el.focus();
 
   await user.keyboard("{Tab}");
   expect(child_1).toHaveFocus();
@@ -83,35 +82,19 @@ test("unmount() should unmount the focus trap setup", () => {
   focusTrap.unmount();
 
   expect(focusTrap.focusable.length).toBe(0);
-  expect(focusTrap.focusableFirst).toBe(undefined);
-  expect(focusTrap.focusableLast).toBe(undefined);
-});
-
-test("mount() should set focus to preferred focus element", () => {
-  el = document.querySelector(".container-2");
-  child_1 = el.querySelector(".child-1");
-  child_2 = el.querySelector(".child-2");
-  child_3 = el.querySelector(".child-3");
-
-  focusTrap.mount(el);
-  expect(child_1).toHaveFocus();
-
-  focusTrap.mount(el, ".child-2");
-  expect(child_2).toHaveFocus();
-
-  focusTrap.mount(el, ".child-3");
-  expect(child_3).toHaveFocus();
+  expect(focusTrap.focusable.first).toBe(undefined);
+  expect(focusTrap.focusable.last).toBe(undefined);
 });
 
 test("should correctly setup focus lock when there are no focusable elements", async () => {
   el = document.querySelector(".container-3");
   focusTrap = new FocusTrap(el);
   focusTrap.mount();
+  el.focus();
 
-  expect(el).toHaveFocus();
   expect(focusTrap.focusable.length).toBe(0);
-  expect(focusTrap.focusableFirst).toBe(undefined);
-  expect(focusTrap.focusableLast).toBe(undefined);
+  expect(focusTrap.focusable.first).toBe(undefined);
+  expect(focusTrap.focusable.last).toBe(undefined);
 
   await user.keyboard("{Tab}");
   expect(el).toHaveFocus();

--- a/packages/core/tests/modules/FocusTrap.test.js
+++ b/packages/core/tests/modules/FocusTrap.test.js
@@ -43,8 +43,8 @@ test("mount() should mount the focus trap setup", () => {
 
   expect(el).toHaveFocus();
   expect(focusTrap.focusable.length).toBe(3);
-  expect(focusTrap.focusableFirst).toBe(child_1);
-  expect(focusTrap.focusableLast).toBe(child_3);
+  expect(focusTrap.focusable.first).toBe(child_1);
+  expect(focusTrap.focusable.last).toBe(child_3);
 });
 
 test("should correctly cycle through focusable elements on tab", async () => {
@@ -87,33 +87,20 @@ test("unmount() should unmount the focus trap setup", () => {
   expect(focusTrap.focusableLast).toBe(undefined);
 });
 
-test("focus() should set focus to preferred focus element", () => {
+test("mount() should set focus to preferred focus element", () => {
   el = document.querySelector(".container-2");
   child_1 = el.querySelector(".child-1");
   child_2 = el.querySelector(".child-2");
   child_3 = el.querySelector(".child-3");
 
-  focusTrap.focus(el);
+  focusTrap.mount(el);
   expect(child_1).toHaveFocus();
 
-  focusTrap.focus(el, ".child-2");
+  focusTrap.mount(el, ".child-2");
   expect(child_2).toHaveFocus();
 
   focusTrap.mount(el, ".child-3");
   expect(child_3).toHaveFocus();
-});
-
-test("getFocusable() should return focusable elements array", () => {
-  el = document.querySelector(".container-2");
-  child_1 = el.querySelector(".child-1");
-  child_2 = el.querySelector(".child-2");
-  child_3 = el.querySelector(".child-3");
-
-  const result = focusTrap.getFocusable(el);
-  expect(result.length).toBe(3);
-  expect(result[0]).toBe(child_1);
-  expect(result[1]).toBe(child_2);
-  expect(result[2]).toBe(child_3);
 });
 
 test("should correctly setup focus lock when there are no focusable elements", async () => {

--- a/packages/core/tests/modules/FocusableArray.test.js
+++ b/packages/core/tests/modules/FocusableArray.test.js
@@ -1,0 +1,82 @@
+import { FocusableArray } from "../../src/js/modules";
+
+describe("FocusableArray", () => {
+  let container;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="container">
+        <button id="btn1">Button 1</button>
+        <a href="#" id="link1">Link 1</a>
+        <input type="text" id="input1" />
+        <div id="nonFocusable">Non-focusable</div>
+      </div>
+    `;
+    container = document.getElementById("container");
+  });
+
+  it("initializes correctly with elements matching selectors", () => {
+    const focusableArray = new FocusableArray(container);
+    expect(focusableArray).toHaveLength(3);
+    expect(focusableArray.first).toBe(document.getElementById("btn1"));
+    expect(focusableArray.last).toBe(document.getElementById("input1"));
+  });
+
+  it("handles empty containers gracefully", () => {
+    const emptyDiv = document.createElement("div");
+    const focusableArray = new FocusableArray(emptyDiv);
+    expect(focusableArray).toHaveLength(0);
+    expect(focusableArray.first).toBeUndefined();
+    expect(focusableArray.last).toBeUndefined();
+  });
+
+  it("sets a new container and updates the array with matching elements", () => {
+    const focusableArray = new FocusableArray();
+    focusableArray.set(container);
+    expect(focusableArray).toHaveLength(3);
+    expect(focusableArray.first).toBe(document.getElementById("btn1"));
+    expect(focusableArray.last).toBe(document.getElementById("input1"));
+  });
+
+  it("clears all elements from the array", () => {
+    const focusableArray = new FocusableArray(container);
+    focusableArray.clear();
+    expect(focusableArray).toHaveLength(0);
+    expect(focusableArray.first).toBeUndefined();
+    expect(focusableArray.last).toBeUndefined();
+  });
+
+  it("can reset with a new element using set()", () => {
+    const newContainer = document.createElement("div");
+    newContainer.innerHTML = `
+      <button id="btn2">Button 2</button>
+      <a href="#" id="link2">Link 2</a>
+    `;
+    document.body.appendChild(newContainer);
+
+    const focusableArray = new FocusableArray(container);
+    expect(focusableArray).toHaveLength(3);
+    
+    focusableArray.set(newContainer);
+    expect(focusableArray).toHaveLength(2);
+    expect(focusableArray.first).toBe(document.getElementById("btn2"));
+    expect(focusableArray.last).toBe(document.getElementById("link2"));
+
+    document.body.removeChild(newContainer);
+  });
+
+  it("does nothing if no container is set on construction or set()", () => {
+    const focusableArray = new FocusableArray();
+    expect(focusableArray).toHaveLength(0);
+    expect(focusableArray.first).toBeUndefined();
+    expect(focusableArray.last).toBeUndefined();
+  });
+
+  it("handles duplicate set() calls gracefully", () => {
+    const focusableArray = new FocusableArray(container);
+    focusableArray.set(container);
+    expect(focusableArray).toHaveLength(3);
+    expect(focusableArray.first).toBe(document.getElementById("btn1"));
+    expect(focusableArray.last).toBe(document.getElementById("input1"));
+  });
+});

--- a/packages/core/tests/plugins/focusTrap.test.js
+++ b/packages/core/tests/plugins/focusTrap.test.js
@@ -1,0 +1,120 @@
+import { FocusTrap } from "../../src/js/modules";
+import { focusTrap } from "../../src/js/plugins";
+
+vi.mock("../../src/js/modules", () => ({
+  FocusTrap: vi.fn().mockImplementation(() => ({
+    mount: vi.fn(),
+    unmount: vi.fn(),
+  })),
+}));
+
+describe("focusTrap Plugin", () => {
+  let plugin;
+  let parentMock;
+  let entryMock;
+
+  beforeEach(() => {
+    FocusTrap.mockClear();
+
+    plugin = focusTrap();
+
+    parentMock = {
+      on: vi.fn(),
+      off: vi.fn(),
+    };
+
+    entryMock = {
+      parent: parentMock,
+      dialog: document.createElement("div"),
+      focusTrap: null,
+    };
+  });
+
+  it("returns a plugin object with default properties", () => {
+    expect(plugin.name).toBe("focusTrap");
+    expect(plugin.defaults).toEqual({ condition: true });
+    expect(typeof plugin.setup).toBe("function");
+    expect(typeof plugin.teardown).toBe("function");
+    expect(typeof plugin.onCreateEntry).toBe("function");
+  });
+
+  describe("setup", () => {
+    it("attaches 'opened' and 'closed' event listeners to the parent", () => {
+      plugin.setup({ parent: parentMock });
+      expect(parentMock.on).toHaveBeenCalledWith("opened", expect.any(Function), plugin);
+      expect(parentMock.on).toHaveBeenCalledWith("closed", expect.any(Function), plugin);
+    });
+  });
+
+  describe("teardown", () => {
+    it("removes 'opened' and 'closed' event listeners from the parent", () => {
+      plugin.teardown({ parent: parentMock });
+      expect(parentMock.off).toHaveBeenCalledWith("opened", expect.any(Function));
+      expect(parentMock.off).toHaveBeenCalledWith("closed", expect.any(Function));
+    });
+  });
+
+  describe("setupFocusTrap", () => {
+    it("mounts the focus trap if condition evaluates to true", () => {
+      const mockPlugin = {
+        settings: { condition: true },
+      };
+
+      plugin.setup({ parent: parentMock });
+
+      entryMock.focusTrap = new FocusTrap();
+      const setupFocusTrap = parentMock.on.mock.calls[0][1];
+
+      setupFocusTrap(entryMock, mockPlugin);
+
+      expect(entryMock.focusTrap.mount).toHaveBeenCalledWith(entryMock.dialog);
+    });
+
+    it("does not mount the focus trap if condition evaluates to false", () => {
+      const mockPlugin = {
+        settings: { condition: false },
+      };
+
+      plugin.setup({ parent: parentMock });
+
+      entryMock.focusTrap = new FocusTrap();
+      const setupFocusTrap = parentMock.on.mock.calls[0][1];
+
+      setupFocusTrap(entryMock, mockPlugin);
+
+      expect(entryMock.focusTrap.mount).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("teardownFocusTrap", () => {
+    it("unmounts the focus trap if condition evaluates to true", () => {
+      const mockPlugin = {
+        settings: { condition: true },
+      };
+
+      plugin.setup({ parent: parentMock });
+
+      entryMock.focusTrap = new FocusTrap();
+      const teardownFocusTrap = parentMock.on.mock.calls[1][1];
+
+      teardownFocusTrap(entryMock, mockPlugin);
+
+      expect(entryMock.focusTrap.unmount).toHaveBeenCalled();
+    });
+
+    it("does not unmount the focus trap if condition evaluates to false", () => {
+      const mockPlugin = {
+        settings: { condition: false },
+      };
+
+      plugin.setup({ parent: parentMock });
+
+      entryMock.focusTrap = new FocusTrap();
+      const teardownFocusTrap = parentMock.on.mock.calls[1][1];
+
+      teardownFocusTrap(entryMock, mockPlugin);
+
+      expect(entryMock.focusTrap.unmount).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/drawer/index.html
+++ b/packages/drawer/index.html
@@ -10,12 +10,13 @@
   <script type="module">
     import "vrembem/dist/index.css";
     import Drawer from "./index.js";
-    import { propStore, mediaQuery, teleport } from "@vrembem/core";
+    import { focusTrap, mediaQuery, propStore, teleport } from "@vrembem/core";
 
     const drawer = new Drawer({
       plugins: [
-        propStore(),
+        focusTrap(),
         mediaQuery(),
+        propStore(),
         teleport({
           where: ".drawer-main",
           how: "before"
@@ -69,8 +70,9 @@
           
           <div id="drawer-modal" class="drawer drawer_modal is-closed">
             <div class="drawer__dialog dialog">
-              <div class="dialog__body">
-                drawer-modal
+              <div class="dialog__header flex justify-content-between">
+                <p>drawer-modal</p>
+                <button data-drawer-close class="link">Close</button>
               </div>
             </div>
           </div>

--- a/packages/drawer/src/js/Drawer.js
+++ b/packages/drawer/src/js/Drawer.js
@@ -1,4 +1,4 @@
-import { Collection, FocusTrap } from "@vrembem/core";
+import { Collection } from "@vrembem/core";
 
 import defaults from "./defaults";
 import { DrawerEntry } from "./DrawerEntry";
@@ -15,7 +15,6 @@ export class Drawer extends Collection {
     super({ ...defaults, ...options});
     this.module = "Drawer";
     this.entryClass = DrawerEntry;
-    this.focusTrap = new FocusTrap();
     this.#handleClick = handleClick.bind(this);
     this.#handleKeydown = handleKeydown.bind(this);
   }

--- a/packages/drawer/src/js/helpers/updateFocusState.js
+++ b/packages/drawer/src/js/helpers/updateFocusState.js
@@ -1,11 +1,10 @@
 export function updateFocusState(entry) {
   // Check if there's an active modal
   if (entry.state === "opened") {
+    (entry.dialog.querySelector(this.settings.selectorFocus) || entry.dialog).focus();
     // Mount the focus trap on the opened drawer.
     if (entry.mode === "modal") {
-      this.focusTrap.mount(entry.dialog, this.settings.selectorFocus);
-    } else {
-      (entry.dialog.querySelector(this.settings.selectorFocus) || entry.dialog).focus();
+      this.focusTrap.mount(entry.dialog);
     }
   } else {
     // Set focus to root trigger and unmount the focus trap.

--- a/packages/drawer/src/js/helpers/updateFocusState.js
+++ b/packages/drawer/src/js/helpers/updateFocusState.js
@@ -5,7 +5,7 @@ export function updateFocusState(entry) {
     if (entry.mode === "modal") {
       this.focusTrap.mount(entry.dialog, this.settings.selectorFocus);
     } else {
-      this.focusTrap.focus(entry.dialog, this.settings.selectorFocus);
+      (entry.dialog.querySelector(this.settings.selectorFocus) || entry.dialog).focus();
     }
   } else {
     // Set focus to root trigger and unmount the focus trap.

--- a/packages/drawer/src/js/helpers/updateFocusState.js
+++ b/packages/drawer/src/js/helpers/updateFocusState.js
@@ -2,16 +2,11 @@ export function updateFocusState(entry) {
   // Check if there's an active modal
   if (entry.state === "opened") {
     (entry.dialog.querySelector(this.settings.selectorFocus) || entry.dialog).focus();
-    // Mount the focus trap on the opened drawer.
-    if (entry.mode === "modal") {
-      this.focusTrap.mount(entry.dialog);
-    }
   } else {
     // Set focus to root trigger and unmount the focus trap.
     if (entry.trigger) {
       entry.trigger.focus();
       entry.trigger = null;
     }
-    this.focusTrap.unmount();
   }
 }

--- a/packages/drawer/src/js/presets.js
+++ b/packages/drawer/src/js/presets.js
@@ -1,4 +1,9 @@
 export default {
+  focusTrap: {
+    condition: ({entry}) => {
+      return entry.state === "closed" || (entry.state === "opened" && entry.mode === "modal");
+    }
+  },
   mediaQuery: {
     onChange(event, entry) {
       entry.mode = (event.matches) ? "inline" : "modal";

--- a/packages/drawer/src/js/switchMode.js
+++ b/packages/drawer/src/js/switchMode.js
@@ -21,9 +21,6 @@ async function toInline(entry) {
   // Update the global state.
   setGlobalState(false, entry.getSetting("selectorInert"), entry.getSetting("selectorOverflow"));
 
-  // Remove any focus traps.
-  this.focusTrap.unmount();
-
   // Apply the inline state.
   entry.applyState();
 

--- a/packages/drawer/tests/switchMode.test.js
+++ b/packages/drawer/tests/switchMode.test.js
@@ -1,6 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 import Drawer from "../index";
-import { propStore, mediaQuery } from "@vrembem/core";
+import { focusTrap, mediaQuery, propStore } from "@vrembem/core";
+import { expect } from "vitest";
 
 document.body.innerHTML = `
   <div id="drawer-1" class="drawer">
@@ -53,8 +54,9 @@ function resizeWindow(value, collection) {
 const drawer = new Drawer({ 
   transition: false,
   plugins: [
-    propStore(),
-    mediaQuery()
+    focusTrap(),
+    mediaQuery(),
+    propStore()
   ]
 });
 
@@ -189,4 +191,9 @@ test("should setup match media breakpoint for drawer on register", async () => {
   expect(entry.mode).toBe("inline");
   resizeWindow(400, drawer.collection);
   expect(entry.mode).toBe("modal");
+});
+
+test("should run teardown methods of all plugins when unmounted", async () => {
+  await drawer.unmount();
+  expect(drawer.plugins.length).toBe(0);
 });

--- a/packages/modal/index.html
+++ b/packages/modal/index.html
@@ -10,10 +10,11 @@
   <script type="module">
     import "vrembem/dist/index.css";
     import Modal from "./index.js";
-    import { propStore, teleport } from "@vrembem/core";
+    import { focusTrap, propStore, teleport } from "@vrembem/core";
 
     const modal = new Modal({
       plugins: [
+        focusTrap(),
         propStore({
           onChange({ plugin, parent, entry }) {
             if (["opening", "closing"].includes(entry.state)) return;

--- a/packages/modal/index.html
+++ b/packages/modal/index.html
@@ -64,6 +64,7 @@
 
       <ul class="list">
         <li><button class="link" data-modal-open="modal-default">default</button></li>
+        <li><button class="link" data-modal-open="modal-focus-lock">focus lock</button></li>
         <li><button class="link" data-modal-open="modal-dialog">dialog</button></li>
         <li><button class="link" data-modal-open="modal-focus-dialog">focus dialog</button></li>
         <li><button class="link" data-modal-open="modal-focus-inner">focus element</button></li>
@@ -75,6 +76,14 @@
           <div class="dialog__body flex justify-content-between">
             <p>This is a basic modal</p>
             <button data-modal-close class="link">Close</button>
+          </div>
+        </div>
+      </div>
+
+      <div id="modal-focus-lock" class="modal">
+        <div class="modal__dialog dialog" role="dialog" aria-modal="true">
+          <div class="dialog__body flex justify-content-between">
+            <p>This is a basic modal with nothing focusable inside.</p>
           </div>
         </div>
       </div>

--- a/packages/modal/src/js/Modal.js
+++ b/packages/modal/src/js/Modal.js
@@ -1,4 +1,4 @@
-import { Collection, FocusTrap, StackArray, setGlobalState } from "@vrembem/core";
+import { Collection, StackArray, setGlobalState } from "@vrembem/core";
 
 import defaults from "./defaults";
 import { ModalEntry } from "./ModalEntry";
@@ -18,7 +18,6 @@ export class Modal extends Collection {
     this.module = "Modal";
     this.entryClass = ModalEntry;
     this.trigger = null;
-    this.focusTrap = new FocusTrap();
     this.#handleClick = handleClick.bind(this);
     this.#handleKeydown = handleKeydown.bind(this);
 

--- a/packages/modal/src/js/helpers/updateFocusState.js
+++ b/packages/modal/src/js/helpers/updateFocusState.js
@@ -2,14 +2,11 @@ export function updateFocusState() {
   // Check if there's an active modal
   if (this.active) {
     (this.active.dialog.querySelector(this.settings.selectorFocus) || this.active.dialog).focus();
-    // Mount the focus trap on the active modal.
-    this.focusTrap.mount(this.active.dialog);
   } else {
     // Set focus to root trigger and unmount the focus trap.
     if (this.trigger) {
       this.trigger.focus();
       this.trigger = null;
     }
-    this.focusTrap.unmount();
   }
 }

--- a/packages/modal/src/js/helpers/updateFocusState.js
+++ b/packages/modal/src/js/helpers/updateFocusState.js
@@ -1,8 +1,9 @@
 export function updateFocusState() {
   // Check if there's an active modal
   if (this.active) {
+    (this.active.dialog.querySelector(this.settings.selectorFocus) || this.active.dialog).focus();
     // Mount the focus trap on the active modal.
-    this.focusTrap.mount(this.active.dialog, this.settings.selectorFocus);
+    this.focusTrap.mount(this.active.dialog);
   } else {
     // Set focus to root trigger and unmount the focus trap.
     if (this.trigger) {


### PR DESCRIPTION
## What changed?

This PR converts the existing implementation of focus trapping into a modular plugin. This allows the feature to be excluded and added as needed to any component using the new plugin system and also enables more flexibility with the condition that it is applied. As part of this update, there's also a refactored `FocusTrap` class that can be used on its own where the `focusTrap` plugin implements the module in the form of a collection plugin.