### PR TITLE
Remove aria-hidden from updateGlobalState module

### DIFF
--- a/packages/core/src/js/updateGlobalState.js
+++ b/packages/core/src/js/updateGlobalState.js
@@ -13,15 +13,8 @@ function setOverflowHidden(state, selector) {
 
 function setInert(state, selector) {
   if (selector) {
-    const els = document.querySelectorAll(selector);
-    els.forEach((el) => {
-      if (state) {
-        el.inert = true;
-        el.setAttribute("aria-hidden", true);
-      } else {
-        el.inert = null;
-        el.removeAttribute("aria-hidden");
-      }
+    document.querySelectorAll(selector).forEach((el) => {
+      el.inert = state;
     });
   }
 }

--- a/packages/core/tests/updateGlobalState.test.js
+++ b/packages/core/tests/updateGlobalState.test.js
@@ -23,30 +23,22 @@ describe("updateGlobalState()", () => {
   it("should apply inert and aria hidden to passed selectors", () => {
     expect(main.inert).not.toBe(true);
     expect(header.inert).not.toBe(true);
-    expect(main).not.toHaveAttribute("aria-hidden");
-    expect(header).not.toHaveAttribute("aria-hidden");
 
     updateGlobalState(true, config);
     expect(main.inert).toBe(true);
     expect(header.inert).toBe(true);
-    expect(main).toHaveAttribute("aria-hidden", "true");
-    expect(header).toHaveAttribute("aria-hidden", "true");
   });
 
   it("should remove inert and aria hidden when set to false", () => {
     updateGlobalState(false, config);
     expect(main.inert).not.toBe(true);
     expect(header.inert).not.toBe(true);
-    expect(main).not.toHaveAttribute("aria-hidden");
-    expect(header).not.toHaveAttribute("aria-hidden");
   });
 
   it("should do nothing if selector is not passed", () => {
     updateGlobalState(true, configEmpty);
     expect(main.inert).not.toBe(true);
     expect(header.inert).not.toBe(true);
-    expect(main).not.toHaveAttribute("aria-hidden");
-    expect(header).not.toHaveAttribute("aria-hidden");
   });
 
   it("should apply overflow hidden to passed selectors", () => {

--- a/packages/drawer/tests/accessibility.test.js
+++ b/packages/drawer/tests/accessibility.test.js
@@ -39,7 +39,6 @@ test("should properly hide content when modal drawer is opened", async () => {
   await transition(el);
 
   expect(main.inert).toBe(true);
-  expect(main.getAttribute("aria-hidden")).toBe("true");
   expect(main).toHaveStyle({ overflow: "hidden" });
 });
 
@@ -47,7 +46,6 @@ test("should properly show content when modal drawer is closed", async () => {
   btn.click();
   await transition(el);
 
-  expect(main.inert).toBe(null);
-  expect(main.hasAttribute("aria-hidden")).toBe(false);
+  expect(main).not.toHaveAttribute("inert");
   expect(main).not.toHaveStyle({ overflow: "hidden" });
 });

--- a/packages/modal/tests/api.test.js
+++ b/packages/modal/tests/api.test.js
@@ -170,7 +170,6 @@ describe("register() & deregister()", () => {
     });
     await modal.init();
     expect(document.body.style.overflow).toBe("hidden");
-    expect(main).toHaveAttribute("aria-hidden", "true");
     expect(main.inert).toBe(true);
     expect(main.style.overflow).toBe("hidden");
     expect(modal.get("modal-default").state).toBe("opened");

--- a/packages/modal/tests/inert.test.js
+++ b/packages/modal/tests/inert.test.js
@@ -1,3 +1,4 @@
+import "@testing-library/jest-dom";
 import { transition } from "./helpers/transition";
 import Modal from "../index";
 
@@ -30,14 +31,12 @@ describe("when selectorInert is set:", () => {
     btnOpen.click();
     await transition(el);
     expect(main.inert).toBe(true);
-    expect(main.getAttribute("aria-hidden")).toBe("true");
   });
 
   it("should properly show content when modal is closed", async () => {
     const btnClose = document.querySelector("[data-modal-close]");
     btnClose.click();
     await transition(el);
-    expect(main.inert).toBe(null);
-    expect(main.hasAttribute("aria-hidden")).toBe(false);
+    expect(main).not.toHaveAttribute("inert");
   });
 });


### PR DESCRIPTION
## What changed?

I'm currently getting this warning whenever the `updateGlobalState` module is used:

```
Blocked aria-hidden on an element because its descendant retained focus. The focus must not be hidden from assistive technology users. Avoid using aria-hidden on a focused element or its ancestor. Consider using the inert attribute instead, which will also prevent focus. For more details, see the aria-hidden section of the WAI-ARIA specification at https://w3c.github.io/aria/#aria-hidden.
```

This PR fixes this error by removing the use of `aria-hidden` because inert is enough to handle the global state of the page when an area needs to be disabled/hidden from user interaction. Tests are also fixed to accommodate this change.
