### PR TITLE
Add breakpoint modifier support to bem function

### DIFF
--- a/packages/core/src/scss/library/_bem.scss
+++ b/packages/core/src/scss/library/_bem.scss
@@ -1,6 +1,7 @@
+@use "sass:string";
+@use "../utilities/escape-colon" as *;
 @use "../modules/config";
 
-/// TODO: Add support for breakpoint prefixes `md:` similar to utility function.
 /// Output a valid BEM class selector using core prefixes and the provided
 /// parameters; block, element, modifier and modifier-value.
 /// @param {string} $b
@@ -11,10 +12,12 @@
 ///   The modifier name.
 /// @param {string} $v [null]
 ///   The modifier value name.
+/// @param {string} $bp [bull]
+///   A breakpoint modifier to prepend to class, e.g: `md:`.
 /// @return {selector}
 ///   A valid BEM CSS selector using the provided parameters.
-@function bem($b, $e: null, $m: null, $v: null) {
-  $class: '.#{config.get("prefix-blocks")}#{$b}';
+@function bem($b, $e: null, $m: null, $v: null, $bp: null) {
+  $class: '#{config.get("prefix-blocks")}#{$b}';
   @if ($e) {
     $class: '#{$class}#{config.get("prefix-elements")}#{$e}';
   }
@@ -24,5 +27,19 @@
   @if ($v) {
     $class: '#{$class}#{config.get("prefix-modifier-values")}#{$v}';
   }
-  @return $class;
+  @if ($bp) {
+    // Add the colon if it doesn't exist.
+    @if not string.index($bp, ":") {
+      $bp: '#{$bp}:';
+    }
+
+    // Escape the colon.
+    $bp: escape-colon($bp);
+
+    // Prepend the breakpoint modifier to class.
+    $class: '#{$bp}#{$class}';
+  }
+
+  // Return class with as a class selector.
+  @return '.#{$class}';
 }

--- a/packages/flex/src/_flex-basis.scss
+++ b/packages/flex/src/_flex-basis.scss
@@ -1,11 +1,13 @@
-.flex-basis-0 {
+@use "@vrembem/core";
+
+#{core.bem("flex-basis-0")} {
   flex-basis: 0;
 }
 
-.flex-basis-auto {
+#{core.bem("flex-basis-auto")} {
   flex-basis: auto;
 }
 
-.flex-basis-full {
+#{core.bem("flex-basis-full")} {
   flex-basis: 100%;
 }

--- a/packages/flex/src/_flex-grow.scss
+++ b/packages/flex/src/_flex-grow.scss
@@ -1,11 +1,12 @@
+@use "@vrembem/core";
 @use "./variables" as var;
 
-.flex-grow {
+#{core.bem("flex-grow")} {
   flex-grow: 1;
 }
 
 @for $i from 0 through var.$grow-count {
-  .flex-grow-#{$i} {
+  #{core.bem("flex-grow-#{$i}")} {
     flex-grow: $i;
   }
 }

--- a/packages/flex/src/_flex-shrink.scss
+++ b/packages/flex/src/_flex-shrink.scss
@@ -1,11 +1,12 @@
+@use "@vrembem/core";
 @use "./variables" as var;
 
-.flex-shrink {
+#{core.bem("flex-shrink")} {
   flex-shrink: 1;
 }
 
 @for $i from 0 through var.$shrink-count {
-  .flex-shrink-#{$i} {
+  #{core.bem("flex-shrink-#{$i}")} {
     flex-shrink: $i;
   }
 }

--- a/packages/flex/src/_flex_direction.scss
+++ b/packages/flex/src/_flex_direction.scss
@@ -17,21 +17,21 @@
   flex-direction: column-reverse;
 }
 
-@each $key, $value in var.$breakpoints {
+@each $bp, $value in var.$breakpoints {
   @include core.media-min($value) {
-    #{core.bem("#{$key}\\:flex", null, "direction", "row")} {
+    #{core.bem("flex", null, "direction", "row", $bp)} {
       flex-direction: row;
     }
     
-    #{core.bem("#{$key}\\:flex", null, "direction", "row-reverse")} {
+    #{core.bem("flex", null, "direction", "row-reverse", $bp)} {
       flex-direction: row-reverse;
     }
     
-    #{core.bem("#{$key}\\:flex", null, "direction", "col")} {
+    #{core.bem("flex", null, "direction", "col", $bp)} {
       flex-direction: column;
     }
     
-    #{core.bem("#{$key}\\:flex", null, "direction", "col-reverse")} {
+    #{core.bem("flex", null, "direction", "col-reverse", $bp)} {
       flex-direction: column-reverse;
     }
   }

--- a/packages/flex/src/_flex_gap.scss
+++ b/packages/flex/src/_flex_gap.scss
@@ -21,17 +21,17 @@
 @each $bp, $value in var.$breakpoints {
   @include core.media-min($value) {
     @each $key, $value in var.$gap-map {
-      #{core.bem("#{$bp}\\:flex", null, "gap", $key)} {
+      #{core.bem("flex", null, "gap", $key, $bp)} {
         @include css.override("flex", "gap", $value);
       }
     }
     
     @each $key, $value in var.$gap-map {
-      #{core.bem("#{$bp}\\:flex", null, "gap-x", $key)} {
+      #{core.bem("flex", null, "gap-x", $key, $bp)} {
         @include css.override("flex", "gap-x", $value);
       }
     
-      #{core.bem("#{$bp}\\:flex", null, "gap-y", $key)} {
+      #{core.bem("flex", null, "gap-y", $key, $bp)} {
         @include css.override("flex", "gap-y", $value);
       }
     }

--- a/packages/flex/src/_flex_items.scss
+++ b/packages/flex/src/_flex_items.scss
@@ -39,39 +39,39 @@
   }
 }
 
-@each $key, $value in var.$breakpoints {
+@each $bp, $value in var.$breakpoints {
   @include core.media-min($value) {
-    #{core.bem("#{$key}\\:flex", null, "items", "initial")} {
+    #{core.bem("flex", null, "items", "initial", $bp)} {
       > * {
         flex: initial; // Equivalent to setting flex: 0 1 auto.
       }
     }
     
-    #{core.bem("#{$key}\\:flex", null, "items", "auto")} {
+    #{core.bem("flex", null, "items", "auto", $bp)} {
       > * {
         flex: auto; // Equivalent to setting flex: 1 1 auto.
       }
     }
     
-    #{core.bem("#{$key}\\:flex", null, "items", "none")} {
+    #{core.bem("flex", null, "items", "none", $bp)} {
       > * {
         flex: none; // Equivalent to setting flex: 0 0 auto.
       }
     }
     
-    #{core.bem("#{$key}\\:flex", null, "items", "equal")} {
+    #{core.bem("flex", null, "items", "equal", $bp)} {
       > * {
         flex: 1 1 0;
       }
     }
     
-    #{core.bem("#{$key}\\:flex", null, "items", "fill")} {
+    #{core.bem("flex", null, "items", "fill", $bp)} {
       > * {
         flex: 1 0 auto;
       }
     }
     
-    #{core.bem("#{$key}\\:flex", null, "items", "full")} {
+    #{core.bem("flex", null, "items", "full", $bp)} {
       flex-wrap: wrap;
       
       > * {
@@ -81,53 +81,53 @@
   }
 }
 
-.flex-initial {
+#{core.bem("flex-initial")} {
   flex: initial; // Equivalent to setting flex: 0 1 auto.
 }
 
-.flex-auto {
+#{core.bem("flex-auto")} {
   flex: auto; // Equivalent to setting flex: 1 1 auto.
 }
 
-.flex-none {
+#{core.bem("flex-none")} {
   flex: none; // Equivalent to setting flex: 0 0 auto.
 }
 
-.flex-equal {
+#{core.bem("flex-equal")} {
   flex: 1 1 0;
 }
 
-.flex-fill {
+#{core.bem("flex-fill")} {
   flex: 1 0 auto;
 }
 
-.flex-full {
+#{core.bem("flex-full")} {
   flex: 1 0 100%;
 }
 
-@each $key, $value in var.$breakpoints {
+@each $bp, $value in var.$breakpoints {
   @include core.media-min($value) {
-    .#{$key}\:flex-initial {
+    #{core.bem("flex-initial", $bp: $bp)} {
       flex: initial; // Equivalent to setting flex: 0 1 auto.
     }
     
-    .#{$key}\:flex-auto {
+    #{core.bem("flex-auto", $bp: $bp)} {
       flex: auto; // Equivalent to setting flex: 1 1 auto.
     }
     
-    .#{$key}\:flex-none {
+    #{core.bem("flex-none", $bp: $bp)} {
       flex: none; // Equivalent to setting flex: 0 0 auto.
     }
     
-    .#{$key}\:flex-equal {
+    #{core.bem("flex-equal", $bp: $bp)} {
       flex: 1 1 0;
     }
     
-    .#{$key}\:flex-fill {
+    #{core.bem("flex-fill", $bp: $bp)} {
       flex: 1 0 auto;
     }
     
-    .#{$key}\:flex-full {
+    #{core.bem("flex-full", $bp: $bp)} {
       flex: 1 0 100%;
     }
   }

--- a/packages/grid/src/_col.scss
+++ b/packages/grid/src/_col.scss
@@ -2,52 +2,52 @@
 @use "@vrembem/core/css";
 @use "./variables" as var;
 
-.col-auto {
+#{core.bem("col-auto")} {
   grid-column: auto;
 }
 
-.col-full {
+#{core.bem("col-full")} {
   grid-column: span css.get("grid", "cols");
 }
 
 @for $i from 1 through var.$cols {
-  .col-#{$i} {
+  #{core.bem("col-#{$i}")} {
     grid-column: span $i;
   }
 }
 
 @for $i from 1 through (var.$cols + 1) {
-  .col-start-#{$i} {
+  #{core.bem("col-start-#{$i}")} {
     grid-column-start: $i;
   }
 
-  .col-end-#{$i} {
+  #{core.bem("col-end-#{$i}")} {
     grid-column-end: $i;
   }
 }
 
-@each $key, $value in var.$breakpoints {
+@each $bp, $value in var.$breakpoints {
   @include core.media-min($value) {
-    .#{$key}\:col-auto {
+    #{core.bem("col-auto", $bp: $bp)} {
       grid-column: auto;
     }
 
-    .#{$key}\:col-full {
+    #{core.bem("col-full", $bp: $bp)} {
       grid-column: span css.get("grid", "cols");
     }
 
     @for $i from 1 through var.$cols {
-      .#{$key}\:col-#{$i} {
+      #{core.bem("col-full-#{$i}", $bp: $bp)} {
         grid-column: span $i;
       }
     }
 
     @for $i from 1 through (var.$cols + 1) {
-      .#{$key}\:col-start-#{$i} {
+      #{core.bem("col-start-#{$i}", $bp: $bp)} {
         grid-column-start: $i;
       }
 
-      .#{$key}\:col-end-#{$i} {
+      #{core.bem("col-end-#{$i}", $bp: $bp)} {
         grid-column-end: $i;
       }
     }

--- a/packages/grid/src/_grid_cols.scss
+++ b/packages/grid/src/_grid_cols.scss
@@ -8,10 +8,10 @@
   }
 }
 
-@each $key, $value in var.$breakpoints {
+@each $bp, $value in var.$breakpoints {
   @include core.media-min($value) {
     @for $i from 1 through var.$cols {
-      #{core.bem("#{$key}\\:grid", null, "cols", $i)} {
+      #{core.bem("grid", null, "cols", $i, $bp)} {
         @include css.override("grid", "cols", $i);
       }
     }

--- a/packages/grid/src/_grid_gap.scss
+++ b/packages/grid/src/_grid_gap.scss
@@ -21,17 +21,17 @@
 @each $bp, $value in var.$breakpoints {
   @include core.media-min($value) {
     @each $key, $value in var.$gap-map {
-      #{core.bem("#{$bp}\\:grid", null, "gap", $key)} {
+      #{core.bem("grid", null, "gap", $key, $bp)} {
         @include css.override("grid", "gap", $value);
       }
     }
     
     @each $key, $value in var.$gap-map {
-      #{core.bem("#{$bp}\\:grid", null, "gap-x", $key)} {
+      #{core.bem("grid", null, "gap-x", $key, $bp)} {
         @include css.override("grid", "gap-x", $value);
       }
     
-      #{core.bem("#{$bp}\\:grid", null, "gap-y", $key)} {
+      #{core.bem("grid", null, "gap-y", $key, $bp)} {
         @include css.override("grid", "gap-y", $value);
       }
     }

--- a/packages/grid/src/_grid_rows.scss
+++ b/packages/grid/src/_grid_rows.scss
@@ -8,10 +8,10 @@
   }
 }
 
-@each $key, $value in var.$breakpoints {
+@each $bp, $value in var.$breakpoints {
   @include core.media-min($value) {
     @for $i from 1 through var.$rows {
-      #{core.bem("#{$key}\\:grid", null, "rows", $i)} {
+      #{core.bem("grid", null, "rows", $i, $bp)} {
         @include css.override("grid", "rows", $i);
       }
     }

--- a/packages/grid/src/_row.scss
+++ b/packages/grid/src/_row.scss
@@ -2,52 +2,52 @@
 @use "@vrembem/core/css";
 @use "./variables" as var;
 
-.row-auto {
+#{core.bem("row-auto")} {
   grid-row: auto;
 }
 
-.row-full {
+#{core.bem("row-full")} {
   grid-row: span css.get("grid", "rows");
 }
 
 @for $i from 1 through var.$rows {
-  .row-#{$i} {
+  #{core.bem("row-#{$i}")} {
     grid-row: span $i;
   }
 }
 
 @for $i from 1 through (var.$rows + 1) {
-  .row-start-#{$i} {
+  #{core.bem("row-start-#{$i}")} {
     grid-row-start: $i;
   }
 
-  .row-end-#{$i} {
+  #{core.bem("row-end-#{$i}")} {
     grid-row-end: $i;
   }
 }
 
-@each $key, $value in var.$breakpoints {
+@each $bp, $value in var.$breakpoints {
   @include core.media-min($value) {
-    .#{$key}\:row-auto {
+    #{core.bem("row-auto", $bp: $bp)} {
       grid-row: auto;
     }
 
-    .#{$key}\:row-full {
+    #{core.bem("row-full", $bp: $bp)} {
       grid-row: span css.get("grid", "rows");
     }
 
     @for $i from 1 through var.$rows {
-      .#{$key}\:row-#{$i} {
+      #{core.bem("row-#{$i}", $bp: $bp)} {
         grid-row: span $i;
       }
     }
 
     @for $i from 1 through (var.$rows + 1) {
-      .#{$key}\:row-start-#{$i} {
+      #{core.bem("row-start-#{$i}", $bp: $bp)} {
         grid-row-start: $i;
       }
 
-      .#{$key}\:row-end-#{$i} {
+      #{core.bem("row-end-#{$i}", $bp: $bp)} {
         grid-row-end: $i;
       }
     }


### PR DESCRIPTION
## What changed?

This PR adds a new argument to the core `bem()` function to add support for breakpoint modifiers. This feature has been carried over from similar implementation in the `utiltiy()` function which will prepend breakpoint modifiers to a class with a colon. This feature also ensure the colon is applied and escaped automatically.

**Additional changes**
- Applies new breakpoint modifier function to flex and grid components.
- Ensure `bem` is used for all flex and grid classes, even soft utilities.
- Fixed bug where block prefixes were being applied in front of breakpoint modifiers.
- Renamed breakpoint map loops to use `$bp` instead of `$key` for clarity. 