### PR TITLE
Fix order of default root exports

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,8 +10,8 @@
     "component",
     "core"
   ],
-  "types": "./dist/index.d.ts",
   "style": "./dist/index.css",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "sass": "./index.scss",

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -10,8 +10,8 @@
     "component",
     "drawer"
   ],
-  "types": "./dist/index.d.ts",
   "style": "./dist/index.css",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "sass": "./index.scss",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -10,8 +10,8 @@
     "component",
     "modal"
   ],
-  "types": "./dist/index.d.ts",
   "style": "./dist/index.css",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "sass": "./index.scss",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -10,8 +10,8 @@
     "component",
     "popover"
   ],
-  "types": "./dist/index.d.ts",
   "style": "./dist/index.css",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "sass": "./index.scss",

--- a/packages/vrembem/package.json
+++ b/packages/vrembem/package.json
@@ -10,8 +10,8 @@
     "component",
     "library"
   ],
-  "types": "./dist/index.d.ts",
   "style": "./dist/index.css",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "sass": "./index.scss",


### PR DESCRIPTION
## What changed?

This PR fixes an issue that was introduced when the default root exports did not include the `sass` and `style` keys first.
