### PR TITLE
Remove aria-hidden from setGlobalState module

### DIFF
--- a/packages/core/src/js/helpers/setGlobalState.ts
+++ b/packages/core/src/js/helpers/setGlobalState.ts
@@ -18,22 +18,16 @@ function setOverflowHidden(state: boolean, selector: string): void {
 }
 
 /**
- * Sets the `inert` and `aria-hidden` attributes on elements based on the state.
+ * Sets the `inert` attributes on elements based on the state.
  *
- * @param {boolean} state - Whether to set or remove `inert` and `aria-hidden`.
+ * @param {boolean} state - Whether to set or remove `inert`.
  * @param {string} selector - A CSS selector to query the elements.
  */
 function setInert(state: boolean, selector: string): void {
   if (selector) {
     const els = document.querySelectorAll<HTMLElement>(selector);
     els.forEach((el) => {
-      if (state) {
-        (el as HTMLElement & { inert?: boolean }).inert = true;
-        el.setAttribute("aria-hidden", "true");
-      } else {
-        (el as HTMLElement & { inert?: boolean }).inert = false;
-        el.removeAttribute("aria-hidden");
-      }
+      (el as HTMLElement & { inert?: boolean }).inert = state;
     });
   }
 }

--- a/packages/core/tests/helpers/setGlobalState.test.js
+++ b/packages/core/tests/helpers/setGlobalState.test.js
@@ -15,30 +15,22 @@ describe("setGlobalState()", () => {
   it("should apply inert and aria hidden to passed selectors", () => {
     expect(main.inert).not.toBe(true);
     expect(header.inert).not.toBe(true);
-    expect(main).not.toHaveAttribute("aria-hidden");
-    expect(header).not.toHaveAttribute("aria-hidden");
 
     setGlobalState(true, ".main, .header", "body, .main");
     expect(main.inert).toBe(true);
     expect(header.inert).toBe(true);
-    expect(main).toHaveAttribute("aria-hidden", "true");
-    expect(header).toHaveAttribute("aria-hidden", "true");
   });
 
   it("should remove inert and aria hidden when set to false", () => {
     setGlobalState(false, ".main, .header", "body, .main");
     expect(main.inert).not.toBe(true);
     expect(header.inert).not.toBe(true);
-    expect(main).not.toHaveAttribute("aria-hidden");
-    expect(header).not.toHaveAttribute("aria-hidden");
   });
 
   it("should do nothing if selector is not passed", () => {
     setGlobalState(true, null, null);
     expect(main.inert).not.toBe(true);
     expect(header.inert).not.toBe(true);
-    expect(main).not.toHaveAttribute("aria-hidden");
-    expect(header).not.toHaveAttribute("aria-hidden");
   });
 
   it("should apply overflow hidden to passed selectors", () => {

--- a/packages/drawer/tests/accessibility.test.js
+++ b/packages/drawer/tests/accessibility.test.js
@@ -44,7 +44,6 @@ test("should properly hide content when modal drawer is opened", async () => {
   await vi.runAllTimers();
 
   expect(main.inert).toBe(true);
-  expect(main.getAttribute("aria-hidden")).toBe("true");
   expect(main).toHaveStyle({ overflow: "hidden" });
 });
 
@@ -53,6 +52,5 @@ test("should properly show content when modal drawer is closed", async () => {
   await vi.runAllTimers();
 
   expect(main.inert).toBe(false);
-  expect(main.hasAttribute("aria-hidden")).toBe(false);
   expect(main).not.toHaveStyle({ overflow: "hidden" });
 });

--- a/packages/modal/tests/api.test.js
+++ b/packages/modal/tests/api.test.js
@@ -112,7 +112,6 @@ describe("register() & deregister()", () => {
     });
     await modal.mount();
     expect(document.body.style.overflow).toBe("hidden");
-    expect(main).toHaveAttribute("aria-hidden", "true");
     expect(main.inert).toBe(true);
     expect(main.style.overflow).toBe("hidden");
     expect(modal.get("modal-default").state).toBe("opened");

--- a/packages/modal/tests/inert.test.js
+++ b/packages/modal/tests/inert.test.js
@@ -28,8 +28,6 @@ describe("when selectorInert is set:", () => {
     btnOpen.click();
     await vi.runAllTimers();
     expect(main.inert).toBe(true);
-    expect(main.hasAttribute("aria-hidden")).toBe(true);
-    expect(main.getAttribute("aria-hidden")).toBe("true");
   });
 
   it("should properly show content when modal is closed", async () => {
@@ -37,6 +35,5 @@ describe("when selectorInert is set:", () => {
     btnClose.click();
     await vi.runAllTimers();
     expect(main.inert).toBe(false);
-    expect(main.hasAttribute("aria-hidden")).toBe(false);
   });
 });


### PR DESCRIPTION
## What changed?

I'm currently getting this warning whenever the `setGlobalState` module is used:

```
Blocked aria-hidden on an element because its descendant retained focus. The focus must not be hidden from assistive technology users. Avoid using aria-hidden on a focused element or its ancestor. Consider using the inert attribute instead, which will also prevent focus. For more details, see the aria-hidden section of the WAI-ARIA specification at https://w3c.github.io/aria/#aria-hidden.
```

This PR fixes this error by removing the use of `aria-hidden` because inert is enough to handle the global state of the page when an area needs to be disabled/hidden from user interaction. Tests are also fixed to acomodate this change.
