### PR TITLE
Apply new breakpoint modifier methodology to all components

### DIFF
--- a/docs/src/content/packages/button.mdx
+++ b/docs/src/content/packages/button.mdx
@@ -107,11 +107,11 @@ Gives a button "block" styles so that it spans the full width of its container. 
 **Available variants**
 
 - `button_block`
-- `button_block_xs`
-- `button_block_sm`
-- `button_block_md`
-- `button_block_lg`
-- `button_block_xl`
+- `xs:button_block`
+- `sm:button_block`
+- `md:button_block`
+- `lg:button_block`
+- `xl:button_block`
 
 ## button_color_[value]
 

--- a/docs/src/content/packages/table.mdx
+++ b/docs/src/content/packages/table.mdx
@@ -302,7 +302,7 @@ Adds hover and focus state styles for table row (`<tr>`) elements.
   ```
 </CodeExample>
 
-## table_responsive_[key]
+## table_responsive
 
 When the [`scroll-box` base module](/packages/base#scroll-box) isn't mobile friendly enough, this modifier adds responsive styles to a table so that it's easier to read on specific breakpoints. This is done by using the `data-mobile-label` attribute on table cells that should correspond to the table column header for that specific cell. Use the value-less `table_responsive` modifier to apply these styles universally.
 
@@ -356,23 +356,11 @@ The mobile label value will be truncated if it exceeds the width set by `$mobile
 **Available variants**
 
 - `table_responsive`
-- `table_responsive_xs`
-- `table_responsive_sm`
-- `table_responsive_md`
-- `table_responsive_lg`
-- `table_responsive_xl`
-
-### `@mixin table-responsive-styles()`
-
-Output responsive table styles. This is used to generate the styles for the `table_responsive_[key]` modifier.
-
-**Example**
-
-```scss
-.table_custom_modifier {
-  @include table-responsive-styles();
-}
-```
+- `xs:table_responsive`
+- `sm:table_responsive`
+- `md:table_responsive`
+- `lg:table_responsive`
+- `xl:table_responsive`
 
 ## table_size_[value]
 

--- a/packages/base/index.html
+++ b/packages/base/index.html
@@ -16,7 +16,7 @@
     import "../grid/dist/index.css";
 
     // Import local styles.
-    import "./index.scss"
+    import "./index.scss";
   </script>
   <style></style>
 </head>

--- a/packages/button/index.html
+++ b/packages/button/index.html
@@ -17,7 +17,7 @@
     import "../icon/dist/index.css";
 
     // Import local styles.
-    import "./index.scss"
+    import "./index.scss";
   </script>
   <style></style>
 </head>

--- a/packages/button/index.html
+++ b/packages/button/index.html
@@ -3,149 +3,137 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>@vrembem/button</title>
-  <link rel="icon" type="image/png" sizes="32x32" href="https://sebnitu.com/dist/favicon.png">
+  <title>%VITE_NAME%</title>
+  <link rel="icon" type="image/png" href="https://sebnitu.com/icons/vb-favicon.png">
+  <link rel="icon" type="image/svg+xml" href="https://sebnitu.com/icons/vb-favicon.svg">
+  <script type="module">
+    // Import required vite demo styles.
+    import "../core/dist/index.css";
+    import "../base/dist/index.css";
+    import "../utility/dist/index.css";
+    import "../section/dist/index.css";
+    import "../flex/dist/index.css";
+    import "../grid/dist/index.css";
+    import "../icon/dist/index.css";
+
+    // Import local styles.
+    import "./index.scss"
+  </script>
+  <style></style>
 </head>
 <body>
-  <main>
-    <header class="section background-dark">
-      <div class="section__container max-width-xs spacing">
-        <h1>@vrembem/button</h1>
-        <p>Buttons are a simple component that allow users to take actions.</p>
-        <div class="flex align-items-center foreground-lighter">
-          <div class="flex flex_gap_sm align-items-center">
-            <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
-            </svg>
-            <a class="link" href="https://github.com/sebnitu/vrembem">
-              <span>vrembem</span>
-            </a>
-          </div>
-          <span>/</span>
-          <div class="flex flex_gap_sm align-items-center">
-            <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line>
-            </svg>
-            <a class="link" href="https://github.com/sebnitu/vrembem/tree/main/packages/button#readme">
-              <span>button</span>
-            </a>
-          </div>
-        </div>
+
+  <header class="section background-dark">
+    <div class="section__container max-width-xs spacing-sm">
+      <h1 class="text-size-lg">%VITE_NAME%</h1>
+      <p class="foreground-light">%VITE_DESCRIPTION%</p>
+      <ol class="foreground-lighter flex flex_gap flex_gap-y_sm margin-top-lg list-style-none">
+        <li class="flex flex_gap_sm align-items-center">
+          <svg class="icon icon_size_sm" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path></svg>
+          <a class="link" target="_blank" href="https://github.com/sebnitu/%VITE_ROOT%">%VITE_ROOT%</a>
+        </li>
+        <li class="foreground-neutral-80">/</li>
+        <li class="flex flex_gap_sm align-items-center">
+          <svg class="icon icon_size_sm" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
+          <a class="link" target="_blank" href="https://github.com/sebnitu/%VITE_ROOT%/tree/main/packages/%VITE_PACKAGE%#readme">%VITE_PACKAGE%</a>
+        </li>
+      </ol>
+    </div>
+  </header>
+
+  <section class="section">
+    <div class="section__container max-width-xs spacing">
+
+      <h2 id="button"><a href="#button">button</a></h2>
+
+      <div class="flex">
+        <button class="button">Button</button>
       </div>
-    </header>
 
-    <section class="section">
-      <div class="section__container max-width-xs spacing">
+      <h2 id="button_color_value"><a href="#button_color_value">button_color_[value]</a></h2>
 
-        <div class="margin-bottom-sm">
-          <code>button</code>
-        </div>
-
-        <div class="flex">
-          <button class="button">Button</button>
-        </div>
-
-        <div class="margin-top-lg margin-bottom-sm">
-          <code>button_color_[value]</code>
-        </div>
-
-        <div class="flex">
-          <button class="button">Button</button>
-          <button class="button button_color_primary">Primary</button>
-          <button class="button button_color_secondary">Secondary</button>
-          <button class="button button_color_neutral">Neutral</button>
-          <button class="button button_color_important">Important</button>
-        </div>
-
-        <div class="margin-top-lg margin-bottom-sm">
-          <code>is-loading</code>
-        </div>
-
-        <div class="flex">
-          <button class="button is-loading" disabled>Button</button>
-          <button class="button button_color_primary is-loading" disabled>Primary</button>
-          <button class="button button_color_secondary is-loading" disabled>Secondary</button>
-          <button class="button button_color_neutral is-loading" disabled>Neutral</button>
-          <button class="button button_color_important is-loading" disabled>Important</button>
-        </div>
-
-        <div class="margin-top-lg margin-bottom-sm">
-          <code>disabled</code>
-        </div>
-
-        <div class="flex">
-          <button class="button" disabled>Button</button>
-          <button class="button button_color_primary" disabled>Primary</button>
-          <button class="button button_color_secondary" disabled>Secondary</button>
-          <button class="button button_color_neutral" disabled>Neutral</button>
-          <button class="button button_color_important" disabled>Important</button>
-        </div>
-
-        <div class="margin-top-lg margin-bottom-sm">
-          <code>button_size_[value]</code>
-        </div>
-
-        <div class="flex">
-          <button class="button button_size_sm">button_size_sm</button>
-          <button class="button">Button</button>
-          <button class="button button_size_lg">button_size_lg</button>
-        </div>
-
-        <div class="margin-top-lg margin-bottom-sm">
-          <code>button_icon</code>
-        </div>
-
-        <div class="flex flex_gap_lg">
-          <button class="button button_icon button_size_sm">
-            <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line>
-            </svg>
-          </button>
-          <button class="button button_icon">
-            <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line>
-            </svg>
-          </button>
-          <button class="button button_icon button_size_lg">
-            <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line>
-            </svg>
-          </button>
-          <button class="button">
-            <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line>
-            </svg>
-            <span>Button</span>
-          </button>
-          <button class="button">Button</button>
-          <button class="button">
-            <span>Button</span>
-            <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line>
-            </svg>
-          </button>
-        </div>
-
-        <div class="margin-top-lg margin-bottom-sm">
-          <code>button_block_[value]</code>
-        </div>
-
-        <div class="flex">
-          <button class="button button_block">button_block</button>
-          <button class="button button_block_xs">button_block_xs</button>
-          <button class="button button_block_sm">button_block_sm</button>
-          <button class="button button_block_md">button_block_md</button>
-          <button class="button button_block_lg">button_block_lg</button>
-          <button class="button button_block_xl">button_block_xl</button>
-        </div>
-
+      <div class="flex">
+        <button class="button">Button</button>
+        <button class="button button_color_primary">Primary</button>
+        <button class="button button_color_secondary">Secondary</button>
+        <button class="button button_color_neutral">Neutral</button>
+        <button class="button button_color_important">Important</button>
       </div>
-    </section>
-  </main>
 
-  <script type="module">
-    import 'vrembem/scss';
-  </script>
+      <h2 id="is-loading"><a href="#is-loading">is-loading</a></h2>
+
+      <div class="flex">
+        <button class="button is-loading" disabled>Button</button>
+        <button class="button button_color_primary is-loading" disabled>Primary</button>
+        <button class="button button_color_secondary is-loading" disabled>Secondary</button>
+        <button class="button button_color_neutral is-loading" disabled>Neutral</button>
+        <button class="button button_color_important is-loading" disabled>Important</button>
+      </div>
+
+      <h2 id="disabled"><a href="#disabled">disabled</a></h2>
+
+      <div class="flex">
+        <button class="button" disabled>Button</button>
+        <button class="button button_color_primary" disabled>Primary</button>
+        <button class="button button_color_secondary" disabled>Secondary</button>
+        <button class="button button_color_neutral" disabled>Neutral</button>
+        <button class="button button_color_important" disabled>Important</button>
+      </div>
+
+      <h2 id="button_size_value"><a href="#button_size_value">button_size_[value]</a></h2>
+
+      <div class="flex align-items-center">
+        <button class="button button_size_sm">button_size_sm</button>
+        <button class="button">Button</button>
+        <button class="button button_size_lg">button_size_lg</button>
+      </div>
+
+      <h2 id="button_icon"><a href="#button_icon">button_icon</a></h2>
+
+      <div class="flex align-items-center">
+        <button class="button button_icon button_size_sm">
+          <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line>
+          </svg>
+        </button>
+        <button class="button button_icon">
+          <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line>
+          </svg>
+        </button>
+        <button class="button button_icon button_size_lg">
+          <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line>
+          </svg>
+        </button>
+        <button class="button">
+          <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line>
+          </svg>
+          <span>Button</span>
+        </button>
+        <button class="button">Button</button>
+        <button class="button">
+          <span>Button</span>
+          <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line>
+          </svg>
+        </button>
+      </div>
+
+      <h2 id="button_block"><a href="#button_block">button_block</a></h2>
+
+      <div class="flex">
+        <button class="button button_block">button_block</button>
+        <button class="button xs:button_block">xs:button_block</button>
+        <button class="button sm:button_block">sm:button_block</button>
+        <button class="button md:button_block">md:button_block</button>
+        <button class="button lg:button_block">lg:button_block</button>
+        <button class="button xl:button_block">xl:button_block</button>
+      </div>
+
+    </div>
+  </section>
 
 </body>
 </html>

--- a/packages/button/src/_button_block.scss
+++ b/packages/button/src/_button_block.scss
@@ -1,20 +1,16 @@
 @use "@vrembem/core";
+@use "./variables" as var;
 
 #{core.bem("button", null, "block")} {
   display: flex;
   width: 100%;
 }
 
-@each $key, $value in core.$breakpoints {
-  #{core.bem("button", null, "block", $key)} {
-    display: flex;
-    width: 100%;
-  }
-
-  @include core.media-min($value) {
-    #{core.bem("button", null, "block", $key)} {
-      display: inline-flex;
-      width: auto;
+@each $bp, $value in var.$breakpoints {
+  @include core.media-max($value) {
+    #{core.bem("button", null, "block", $bp: $bp)} {
+      display: flex;
+      width: 100%;
     }
   }
 }

--- a/packages/button/src/_variables.scss
+++ b/packages/button/src/_variables.scss
@@ -2,6 +2,8 @@
 @use "@vrembem/core/css";
 
 @include css.register("button");
+
+$breakpoints: core.$breakpoints !default;
 $accent: css.get("button", "accent", css.get("form-control-accent")) !default;
 $gap: 0.5rem !default;
 

--- a/packages/button/vite.config.mjs
+++ b/packages/button/vite.config.mjs
@@ -1,0 +1,24 @@
+import { defineConfig } from "vite";
+import data from "./package.json";
+
+const parts = data.name.replace("@", "").split("/");
+
+export default defineConfig({
+  build: {
+    emptyOutDir: false,
+    sourcemap: true
+  },
+  define: {
+    "import.meta.env.VITE_ROOT": JSON.stringify(parts[0]),
+    "import.meta.env.VITE_PACKAGE": JSON.stringify(parts[1]),
+    "import.meta.env.VITE_NAME": JSON.stringify(data.name),
+    "import.meta.env.VITE_DESCRIPTION": JSON.stringify(data.description)
+  },
+  css: {
+    preprocessorOptions : {
+      scss: {
+        api: "modern",
+      }        
+    } 
+  }
+});

--- a/packages/table/index.html
+++ b/packages/table/index.html
@@ -3,49 +3,370 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>@vrembem/table</title>
-  <link rel="icon" type="image/png" sizes="32x32" href="https://sebnitu.com/dist/favicon.png">
+  <title>%VITE_NAME%</title>
+  <link rel="icon" type="image/png" href="https://sebnitu.com/icons/vb-favicon.png">
+  <link rel="icon" type="image/svg+xml" href="https://sebnitu.com/icons/vb-favicon.svg">
+  <script type="module">
+    // Import required vite demo styles.
+    import "../core/dist/index.css";
+    import "../base/dist/index.css";
+    import "../utility/dist/index.css";
+    import "../section/dist/index.css";
+    import "../flex/dist/index.css";
+    import "../grid/dist/index.css";
+
+    // Import local styles.
+    import "./index.scss";
+    import "./root.scss";
+  </script>
+  <style></style>
 </head>
 <body>
-  <main>
-    <header class="section background-dark">
-      <div class="section__container max-width-xs spacing">
-        <h1>@vrembem/table</h1>
-        <p>A table component for displaying HTML tables.</p>
-        <div class="flex align-items-center foreground-lighter">
-          <div class="flex flex_gap_sm align-items-center">
-            <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
-            </svg>
-            <a class="link" href="https://github.com/sebnitu/vrembem">
-              <span>vrembem</span>
-            </a>
-          </div>
-          <span>/</span>
-          <div class="flex flex_gap_sm align-items-center">
-            <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line>
-            </svg>
-            <a class="link" href="https://github.com/sebnitu/vrembem/tree/main/packages/table#readme">
-              <span>table</span>
-            </a>
-          </div>
-        </div>
+
+  <header class="section background-dark">
+    <div class="section__container max-width-xs spacing-sm">
+      <h1 class="text-size-lg">%VITE_NAME%</h1>
+      <p class="foreground-light">%VITE_DESCRIPTION%</p>
+      <ol class="foreground-lighter flex flex_gap flex_gap-y_sm margin-top-lg list-style-none">
+        <li class="flex flex_gap_sm align-items-center">
+          <svg class="icon icon_size_sm" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path></svg>
+          <a class="link" target="_blank" href="https://github.com/sebnitu/%VITE_ROOT%">%VITE_ROOT%</a>
+        </li>
+        <li class="foreground-neutral-80">/</li>
+        <li class="flex flex_gap_sm align-items-center">
+          <svg class="icon icon_size_sm" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
+          <a class="link" target="_blank" href="https://github.com/sebnitu/%VITE_ROOT%/tree/main/packages/%VITE_PACKAGE%#readme">%VITE_PACKAGE%</a>
+        </li>
+      </ol>
+    </div>
+  </header>
+
+  <section class="section">
+    <div class="section__container max-width-xs spacing">
+
+      <h2 id="table"><a href="#table">table</a></h2>
+
+      <table class="table">
+        <caption>Example of a table caption.</caption>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Mass</th>
+            <th>Class</th>
+            <th>Variant</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Locust</td>
+            <td>20t</td>
+            <td>Light</td>
+            <td>LCT-1V</td>
+          </tr>
+          <tr>
+            <td>Shadow Hawk</td>
+            <td>55t</td>
+            <td>Medium</td>
+            <td>SHD-2H</td>
+          </tr>
+          <tr>
+            <td>Thunderbolt</td>
+            <td>65t</td>
+            <td>Heavy</td>
+            <td>TDR-5S</td>
+          </tr>
+          <tr>
+            <td>BattleMaster</td>
+            <td>85t</td>
+            <td>Assault</td>
+            <td>BLR-1G</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="scroll-box">
+        <table class="table" style="width: 64rem">
+          <thead>
+            <tr>
+              <th>Book</th>
+              <th>Pages</th>
+              <th>Quote</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="text-nowrap">The Hobbit</td>
+              <td>272</td>
+              <td>"Do you wish me a good morning, or mean that it is a good morning whether I want it or not; or that you feel good this morning; or that it is a morning to be good on?"</td>
+            </tr>
+            <tr>
+              <td class="text-nowrap">The Fellowship of the Ring</td>
+              <td>377</td>
+              <td>"I wish it need not have happened in my time," said Frodo. "So do I," said Gandalf, "and so do all who live to see such times. But that is not for them to decide. All we have to decide is what to do with the time that is given us."</td>
+            </tr>
+            <tr>
+              <td class="text-nowrap">The Two Towers</td>
+              <td>322</td>
+              <td>"War must be, while we defend our lives against a destroyer who would devour all; but I do not love the bright sword for its sharpness, nor the arrow for its swiftness, nor the warrior for his glory. I love only that which they defend."</td>
+            </tr>
+            <tr>
+              <td class="text-nowrap">The Return of the King</td>
+              <td>277</td>
+              <td>"But I have been too deeply hurt, Sam. I tried to save the Shire, and it has been saved, but not for me. It must often be so, Sam, when things are in danger: some one has to give them up, lose them, so that others may keep them."</td>
+            </tr>
+          </tbody>
+        </table>
       </div>
-    </header>
 
-    <section class="section">
-      <div class="section__container max-width-xs spacing">
+      <h2 id="table_ellipsis"><a href="#table_ellipsis">table_ellipsis</a></h2>
 
-        <p>...</p>
+      <table class="table table_ellipsis">
+        <thead>
+          <tr>
+            <th>Book</th>
+            <th>Pages</th>
+            <th>Quote</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="text-nowrap">The Hobbit</td>
+            <td>272</td>
+            <td>"Do you wish me a good morning, or mean that it is a good morning whether I want it or not; or that you feel good this morning; or that it is a morning to be good on?"</td>
+          </tr>
+          <tr>
+            <td class="text-nowrap">The Fellowship of the Ring</td>
+            <td>377</td>
+            <td>"I wish it need not have happened in my time," said Frodo. "So do I," said Gandalf, "and so do all who live to see such times. But that is not for them to decide. All we have to decide is what to do with the time that is given us."</td>
+          </tr>
+          <tr>
+            <td class="text-nowrap">The Two Towers</td>
+            <td>322</td>
+            <td>"War must be, while we defend our lives against a destroyer who would devour all; but I do not love the bright sword for its sharpness, nor the arrow for its swiftness, nor the warrior for his glory. I love only that which they defend."</td>
+          </tr>
+          <tr>
+            <td class="text-nowrap">The Return of the King</td>
+            <td>277</td>
+            <td>"But I have been too deeply hurt, Sam. I tried to save the Shire, and it has been saved, but not for me. It must often be so, Sam, when things are in danger: some one has to give them up, lose them, so that others may keep them."</td>
+          </tr>
+        </tbody>
+      </table>
 
-      </div>
-    </section>
-  </main>
+      <h2 id="table_hover"><a href="#table_hover">table_hover</a></h2>
 
-  <script type="module">
-    import 'vrembem/scss';
-  </script>
+      <table class="table table_hover">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Mass</th>
+            <th>Class</th>
+            <th>Variant</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Jenner</td>
+            <td>35t</td>
+            <td>Light</td>
+            <td>JR7-D</td>
+          </tr>
+          <tr>
+            <td>Hunchback</td>
+            <td>50t</td>
+            <td>Medium</td>
+            <td>HBK-4G</td>
+          </tr>
+          <tr>
+            <td>Catapult</td>
+            <td>65t</td>
+            <td>Heavy</td>
+            <td>CPLT-C1</td>
+          </tr>
+          <tr>
+            <td>Atlas</td>
+            <td>100t</td>
+            <td>Assault</td>
+            <td>AS7-D</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2 id="table_responsive"><a href="#table_responsive">table_responsive</a></h2>
+
+      <table class="table table_responsive table_style_bordered">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Mass</th>
+            <th>Class</th>
+            <th>Variant</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td data-mobile-label="Name">Jenner</td>
+            <td data-mobile-label="Mass">35t</td>
+            <td data-mobile-label="Class">Light</td>
+            <td data-mobile-label="Variant">JR7-F</td>
+          </tr>
+          <tr>
+            <td data-mobile-label="Name">Hunchback</td>
+            <td data-mobile-label="Mass">50t</td>
+            <td data-mobile-label="Class">Medium</td>
+            <td data-mobile-label="Variant">HBK-4P</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2 id="table_size_sm"><a href="#table_size_sm">table_size_sm</a></h2>
+      
+      <table class="table table_size_sm table_style_bordered">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Mass</th>
+            <th>Class</th>
+            <th>Variant</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Griffin</td>
+            <td>55t</td>
+            <td>Medium</td>
+            <td>GRF-1N</td>
+          </tr>
+          <tr>
+            <td>Wolverine</td>
+            <td>55t</td>
+            <td>Medium</td>
+            <td>WVR-6R</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2 id="table_size_lg"><a href="#table_size_lg">table_size_lg</a></h2>
+      
+      <table class="table table_size_lg table_style_bordered">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Mass</th>
+            <th>Class</th>
+            <th>Variant</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Griffin</td>
+            <td>55t</td>
+            <td>Medium</td>
+            <td>GRF-1N</td>
+          </tr>
+          <tr>
+            <td>Wolverine</td>
+            <td>55t</td>
+            <td>Medium</td>
+            <td>WVR-6R</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2 id="table_style_rowed"><a href="#table_style_rowed">table_style_rowed</a></h2>
+
+      <table class="table table_style_rowed">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Mass</th>
+            <th>Class</th>
+            <th>Variant</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Griffin</td>
+            <td>55t</td>
+            <td>Medium</td>
+            <td>GRF-2N</td>
+          </tr>
+          <tr>
+            <td>Wolverine</td>
+            <td>55t</td>
+            <td>Medium</td>
+            <td>WVR-7K</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2 id="table_style_bordered"><a href="#table_style_bordered">table_style_bordered</a></h2>
+
+      <table class="table table_style_bordered">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Mass</th>
+            <th>Class</th>
+            <th>Variant</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Griffin</td>
+            <td>55t</td>
+            <td>Medium</td>
+            <td>GRF-2N</td>
+          </tr>
+          <tr>
+            <td>Wolverine</td>
+            <td>55t</td>
+            <td>Medium</td>
+            <td>WVR-7K</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2 id="table_zebra"><a href="#table_zebra">table_zebra</a></h2>
+
+      <table class="table table_zebra">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Mass</th>
+            <th>Class</th>
+            <th>Variant</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Firestarter</td>
+            <td>35t</td>
+            <td>Light</td>
+            <td>FS9-A</td>
+          </tr>
+          <tr>
+            <td>Uziel</td>
+            <td>50t</td>
+            <td>Medium</td>
+            <td>UZL-6P</td>
+          </tr>
+          <tr>
+            <td>Crusader</td>
+            <td>65t</td>
+            <td>Heavy</td>
+            <td>CRD-6T</td>
+          </tr>
+          <tr>
+            <td>Cyclops</td>
+            <td>90t</td>
+            <td>Assault</td>
+            <td>CP-11-P</td>
+          </tr>
+        </tbody>
+      </table>
+
+    </div>
+  </section>
 
 </body>
 </html>

--- a/packages/table/src/_table_responsive.scss
+++ b/packages/table/src/_table_responsive.scss
@@ -6,8 +6,8 @@
   @include mixins.table-responsive-styles();
 }
 
-@each $key, $value in var.$breakpoints {
-  #{core.bem("table", null, "responsive", $key)} {
+@each $bp, $value in var.$breakpoints {
+  #{core.bem("table", null, "responsive", $bp: $bp)} {
     @include core.media-max($value) {
       @include mixins.table-responsive-styles();
     }

--- a/packages/table/vite.config.mjs
+++ b/packages/table/vite.config.mjs
@@ -1,0 +1,24 @@
+import { defineConfig } from "vite";
+import data from "./package.json";
+
+const parts = data.name.replace("@", "").split("/");
+
+export default defineConfig({
+  build: {
+    emptyOutDir: false,
+    sourcemap: true
+  },
+  define: {
+    "import.meta.env.VITE_ROOT": JSON.stringify(parts[0]),
+    "import.meta.env.VITE_PACKAGE": JSON.stringify(parts[1]),
+    "import.meta.env.VITE_NAME": JSON.stringify(data.name),
+    "import.meta.env.VITE_DESCRIPTION": JSON.stringify(data.description)
+  },
+  css: {
+    preprocessorOptions : {
+      scss: {
+        api: "modern",
+      }        
+    } 
+  }
+});

--- a/packages/utility/index.html
+++ b/packages/utility/index.html
@@ -16,7 +16,7 @@
     import "../grid/dist/index.css";
 
     // Import local styles.
-    import "./index.scss"
+    import "./index.scss";
 
     const colors = ["primary", "secondary", "neutral", "important"];
     const lightnessRange = [0, 5, 10, 12, 15, 20, 30, 40, 50, 60, 70, 80, 90, 95, 98, 100];

--- a/packages/utility/src/modules/_display.scss
+++ b/packages/utility/src/modules/_display.scss
@@ -9,10 +9,10 @@
     }
   }
 
-  @each $key, $value in var.$breakpoints {
+  @each $bp, $value in var.$breakpoints {
     @include core.media-min($value) {
       @each $property in var.$display-properties {
-        #{fun.utility("display", $property, "#{$key}:")} {
+        #{fun.utility("display", $property, "#{$bp}:")} {
           display: $property !important;
         }
       }


### PR DESCRIPTION
## What changed?

This PR applies the new breakpoint modifier methodology to all components that were still using the previous method. This new approach puts the breakpoint modifier as a prefix to a component or utility class and is delimitated by a colon.

```html
// Old approach
<div class="component_modifier_md">...</div>

// New methodology
<div class="md:component_modifier">...</div>
```

**Additional changes**
- Added new vite demo to button component.
- Added new vite demo to table component.
- General cleanup to vite demos for consistency.