### PR TITLE
Fix partials importing in package exports field

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,10 +23,10 @@
     "./dist/*": "./dist/*",
     "./sass": "./index.scss",
     "./root": "./root.scss",
-    "./config": "./src/scss/modules/config.scss",
-    "./css": "./src/scss/modules/css.scss",
-    "./palette": "./src/scss/modules/palette.scss",
-    "./theme": "./src/scss/modules/theme.scss",
+    "./config": "./src/scss/modules/_config.scss",
+    "./css": "./src/scss/modules/_css.scss",
+    "./palette": "./src/scss/modules/_palette.scss",
+    "./theme": "./src/scss/modules/_theme.scss",
     "./*": "./src/*"
   },
   "files": [


### PR DESCRIPTION
## What changed?

Recent updated build tools such as Vite v8 now requires export values to include partial's underscore. This PR fixes core Sass module entries by including the full name of their files, e.g.: `config.scss` > `_config.scss`.

This PR fixes #2707