### PR TITLE
Implement stylelint-config-clean-order in place of alphabetical order

### DIFF
--- a/docs/src/styles/_badge.scss
+++ b/docs/src/styles/_badge.scss
@@ -2,17 +2,17 @@
 @use "@vrembem/core/palette";
 
 .badge {
-  background-color: css.get("background-darker");
-  border-radius: css.get("border-radius-circle");
-  color: css.get("foreground-lighter");
-  display: inline-block;
-  font-size: css.get("font-size-sm");
-  padding: 0 0.75em;
   position: relative;
   z-index: 1;
+  display: inline-block;
+  padding: 0 0.75em;
+  border-radius: css.get("border-radius-circle");
+  font-size: css.get("font-size-sm");
+  color: css.get("foreground-lighter");
+  background-color: css.get("background-darker");
 }
 
 a.badge:hover {
-  background-color: palette.get("primary", 90);
   color: palette.get("primary", 30);
+  background-color: palette.get("primary", 90);
 }

--- a/docs/src/styles/_box.scss
+++ b/docs/src/styles/_box.scss
@@ -31,17 +31,17 @@
 
 .box,
 .box-alt {
+  padding: css.get("box", "padding");
   border: css.get("box", "border");
   color: css.get("foreground");
-  padding: css.get("box", "padding");
 }
 
 .box {
-  background: css.get("box", "background");
   border-color: css.get("box", "border-color");
+  background: css.get("box", "background");
 }
 
 .box-alt {
-  background: css.get("box", "background-alt");
   border-color: css.get("box", "border-color-alt");
+  background: css.get("box", "background-alt");
 }

--- a/docs/src/styles/_brand.scss
+++ b/docs/src/styles/_brand.scss
@@ -2,9 +2,9 @@
 @use "@vrembem/core/palette";
 
 .brand {
-  align-items: center;
   display: flex;
   gap: 0.5em;
+  align-items: center;
 }
 
 .brand__icon {

--- a/docs/src/styles/_card_reference.scss
+++ b/docs/src/styles/_card_reference.scss
@@ -4,18 +4,18 @@
   .card__header {
     @include css.override("card", "padding", 0.75em 1em);
 
-    align-items: center;
     display: flex;
     flex-wrap: wrap;
     gap: css.get("spacing-md");
+    align-items: center;
   }
 
   .card__title {
     @include css.override("link", "decoration-thickness", 1.5px);
 
-    background: transparent;
-    color: css.get("foreground");
-    font-size: 1rem;
     padding: 0;
+    font-size: 1rem;
+    color: css.get("foreground");
+    background: transparent;
   }
 }

--- a/docs/src/styles/_code-block.scss
+++ b/docs/src/styles/_code-block.scss
@@ -3,15 +3,15 @@
 @use "@vrembem/core/palette";
 
 .code-block {
+  position: relative;
   font-size: css.get("font-size");
   line-height: css.get("line-height");
-  position: relative;
   text-align: left;
 
   .pre {
-    background-color: css.get("background-dark");
-    border: css.get("border");
     padding-right: 4em;
+    border: css.get("border");
+    background-color: css.get("background-dark");
   }
 
   &.has-icon .pre {
@@ -20,10 +20,10 @@
 
   @include core.media-max("xs") {
     .pre {
+      margin: auto calc(css.get("layout", "padding") * -1);
+      border-right: none;
       border-left: none;
       border-radius: 0;
-      border-right: none;
-      margin: auto calc(css.get("layout", "padding") * -1);
     }
   }
 }
@@ -32,19 +32,19 @@
 
 .code-block__icon,
 .code-block__copy-button {
+  position: absolute;
+  inset: 0.8rem;
+  display: flex;
   align-items: center;
-  background-color: css.get("background-dark");
+  padding: 0.5rem;
   border-radius: css.get("border-radius");
   color: css.get("foreground-lighter");
-  display: flex;
-  inset: 0.8rem;
-  padding: 0.5rem;
-  position: absolute;
+  background-color: css.get("background-dark");
 }
 
 .code-block__icon {
-  bottom: auto;
   right: auto;
+  bottom: auto;
 
   @include core.media-max("xs") {
     left: 0;
@@ -80,8 +80,8 @@
   .code-block__icon,
   .code-block__copy-button {
     inset: 1px;
-    padding-left: 1em;
     padding-right: 1em;
+    padding-left: 1em;
   }
 
   .code-block__icon {
@@ -94,9 +94,9 @@
 
   @include core.media-max("xs") {
     .pre {
+      margin: 0;
       border: css.get("border");
       border-radius: css.get("border-radius");
-      margin: 0;
     }
 
     .code-block__icon {

--- a/docs/src/styles/_code-example.scss
+++ b/docs/src/styles/_code-example.scss
@@ -3,11 +3,11 @@
 @use "@vrembem/core/palette";
 
 .code-example {
+  overflow: hidden;
   border: css.get("border");
   border-radius: css.get("border-radius");
   font-size: css.get("font-size");
   line-height: css.get("line-height");
-  overflow: hidden;
 
   * {
     scroll-margin-top: initial;
@@ -18,10 +18,10 @@
   }
 
   @include core.media-max("xs") {
+    margin: 2rem calc(css.get("layout", "padding") * -1) !important;
+    border-right: none;
     border-left: none;
     border-radius: 0;
-    border-right: none;
-    margin: 2rem calc(css.get("layout", "padding") * -1) !important;
 
     .pre {
       margin: 0;
@@ -36,17 +36,17 @@
     position: static;
 
     .pre {
+      max-height: 34rem;
       border: none;
       border-top-left-radius: 0;
       border-top-right-radius: 0;
-      max-height: 34rem;
     }
   }
 
   .code-block__copy-button {
-    background-color: transparent;
-    right: 0.5rem;
     top: calc(-2.5rem + 2px);
+    right: 0.5rem;
+    background-color: transparent;
 
     &:hover {
       background-color: transparent;
@@ -67,9 +67,9 @@
 }
 
 .code-example__inner {
+  width: fit-content;
   min-width: 100%;
   padding: 2rem;
-  width: fit-content;
 
   @include core.media-max("xs") {
     padding: 1rem;
@@ -81,18 +81,18 @@
 }
 
 .code-example__demo {
-  align-items: center;
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+  align-items: center;
   padding: 0.5rem 1rem;
 }
 
 .code-example__toolbar {
-  color: css.get("foreground-lighter");
   display: flex;
   gap: 0.5rem;
   padding: 0.5rem 3.5rem 0.5rem 1rem;
+  color: css.get("foreground-lighter");
 
   [data-reset] {
     margin: -2px 0;

--- a/docs/src/styles/_code-expander.scss
+++ b/docs/src/styles/_code-expander.scss
@@ -3,18 +3,18 @@
 @include css.set("code-expander", "max-height", 20rem);
 
 .code-expander {
+  position: relative;
   border: css.get("border");
   border-radius: css.get("border-radius");
   font-size: css.get("font-size");
   line-height: css.get("line-height");
-  position: relative;
+  transition-timing-function: css.get("transition-timing-function");
   transition-duration: css.get("transition-duration-short");
   transition-property: border-color, box-shadow;
-  transition-timing-function: css.get("transition-timing-function");
 
   .pre {
-    border: none;
     max-height: css.get("code-expander", "max-height");
+    border: none;
     transition: max-height css.get("transition-duration") css.get("transition-timing-function");
   }
 
@@ -25,9 +25,9 @@
     }
 
     .code-block__copy-button {
-      background-color: transparent;
-      right: 0.5rem;
       top: calc(-2.5rem + 2px);
+      right: 0.5rem;
+      background-color: transparent;
 
       &:hover {
         background-color: transparent;
@@ -37,35 +37,35 @@
 }
 
 .code-expander__header {
-  border-bottom: css.get("border");
-  color: css.get("foreground-lighter");
   display: flex;
   gap: 0.5rem;
   padding: 0.5rem 3.5rem 0.5rem 1rem;
+  border-bottom: css.get("border");
+  color: css.get("foreground-lighter");
 }
 
 .code-expander__tools {
-  display: flex;
-  gap: css.get("spacing-sm");
-  inset: auto css.get("spacing-md") css.get("spacing-md") auto;
   position: absolute;
   z-index: 2;
+  inset: auto css.get("spacing-md") css.get("spacing-md") auto;
+  display: flex;
+  gap: css.get("spacing-sm");
 }
 
 .code-expander__unlock-scroll {
   display: none;
   opacity: 0;
+  transition-timing-function: css.get("transition-timing-function");
   transition-duration: css.get("transition-duration-short");
   transition-property: opacity, border-color;
-  transition-timing-function: css.get("transition-timing-function");
 }
 
 .code-expander__screen {
   cursor: pointer;
-  display: none;
-  inset: 1px;
   position: absolute;
   z-index: 1;
+  inset: 1px;
+  display: none;
 }
 
 .code-expander.is-scroll-locked {
@@ -82,10 +82,10 @@
     box-shadow: 0 0 0 css.get("focus-ring-width") palette.get("primary", 50%, css.get("focus-ring-opacity"));
 
     .code-expander__unlock-scroll {
-      border-color: palette.get("primary");
-      box-shadow: 0 0 0 css.get("focus-ring-width") palette.get("primary", 50%, css.get("focus-ring-opacity"));
       display: inline-flex;
+      border-color: palette.get("primary");
       opacity: 1;
+      box-shadow: 0 0 0 css.get("focus-ring-width") palette.get("primary", 50%, css.get("focus-ring-opacity"));
     }
   }
 }

--- a/docs/src/styles/_content.scss
+++ b/docs/src/styles/_content.scss
@@ -18,8 +18,8 @@
   h4,
   h5,
   h6 {
-    outline: none;
     position: relative;
+    outline: none;
   }
 
   h3 {

--- a/docs/src/styles/_doc-block.scss
+++ b/docs/src/styles/_doc-block.scss
@@ -3,12 +3,12 @@
 @use "@vrembem/core/palette";
 
 .doc-block {
+  margin: 2rem 0 !important;
   border: css.get("border");
   border-radius: css.get("border-radius");
-  box-shadow: 0 0 0 0 palette.get("primary", 90);
   font-size: css.get("font-size");
   line-height: css.get("line-height");
-  margin: 2rem 0 !important;
+  box-shadow: 0 0 0 0 palette.get("primary", 90);
   transition: css.get("transition");
   transition-property: border-color, box-shadow;
 
@@ -22,10 +22,10 @@
   }
 
   @include core.media-max("xs") {
+    margin: 2rem calc(css.get("layout", "padding") * -1) !important;
+    border-right: none;
     border-left: none;
     border-radius: 0;
-    border-right: none;
-    margin: 2rem calc(css.get("layout", "padding") * -1) !important;
 
     .doc-block__file .pre {
       margin: 0;
@@ -48,8 +48,8 @@
 }
 
 .doc-block__content {
-  border-top: css.get("border");
   position: relative;
+  border-top: css.get("border");
 }
 
 .doc-block__meta {

--- a/docs/src/styles/_drawer_aside.scss
+++ b/docs/src/styles/_drawer_aside.scss
@@ -23,26 +23,26 @@
 
 @include core.media-min("aside") {
   .drawer_aside {
+    z-index: 2;
     box-sizing: content-box;
+    width: calc(css.get("layout", "aside-width") + css.get("layout", "padding"));
     padding-right: max(0px, calc((100% - (css.get("layout", "width") + (css.get("layout", "padding") * 2))) / 2));
     visibility: visible;
-    width: calc(css.get("layout", "aside-width") + css.get("layout", "padding"));
-    z-index: 2;
 
     > * {
       box-sizing: border-box;
     }
 
     .drawer__dialog {
-      background-color: transparent;
       inset: 0 auto auto 0;
-      max-height: 100vh;
       width: calc(css.get("layout", "aside-width") + css.get("layout", "padding"));
+      max-height: 100vh;
+      background-color: transparent;
     }
 
     .drawer__container {
-      padding: calc(css.get("layout", "navibar-height") + css.get("layout", "content-padding-y")) css.get("layout", "padding") calc(css.get("layout", "footer-height") + css.get("layout", "content-padding-y")) css.get("focus-ring-width");
       scroll-behavior: smooth;
+      padding: calc(css.get("layout", "navibar-height") + css.get("layout", "content-padding-y")) css.get("layout", "padding") calc(css.get("layout", "footer-height") + css.get("layout", "content-padding-y")) css.get("focus-ring-width");
     }
   }
 }

--- a/docs/src/styles/_drawer_sidebar.scss
+++ b/docs/src/styles/_drawer_sidebar.scss
@@ -22,55 +22,55 @@
 
 @include core.media-min("sidebar") {
   .drawer_sidebar {
-    background-color: css.get("background-darker");
+    z-index: 2;
     box-sizing: content-box;
+    width: calc(css.get("layout", "sidebar-width") + css.get("layout", "padding"));
     padding-left: max(0px, calc((100% - (css.get("layout", "width") + (css.get("layout", "padding") * 2))) / 2));
     visibility: visible;
-    width: calc(css.get("layout", "sidebar-width") + css.get("layout", "padding"));
-    z-index: 2;
+    background-color: css.get("background-darker");
+
+    // Fold shadow
+    &::after {
+      pointer-events: none;
+      content: "";
+      position: absolute;
+      z-index: 2;
+      inset: 0 0 auto auto;
+      width: 2rem;
+      height: 100%;
+      background: linear-gradient(268deg, rgb(0 0 0 / 8%) 0, rgb(0 0 0 / 0%) 2rem);
+    }
 
     > * {
       box-sizing: border-box;
     }
 
     .drawer__dialog {
-      background-color: transparent;
       inset: 0 0 0 auto;
       width: calc(css.get("layout", "sidebar-width") + css.get("layout", "padding"));
+      background-color: transparent;
     }
 
     .drawer__container {
       padding: css.get("layout", "navibar-height") css.get("layout", "padding") css.get("layout", "padding");
     }
 
-    // Fold shadow
-    &::after {
-      background: linear-gradient(268deg, rgb(0 0 0 / 8%) 0, rgb(0 0 0 / 0%) 2rem);
-      content: "";
-      height: 100%;
-      inset: 0 0 auto auto;
-      pointer-events: none;
-      position: absolute;
-      width: 2rem;
-      z-index: 2;
-    }
-
     // Scrolling mask
     .drawer__mask {
-      background-color: css.get("background-darker");
-      flex-shrink: 0;
-      height: calc(css.get("layout", "navibar-height") + css.get("layout", "padding"));
-      inset: calc((css.get("layout", "navibar-height") + css.get("layout", "padding")) * -1) 0 auto 0;
-      margin: calc((css.get("layout", "navibar-height") + css.get("layout", "padding")) * -1) calc(css.get("layout", "padding") * -1) css.get("layout", "padding") calc(css.get("layout", "padding") * -1);
       position: sticky;
       z-index: 2;
+      inset: calc((css.get("layout", "navibar-height") + css.get("layout", "padding")) * -1) 0 auto 0;
+      flex-shrink: 0;
+      height: calc(css.get("layout", "navibar-height") + css.get("layout", "padding"));
+      margin: calc((css.get("layout", "navibar-height") + css.get("layout", "padding")) * -1) calc(css.get("layout", "padding") * -1) css.get("layout", "padding") calc(css.get("layout", "padding") * -1);
+      background-color: css.get("background-darker");
 
       &::after {
-        border-bottom: 1px solid css.get("border-color");
         content: "";
+        position: absolute;
         inset: 100% 0 auto;
         margin: 0 css.get("layout", "padding");
-        position: absolute;
+        border-bottom: 1px solid css.get("border-color");
       }
     }
   }

--- a/docs/src/styles/_floats.scss
+++ b/docs/src/styles/_floats.scss
@@ -1,6 +1,6 @@
 .clearfix::after {
-  clear: both;
   content: "";
+  clear: both;
   display: block;
 }
 

--- a/docs/src/styles/_fold-shadow.scss
+++ b/docs/src/styles/_fold-shadow.scss
@@ -1,8 +1,8 @@
 .fold-shadow::after {
-  background: linear-gradient(178deg, rgb(0 0 0 / 8%) 0, rgb(0 0 0 / 0%) 2rem);
   content: "";
-  height: 2rem;
-  inset: auto 0 -2rem;
   position: absolute;
+  inset: auto 0 -2rem;
   width: 100%;
+  height: 2rem;
+  background: linear-gradient(178deg, rgb(0 0 0 / 8%) 0, rgb(0 0 0 / 0%) 2rem);
 }

--- a/docs/src/styles/_footer.scss
+++ b/docs/src/styles/_footer.scss
@@ -3,17 +3,17 @@
 @use "@vrembem/core/palette";
 
 .footer {
-  color: css.get("foreground-lighter");
   display: flex;
+  color: css.get("foreground-lighter");
 }
 
 .footer__content {
-  border-top: css.get("border");
   flex-grow: 1;
-  margin: auto;
-  max-width: css.get("layout", "content-width");
-  padding: 3rem 0;
   width: 100%;
+  max-width: css.get("layout", "content-width");
+  margin: auto;
+  padding: 3rem 0;
+  border-top: css.get("border");
 
   .is-home & {
     max-width: unset;
@@ -21,26 +21,26 @@
 }
 
 .footer__logo {
-  border-top: css.get("border");
-  color: palette.get("primary");
   display: flex;
   flex-grow: 0;
   justify-content: center;
   padding: 3rem 0;
+  border-top: css.get("border");
+  color: palette.get("primary");
   text-align: center;
 
   @include core.media-min("aside") {
     .has-aside & {
-      background-color: css.get("background");
       position: absolute;
+      z-index: 2;
       right: 0;
       width: calc(css.get("layout", "aside-width") - css.get("focus-ring-width"));
-      z-index: 2;
+      background-color: css.get("background");
     }
 
     .is-home & {
-      background-color: transparent;
       position: relative;
+      background-color: transparent;
     }
   }
 }

--- a/docs/src/styles/_global.scss
+++ b/docs/src/styles/_global.scss
@@ -26,15 +26,15 @@ html {
 }
 
 .slide-up {
-  opacity: 0;
   position: relative;
   transform: translateY(1rem);
+  opacity: 0;
   transition: css.get("transition");
   transition-property: transform, opacity;
 
   &.is-active {
-    opacity: 1;
     transform: translateY(0);
+    opacity: 1;
   }
 }
 
@@ -61,10 +61,10 @@ html {
 .svg-icon {
   @include core.size(1rem);
 
-  background-color: salmon;
   display: inline-block;
-  mask-position: center;
+  background-color: salmon;
   mask-repeat: no-repeat;
+  mask-position: center;
   mask-size: 100%;
 
   &.svg-check {

--- a/docs/src/styles/_heading-anchor.scss
+++ b/docs/src/styles/_heading-anchor.scss
@@ -5,22 +5,22 @@
 .heading-anchor {
   @include css.override("core", "form-control-border-width", 0);
 
-  align-items: center;
-  background-color: palette.get("primary", 50%, 0%);
-  border-radius: css.get("border-radius-circle");
+  user-select: none;
   display: inline-flex;
-  font-size: 1rem;
-  font-weight: 500;
+  align-items: center;
   justify-content: center;
   margin-left: 0.5rem;
-  opacity: 0;
   padding: css.get("form-control-padding-y");
+  border-radius: css.get("border-radius-circle");
+  font-size: 1rem;
+  font-weight: 500;
   text-decoration: none !important;
+  vertical-align: middle;
+  opacity: 0;
+  background-color: palette.get("primary", 50%, 0%);
+  transition-timing-function: css.get("transition-timing-function");
   transition-duration: css.get("transition-duration");
   transition-property: color, opacity;
-  transition-timing-function: css.get("transition-timing-function");
-  user-select: none;
-  vertical-align: middle;
 
   &:hover,
   &:focus {
@@ -39,9 +39,9 @@
   }
 
   @include core.media-min("sm") {
-    margin-left: 0;
     position: absolute;
-    right: calc(100% + 0.5rem);
     top: calc(60% - calc(css.get("form-control-size-calc") / 2));
+    right: calc(100% + 0.5rem);
+    margin-left: 0;
   }
 }

--- a/docs/src/styles/_icon_external.scss
+++ b/docs/src/styles/_icon_external.scss
@@ -1,10 +1,10 @@
 @use "@vrembem/core/css";
 
 .icon_external {
-  color: css.get("foreground-lighter");
-  font-size: 0.75em;
   position: relative;
   right: -0.25em;
+  font-size: 0.75em;
+  color: css.get("foreground-lighter");
   stroke-width: 2.5;
   transition: transform css.get("transition-duration-short") css.get("transition-timing-function");
 }

--- a/docs/src/styles/_layout.scss
+++ b/docs/src/styles/_layout.scss
@@ -3,11 +3,11 @@
 @use "@vrembem/core/palette";
 
 .layout {
+  position: relative;
   display: flex;
   justify-content: center;
-  padding: 0 css.get("layout", "padding");
-  position: relative;
   width: 100%;
+  padding: 0 css.get("layout", "padding");
 
   @include core.media-min("xs") {
     @include css.override("layout", "content-padding-x", 1rem);
@@ -40,33 +40,33 @@
 }
 
 .layout__main {
-  margin: auto;
-  max-width: css.get("layout", "width");
-  outline: none;
   position: relative;
   width: 100%;
+  max-width: css.get("layout", "width");
+  margin: auto;
+  outline: none;
 
   @include core.media-min("sidebar") {
     padding-top: css.get("layout", "navibar-height");
 
     &::before {
-      backdrop-filter: blur(8px);
-      background-color: css.get("background-glass");
       content: "";
-      height: css.get("layout", "navibar-height");
       position: fixed;
+      z-index: 4;
       top: 0;
       width: 100%;
-      z-index: 4;
+      height: css.get("layout", "navibar-height");
+      background-color: css.get("background-glass");
+      backdrop-filter: blur(8px);
     }
   }
 }
 
 .layout__container {
-  margin: auto;
-  max-width: calc(css.get("layout", "content-width"));
-  padding: css.get("layout", "content-padding-y") css.get("layout", "content-padding-x") 0;
   width: 100%;
+  max-width: calc(css.get("layout", "content-width"));
+  margin: auto;
+  padding: css.get("layout", "content-padding-y") css.get("layout", "content-padding-x") 0;
 
   > * + * {
     margin-top: calc(css.get("spacing") * 12) !important;

--- a/docs/src/styles/_menu_collection.scss
+++ b/docs/src/styles/_menu_collection.scss
@@ -8,8 +8,8 @@
 
   .menu__action.is-active,
   .menu__action.is-parent {
-    background: css.get("background");
     color: palette.get("primary");
+    background: css.get("background");
   }
 
   .menu {

--- a/docs/src/styles/_menu_minimal.scss
+++ b/docs/src/styles/_menu_minimal.scss
@@ -11,8 +11,17 @@
   );
 
   .menu__action {
-    scroll-margin-bottom: 20rem;
     scroll-margin-top: 14rem;
+    scroll-margin-bottom: 20rem;
+
+    &::before {
+      content: "";
+      position: absolute;
+      inset: 8px auto 8px 0;
+      width: 2px;
+      border-radius: 2px;
+      background: transparent;
+    }
 
     &:hover,
     &:active,
@@ -20,15 +29,6 @@
     &:focus-visible,
     &.is-active {
       background-color: transparent;
-    }
-
-    &::before {
-      background: transparent;
-      border-radius: 2px;
-      content: "";
-      inset: 8px auto 8px 0;
-      position: absolute;
-      width: 2px;
     }
 
     &:hover::before {

--- a/docs/src/styles/_navibar.scss
+++ b/docs/src/styles/_navibar.scss
@@ -2,32 +2,32 @@
 @use "@vrembem/core/css";
 
 .navibar {
-  padding: 0 css.get("layout", "padding");
   position: relative;
-  width: 100%;
   z-index: 5;
+  width: 100%;
+  padding: 0 css.get("layout", "padding");
 
   @include core.media-min("sidebar") {
     position: fixed;
   }
 
   .is-home & {
-    backdrop-filter: blur(8px);
     background-color: css.get("background-glass");
+    backdrop-filter: blur(8px);
   }
 }
 
 .navibar__container {
   display: flex;
-  margin: auto;
-  max-width: css.get("layout", "width");
   width: 100%;
+  max-width: css.get("layout", "width");
+  margin: auto;
 }
 
 .navibar__title,
 .navibar__menu {
-  align-items: center;
   display: flex;
+  align-items: center;
   height: css.get("layout", "navibar-height");
 }
 
@@ -37,19 +37,19 @@
 }
 
 .navibar__skip {
+  position: absolute;
+  z-index: 100;
+  top: -100%;
+  width: calc(100% - 1em);
   margin-right: 1em;
   opacity: 0;
-  position: absolute;
-  top: -100%;
+  transition-timing-function: css.get("transition-timing-function");
   transition-duration: css.get("transition-duration");
   transition-property: top, opacity;
-  transition-timing-function: css.get("transition-timing-function");
-  width: calc(100% - 1em);
-  z-index: 100;
 
   &:focus {
-    opacity: 1;
     top: calc(calc(css.get("layout", "navibar-height") - css.get("form-control-size-calc")) / 2);
+    opacity: 1;
   }
 }
 

--- a/docs/src/styles/_pagi.scss
+++ b/docs/src/styles/_pagi.scss
@@ -14,8 +14,8 @@
 
 .pagi_prev,
 .pagi_next {
-  align-content: stretch;
   flex-basis: calc(50% - (1rem / 2));
+  align-content: stretch;
 }
 
 .pagi_prev {
@@ -27,13 +27,13 @@
 }
 
 .pagi_link {
-  border: 1px solid css.get("border-color");
-  border-radius: css.get("border-radius");
   display: block;
   padding: 1rem;
+  border: 1px solid css.get("border-color");
+  border-radius: css.get("border-radius");
   transition: border-color;
-  transition-duration: css.get("transition-duration");
   transition-timing-function: css.get("transition-timing-function");
+  transition-duration: css.get("transition-duration");
 
   &:hover {
     border-color: palette.get("primary");
@@ -41,11 +41,11 @@
 }
 
 .pagi_label {
-  color: css.get("foreground-lighter");
   font-size: css.get("font-size-sm");
+  color: css.get("foreground-lighter");
 }
 
 .pagi_title {
-  color: palette.get("primary");
   font-size: css.get("font-size-lg");
+  color: palette.get("primary");
 }

--- a/docs/src/styles/_reference-bar.scss
+++ b/docs/src/styles/_reference-bar.scss
@@ -1,23 +1,23 @@
 @use "@vrembem/core/css";
 
 .reference-bar {
-  align-items: center;
-  color: css.get("foreground");
   display: flex;
   flex-wrap: wrap;
   gap: css.get("spacing-sm") css.get("spacing-md");
+  align-items: center;
   justify-content: space-between;
+  color: css.get("foreground");
 
   .link_hash {
-    align-items: center;
     display: flex;
     gap: css.get("spacing-sm");
+    align-items: center;
   }
 }
 
 .reference-bar__item {
-  align-items: center;
   display: flex;
   flex-wrap: nowrap;
   gap: css.get("spacing-sm");
+  align-items: center;
 }

--- a/docs/src/styles/_reference-table.scss
+++ b/docs/src/styles/_reference-table.scss
@@ -21,15 +21,15 @@
 );
 
 .reference-table {
-  font-size: css.get("font-size");
   scroll-margin-top: 84px; // Magic number found using JS: `this.el.getBoundingClientRect().top;`
-  transition: max-height css.get("transition-duration") css.get("transition-timing-function");
   width: 100%;
+  font-size: css.get("font-size");
+  transition: max-height css.get("transition-duration") css.get("transition-timing-function");
 
   table {
-    background-color: transparent;
     position: relative;
     table-layout: fixed;
+    background-color: transparent;
   }
 
   thead {
@@ -37,23 +37,23 @@
   }
 
   tr {
-    border-radius: css.get("border-radius");
+    scroll-margin-top: calc(css.get("layout", "toolbar-height") + 81px);
+    position: relative;
     border-top: css.get("table", "border");
+    border-radius: css.get("border-radius");
     box-shadow:
       0 0 0 0 palette.get("primary"),
       0 0 0 0 palette.get("primary", 50%, 20%);
-    position: relative;
-    scroll-margin-top: calc(css.get("layout", "toolbar-height") + 81px);
 
     @include core.media-min("sidebar") {
       scroll-margin-top: calc(css.get("layout", "navibar-height") + 82px);
     }
 
     &.is-active {
+      z-index: 1;
       box-shadow:
         0 0 0 1px palette.get("primary"),
         0 0 0 0.2rem palette.get("primary", 50%, 20%);
-      z-index: 1;
 
       .table-anchor {
         display: none;
@@ -70,8 +70,8 @@
   }
 
   td {
-    padding: 0;
     position: relative;
+    padding: 0;
 
     &:first-child {
       @include css.override("pre", "foreground", css.get("reference-table", "key-foreground"));
@@ -85,18 +85,18 @@
   }
 
   .code-block {
-    min-width: 0; // Fixes overflow issue
     width: 100%;
+    min-width: 0; // Fixes overflow issue
 
     pre {
-      background-color: transparent;
-      border: 0 none;
       margin: 0;
+      border: 0 none;
+      background-color: transparent;
     }
 
     .code-block__icon {
-      background-color: transparent;
       padding: 0.5em;
+      background-color: transparent;
 
       .icon {
         @include css.override("icon", "size", 1em);
@@ -104,9 +104,9 @@
     }
 
     .code-block__copy-button {
-      background-color: css.get("background");
-      opacity: 0;
       right: 0;
+      opacity: 0;
+      background-color: css.get("background");
 
       &:hover,
       &:focus {
@@ -126,14 +126,14 @@
   }
 
   .notice {
+    margin-top: css.get("spacing-md");
     border-radius: css.get("border-radius");
     font-size: css.get("font-size");
-    margin-top: css.get("spacing-md");
   }
 
   &.is-expandable {
-    max-height: css.get("reference-table", "max-height");
     overflow: hidden;
+    max-height: css.get("reference-table", "max-height");
   }
 
   &.is-expanded {
@@ -150,11 +150,11 @@
 }
 
 .reference-table__header {
-  background: css.get("background");
-  padding: css.get("spacing-md") 0;
   position: sticky;
-  top: calc(css.get("layout", "toolbar-height") - 1px);
   z-index: 2;
+  top: calc(css.get("layout", "toolbar-height") - 1px);
+  padding: css.get("spacing-md") 0;
+  background: css.get("background");
 
   @include core.media-min("sidebar") {
     top: css.get("layout", "navibar-height");
@@ -170,15 +170,15 @@
 
   .input-icon,
   .input-clear {
-    align-items: center;
-    color: css.get("foreground-lighter");
     cursor: pointer;
-    display: flex;
-    inset: 0 auto 0 0;
-    justify-content: center;
-    padding: 0 0.75em;
     position: absolute;
     z-index: 1;
+    inset: 0 auto 0 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 0.75em;
+    color: css.get("foreground-lighter");
 
     &:hover {
       color: palette.get("primary");
@@ -186,10 +186,10 @@
   }
 
   .input-clear {
-    background-color: transparent;
-    border: none;
-    box-shadow: none;
     inset: 0 0 0 auto;
+    border: none;
+    background-color: transparent;
+    box-shadow: none;
   }
 
   .input {
@@ -201,8 +201,8 @@
       )
     );
 
-    font-family: css.get("font-family-mono");
     padding-left: 3.5em;
+    font-family: css.get("font-family-mono");
 
     &:focus ~ .input-icon {
       color: palette.get("primary");
@@ -214,30 +214,30 @@
 .table-anchor-clear {
   @include css.override("core", "form-control-border-width", 0);
 
-  align-items: center;
-  background-color: palette.get("primary", 50%, 0%);
-  border-radius: css.get("border-radius-circle");
+  user-select: none;
+  position: absolute;
+  top: calc(50% - calc(34px / 2));
+  right: calc(100% + 0.5rem);
   display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.5rem;
+  padding: css.get("form-control-padding-y");
+  border-radius: css.get("border-radius-circle");
   font-size: 1rem;
   font-weight: 500;
-  justify-content: center;
   line-height: 1em;
-  margin-left: 0.5rem;
-  opacity: 0;
-  padding: css.get("form-control-padding-y");
-  position: absolute;
-  right: calc(100% + 0.5rem);
   text-decoration: none !important;
-  top: calc(50% - calc(34px / 2));
+  opacity: 0;
+  background-color: palette.get("primary", 50%, 0%);
   transition:
     color 0.25s,
     opacity 0.25s;
-  user-select: none;
 
   &:focus,
   &:hover {
-    background-color: palette.get("primary", 50%, 20%);
     opacity: 1;
+    background-color: palette.get("primary", 50%, 20%);
   }
 
   tr:hover & {
@@ -246,9 +246,9 @@
 }
 
 .table-anchor-clear {
-  background-color: palette.get("important", 50%, 0%);
-  color: palette.get("important");
   display: none;
+  color: palette.get("important");
+  background-color: palette.get("important", 50%, 0%);
 
   &:focus,
   &:hover {
@@ -259,15 +259,15 @@
 @include core.media-max("xs") {
   .table-anchor,
   .table-anchor-clear {
-    left: 3.75rem;
     right: auto;
+    left: 3.75rem;
   }
 }
 
 .reference-table__footer {
-  background: linear-gradient(to bottom, transparent, css.reference("core", "background") 70%);
+  position: sticky;
   bottom: 0;
   padding: 1.5em 0;
-  position: sticky;
   text-align: center;
+  background: linear-gradient(to bottom, transparent, css.reference("core", "background") 70%);
 }

--- a/docs/src/styles/_swatch.scss
+++ b/docs/src/styles/_swatch.scss
@@ -4,7 +4,7 @@
 .swatch {
   @include core.size(4rem);
 
+  display: inline-block;
   border: css.get("border");
   border-radius: css.get("border-radius");
-  display: inline-block;
 }

--- a/docs/src/styles/_tabs.scss
+++ b/docs/src/styles/_tabs.scss
@@ -2,17 +2,17 @@
 @use "@vrembem/core/palette";
 
 [role="tab"] {
-  color: css.get("foreground-lighter");
+  position: relative;
   margin: -0.5rem 0;
   padding: 0.5rem;
-  position: relative;
+  color: css.get("foreground-lighter");
 
   &::after {
-    background: transparent;
     content: "";
-    height: 3px;
-    inset: auto 0 -1px;
     position: absolute;
+    inset: auto 0 -1px;
+    height: 3px;
+    background: transparent;
   }
 
   &:hover {

--- a/docs/src/styles/_theme-icons.scss
+++ b/docs/src/styles/_theme-icons.scss
@@ -6,33 +6,33 @@
 }
 
 .theme-icon {
-  left: 0.5rem;
-  opacity: 0;
   position: absolute;
   top: 0.5rem;
+  left: 0.5rem;
   transform: translateY(calc(100% + 0.5rem));
+  opacity: 0;
+  transition-timing-function: ease;
   transition-duration: 0.5s;
   transition-property: transform, opacity;
-  transition-timing-function: ease;
 }
 
 #{theme.class("auto")} {
   .theme-icon_auto {
-    opacity: 1;
     transform: translateY(0);
+    opacity: 1;
   }
 }
 
 #{theme.class("light")} {
   .theme-icon_light {
-    opacity: 1;
     transform: translateY(0);
+    opacity: 1;
   }
 }
 
 #{theme.class("dark")} {
   .theme-icon_dark {
-    opacity: 1;
     transform: translateY(0);
+    opacity: 1;
   }
 }

--- a/docs/src/styles/_tictactoe.scss
+++ b/docs/src/styles/_tictactoe.scss
@@ -29,9 +29,9 @@
 );
 
 .tictactoe-wrapper {
+  width: fit-content;
   margin: 0 auto;
   text-align: center;
-  width: fit-content;
 
   > * + * {
     margin-top: 2em;
@@ -39,16 +39,16 @@
 }
 
 .tictactoe__cell {
-  box-shadow: inset 0 0 0 0.25em css.get("tictactoe", "box-shadow-color");
   cursor: pointer;
-  font-size: 1.6em;
-  height: 3em;
-  text-align: center;
   width: 3em;
+  height: 3em;
+  font-size: 1.6em;
+  text-align: center;
+  box-shadow: inset 0 0 0 0.25em css.get("tictactoe", "box-shadow-color");
 
   &.is-winner {
-    background-color: css.get("tictactoe", "background-winner");
     color: css.get("tictactoe", "foreground-winner");
+    background-color: css.get("tictactoe", "background-winner");
   }
 
   &:first-child {

--- a/docs/src/styles/_toolbar.scss
+++ b/docs/src/styles/_toolbar.scss
@@ -2,16 +2,16 @@
 @use "@vrembem/core/css";
 
 .toolbar {
-  backdrop-filter: blur(8px);
-  background-clip: padding-box;
-  background-color: css.get("background-glass");
-  border-bottom: 1px solid css.get("border-color");
-  border-top: 1px solid css.get("border-color");
+  position: sticky;
+  z-index: 4;
+  top: -1px;
   display: block;
   padding: css.get("layout", "padding");
-  position: sticky;
-  top: -1px;
-  z-index: 4;
+  border-top: 1px solid css.get("border-color");
+  border-bottom: 1px solid css.get("border-color");
+  background-color: css.get("background-glass");
+  background-clip: padding-box;
+  backdrop-filter: blur(8px);
 
   @include core.media-min("sidebar") {
     display: none;
@@ -24,26 +24,26 @@
  */
 
 .toolbar-mini {
-  opacity: 0;
   position: fixed;
-  right: css.get("layout", "padding");
+  z-index: 6;
   top: css.get("layout", "navibar-height");
+  right: css.get("layout", "padding");
   transform: translate(100%);
+  visibility: hidden;
+  opacity: 0;
   transition:
     opacity 0.5s,
     transform 0.25s ease;
-  visibility: hidden;
-  z-index: 6;
 
   @include core.media-min("sidebar") {
-    opacity: 1;
     transform: translate(0);
     visibility: visible;
+    opacity: 1;
   }
 
   @include core.media-min("aside") {
-    opacity: 0;
     transform: translate(100%);
     visibility: hidden;
+    opacity: 0;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "prettier": "^3.8.1",
         "sass": "^1.98.0",
         "stylelint": "^17.6.0",
+        "stylelint-config-clean-order": "^8.0.1",
         "stylelint-config-standard-scss": "^17.0.0",
         "stylelint-order": "^8.1.1",
         "stylelint-prettier": "^5.0.3",
@@ -17814,6 +17815,17 @@
       },
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/stylelint-config-clean-order": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-config-clean-order/-/stylelint-config-clean-order-8.0.1.tgz",
+      "integrity": "sha512-zKjp7BiINXRZOG9m0fE/6UKoM6clPekL+LoAiHMCiQU2hgirKL5G0mKc5Z0ygIhQXfb1+DTRDM0mu6Ecdv4q8g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "stylelint": ">=16",
+        "stylelint-order": ">=6"
       }
     },
     "node_modules/stylelint-config-recommended": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "prettier": "^3.8.1",
     "sass": "^1.98.0",
     "stylelint": "^17.6.0",
+    "stylelint-config-clean-order": "^8.0.1",
     "stylelint-config-standard-scss": "^17.0.0",
     "stylelint-order": "^8.1.1",
     "stylelint-prettier": "^5.0.3",

--- a/packages/base/src/modules/_blockquote.scss
+++ b/packages/base/src/modules/_blockquote.scss
@@ -5,12 +5,12 @@
   @include css.register("blockquote");
 
   #{fun.selector("blockquote")} {
-    background: css.get("blockquote", "background", transparent);
+    position: relative;
+    padding: css.get("blockquote", "padding", css.get("spacing-md"));
     border: css.get("blockquote", "border", css.get("border"));
     border-radius: css.get("blockquote", "border-radius", css.get("border-radius"));
     color: css.get("blockquote", "foreground", currentcolor);
-    padding: css.get("blockquote", "padding", css.get("spacing-md"));
-    position: relative;
+    background: css.get("blockquote", "background", transparent);
 
     > * + * {
       margin-top: css.get("blockquote", "spacing", css.get("spacing-md"));

--- a/packages/base/src/modules/_code.scss
+++ b/packages/base/src/modules/_code.scss
@@ -5,13 +5,13 @@
   @include css.register("code");
 
   #{fun.selector("code")} {
-    background: css.get("code", "background", css.get("background-alt"));
+    padding: css.get("code", "padding", 0.125rem 0.375rem);
     border: css.get("code", "border", null);
     border-radius: css.get("code", "border-radius", css.get("border-radius"));
-    color: css.get("code", "foreground", css.get("foreground-alt"));
     font-family: css.get("font-family-mono");
     font-size: css.get("code", "font-size", css.get("font-size-sm"));
+    color: css.get("code", "foreground", css.get("foreground-alt"));
     overflow-wrap: break-word;
-    padding: css.get("code", "padding", 0.125rem 0.375rem);
+    background: css.get("code", "background", css.get("background-alt"));
   }
 }

--- a/packages/base/src/modules/_headings.scss
+++ b/packages/base/src/modules/_headings.scss
@@ -8,11 +8,11 @@
   @include css.register("headings");
 
   #{fun.selector(config.get("base-headings"))} {
-    color: css.get("headings", "foreground", css.get("foreground"));
     font-family: css.get("headings", "font-family", inherit);
     font-size: css.get("headings", "font-size", 1em);
     font-weight: css.get("headings", "font-weight", css.get("font-weight-semi-bold"));
     line-height: css.get("headings", "line-height", inherit);
+    color: css.get("headings", "foreground", css.get("foreground"));
   }
 
   @each $key, $value in config.get("base-headings") {

--- a/packages/base/src/modules/_link.scss
+++ b/packages/base/src/modules/_link.scss
@@ -12,8 +12,8 @@
     text-underline-offset: css.get("link", "underline-offset", 2px);
 
     code {
-      background-color: palette.get("primary", 50%, 10%);
       color: css.get("link", "foreground", palette.get("primary"));
+      background-color: palette.get("primary", 50%, 10%);
     }
 
     &:hover,

--- a/packages/base/src/modules/_normalize.scss
+++ b/packages/base/src/modules/_normalize.scss
@@ -22,15 +22,15 @@
   html {
     box-sizing: border-box;
     font-size: css.get("base", "font-size", 16px);
-    -moz-osx-font-smoothing: grayscale;
     line-height: css.get("base", "line-height", css.get("line-height"));
     text-size-adjust: 100%;
+    -moz-osx-font-smoothing: grayscale;
   }
 
   body {
-    background: css.get("base", "background", css.get("background"));
-    color: css.get("base", "foreground", css.get("foreground"));
     font-family: css.get("font-family");
+    color: css.get("base", "foreground", css.get("foreground"));
+    background: css.get("base", "background", css.get("background"));
   }
 
   // Reset font-size for headings
@@ -45,10 +45,10 @@
 
   // Better default styles for images
   img {
+    max-width: 100%;
+    height: auto;
     border: 0;
     border-style: none;
-    height: auto;
-    max-width: 100%;
     vertical-align: middle;
   }
 
@@ -109,13 +109,13 @@
   }
 
   button {
-    background: none;
-    border: 0;
     cursor: pointer;
-    -webkit-font-smoothing: inherit;
-    letter-spacing: inherit;
+    border: 0;
     text-align: inherit;
     text-transform: none;
+    letter-spacing: inherit;
+    background: none;
+    -webkit-font-smoothing: inherit;
   }
 
   // Correct the inability to style clickable types in iOS and Safari

--- a/packages/base/src/modules/_pre.scss
+++ b/packages/base/src/modules/_pre.scss
@@ -5,20 +5,20 @@
   @include css.register("pre");
 
   #{fun.selector("pre")} {
-    background: css.get("pre", "background", css.get("background-dark"));
-    border: css.get("pre", "border", none);
-    border-radius: css.get("pre", "border-radius", css.get("border-radius"));
-    color: css.get("pre", "foreground", css.get("foreground"));
-    font-family: css.get("font-family-mono");
     overflow: auto;
     padding: css.get("pre", "padding", css.get("spacing-md"));
+    border: css.get("pre", "border", none);
+    border-radius: css.get("pre", "border-radius", css.get("border-radius"));
+    font-family: css.get("font-family-mono");
+    color: css.get("pre", "foreground", css.get("foreground"));
+    background: css.get("pre", "background", css.get("background-dark"));
 
     code {
-      background: none;
-      border: none;
-      color: inherit;
-      font-size: css.get("pre", "font-size", css.get("font-size-sm"));
       padding: 0;
+      border: none;
+      font-size: css.get("pre", "font-size", css.get("font-size-sm"));
+      color: inherit;
+      background: none;
     }
   }
 }

--- a/packages/base/src/modules/_separator.scss
+++ b/packages/base/src/modules/_separator.scss
@@ -5,9 +5,9 @@
   @include css.register("separator");
 
   #{fun.selector("separator")} {
-    border: none;
-    border-top: css.get("separator", "border", css.get("border"));
     display: block;
     height: 0;
+    border: none;
+    border-top: css.get("separator", "border", css.get("border"));
   }
 }

--- a/packages/base/src/modules/_type.scss
+++ b/packages/base/src/modules/_type.scss
@@ -6,10 +6,10 @@
   @include css.register("heading");
 
   #{fun.selector("type")} {
-    color: css.get("type", "foreground", css.get("foreground-light"));
     font-family: css.get("type", "font-family", inherit);
     font-size: css.get("type", "font-size", inherit);
     line-height: css.get("type", "line-height", inherit);
+    color: css.get("type", "foreground", css.get("foreground-light"));
 
     > * + * {
       margin-top: css.get("type", "spacing", null);

--- a/packages/button/src/_button.scss
+++ b/packages/button/src/_button.scss
@@ -5,49 +5,49 @@
 #{core.bem("button")} {
   @include mix.base;
 
-  background-color: css.get("button", "background", css.get("background"));
   border-color: css.get("button", "border-color", css.get("border-color-dark"));
-  box-shadow: css.get("button", "box-shadow", none);
   color: css.get("button", "foreground", css.get("foreground"));
+  background-color: css.get("button", "background", css.get("background"));
+  box-shadow: css.get("button", "box-shadow", none);
 
   &:hover {
-    background-color: css.get("button", "background-hover", "background", css.get("background"));
     border-color: css.get("button", "border-color-hover", "border-color", css.get("border-color-darker"));
-    box-shadow: css.get("button", "box-shadow-hover", "box-shadow", css.get("box-shadow-1"));
     color: css.get("button", "foreground-hover", "foreground", css.get("foreground"));
+    background-color: css.get("button", "background-hover", "background", css.get("background"));
+    box-shadow: css.get("button", "box-shadow-hover", "box-shadow", css.get("box-shadow-1"));
   }
 
   &:focus {
-    background-color: css.get("button", "background-focus", "background-hover", "background", css.get("background"));
     border-color: css.get("button", "border-color-focus", "border-color-hover", "border-color", css.get("border-color-darker"));
-    box-shadow: css.get("button", "box-shadow-focus", "box-shadow-hover", "box-shadow", css.get("box-shadow-1"));
     color: css.get("button", "foreground-focus", "foreground-hover", "foreground", css.get("foreground"));
+    background-color: css.get("button", "background-focus", "background-hover", "background", css.get("background"));
+    box-shadow: css.get("button", "box-shadow-focus", "box-shadow-hover", "box-shadow", css.get("box-shadow-1"));
   }
 
   &:focus-visible {
     @include core.focus-ring-color(css.get("button", "accent", css.get("form-control-accent")));
 
-    background-color: css.get("button", "background-focus-visible", "background-focus", "background-hover", "background", css.get("background"));
     border-color: css.get("button", "border-color-focus-visible", "border-color-focus", "border-color-hover", "border-color", css.get("button", "accent", css.get("form-control-accent")));
-    box-shadow: css.get("button", "box-shadow-focus-visible", "box-shadow-focus", "box-shadow-hover", "box-shadow", none);
     color: css.get("button", "foreground-focus-visible", "foreground-focus", "foreground-hover", "foreground", css.get("foreground"));
+    background-color: css.get("button", "background-focus-visible", "background-focus", "background-hover", "background", css.get("background"));
+    box-shadow: css.get("button", "box-shadow-focus-visible", "box-shadow-focus", "box-shadow-hover", "box-shadow", none);
   }
 
   &:active {
-    background-color: css.get("button", "background-active", "background", css.get("background"));
     border-color: css.get("button", "border-color-active", "border-color", css.get("foreground"));
-    box-shadow: css.get("button", "box-shadow-active", "box-shadow", none);
     color: css.get("button", "foreground-active", "foreground", css.get("foreground"));
+    background-color: css.get("button", "background-active", "background", css.get("background"));
+    box-shadow: css.get("button", "box-shadow-active", "box-shadow", none);
   }
 
   &:disabled:not(.is-loading) {
-    opacity: css.get("button", "disabled-opacity", 0.6);
     pointer-events: none;
+    opacity: css.get("button", "disabled-opacity", 0.6);
   }
 
   &.is-loading {
-    color: transparent !important;
     pointer-events: none;
+    color: transparent !important;
 
     &::after {
       content: "";

--- a/packages/button/src/_mixins.scss
+++ b/packages/button/src/_mixins.scss
@@ -11,18 +11,18 @@
   @include core.form-control-properties("button");
   @include core.focus-ring-base;
 
-  align-items: center;
-  background-clip: border-box;
-  border-style: solid;
   cursor: pointer;
+  position: relative;
   display: inline-flex;
+  gap: css.get("button", "gap", css.get("spacing-sm"));
+  align-items: center;
+  justify-content: center;
+  border-style: solid;
   font-family: inherit;
   font-weight: inherit;
-  gap: css.get("button", "gap", css.get("spacing-sm"));
-  justify-content: center;
-  position: relative;
   text-decoration: none;
   white-space: nowrap;
+  background-clip: border-box;
 }
 
 /// Creates a button variant using custom properties and hsl relative values.

--- a/packages/card/src/_card.scss
+++ b/packages/card/src/_card.scss
@@ -5,30 +5,30 @@
 $-transition-property: background-color, border-color, box-shadow, transform;
 
 #{core.bem("card")} {
-  background: css.get("card", "background");
-  background-clip: padding-box;
-  border: css.get("card", "border", 1px solid css.get("border-color"));
-  border-radius: css.get("card", "border-radius", css.get("border-radius"));
-  box-shadow: css.get("card", "box-shadow", none);
-  color: css.get("card", "foreground", css.get("foreground-light"));
+  position: relative;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
-  position: relative;
+  border: css.get("card", "border", 1px solid css.get("border-color"));
+  border-radius: css.get("card", "border-radius", css.get("border-radius"));
+  color: css.get("card", "foreground", css.get("foreground-light"));
+  background: css.get("card", "background");
+  background-clip: padding-box;
+  box-shadow: css.get("card", "box-shadow", none);
+  transition-timing-function: css.get("card", "transition-timing-function", css.get("transition-timing-function"));
   transition-duration: css.get("card", "transition-duration", css.get("transition-duration"));
   transition-property: css.get("card", "transition-property", $-transition-property);
-  transition-timing-function: css.get("card", "transition-timing-function", css.get("transition-timing-function"));
 }
 
 a#{core.bem("card")} {
-  box-shadow: css.get("card", "link-box-shadow", css.get("box-shadow-2"));
   transform: translate(0, 0);
+  box-shadow: css.get("card", "link-box-shadow", css.get("box-shadow-2"));
 
   &:hover,
   &:focus,
   &:focus-within {
-    box-shadow: css.get("card", "link-box-shadow-hover", css.get("box-shadow-3"));
     transform: translate(0, css.get("card", "link-offset", -0.25em));
+    box-shadow: css.get("card", "link-box-shadow-hover", css.get("box-shadow-3"));
   }
 }
 
@@ -45,8 +45,8 @@ a#{core.bem("card")} {
   }
 
   &:last-child {
-    border-bottom-left-radius: css.get("card", "border-radius", css.get("border-radius"));
     border-bottom-right-radius: css.get("card", "border-radius", css.get("border-radius"));
+    border-bottom-left-radius: css.get("card", "border-radius", css.get("border-radius"));
   }
 }
 
@@ -74,37 +74,37 @@ a#{core.bem("card")} {
 
 #{core.bem("card", "image")} {
   flex: 0 1 auto;
-  height: auto;
   width: 100%;
+  height: auto;
 }
 
 #{core.bem("card", "title")} {
-  color: css.get("card", "title-color", css.get("foreground"));
   flex-grow: 1;
   font-size: css.get("card", "title-font-size", css.get("font-size-lg"));
   font-weight: css.get("card", "title-font-weight", css.get("font-weight-semi-bold"));
   line-height: css.get("card", "title-line-height", inherit);
+  color: css.get("card", "title-color", css.get("foreground"));
 }
 
 #{core.bem("card", "background")},
 #{core.bem("card", "screen")} {
   @include core.size(100%);
 
-  border-radius: css.get("card", "border-radius", css.get("border-radius"));
-  inset: 0;
   position: absolute;
+  inset: 0;
+  border-radius: css.get("card", "border-radius", css.get("border-radius"));
+  transition-timing-function: css.get("card", "transition-timing-function", css.get("transition-timing-function"));
   transition-duration: css.get("card", "transition-duration", css.get("transition-duration"));
   transition-property: css.get("card", "transition-property", $-transition-property);
-  transition-timing-function: css.get("card", "transition-timing-function", css.get("transition-timing-function"));
 }
 
 #{core.bem("card", "background")} {
-  object-fit: cover;
   z-index: 1;
+  object-fit: cover;
 }
 
 #{core.bem("card", "screen")} {
-  background: css.get("card", "screen-background");
-  opacity: css.get("card", "screen-opacity");
   z-index: 2;
+  opacity: css.get("card", "screen-opacity");
+  background: css.get("card", "screen-background");
 }

--- a/packages/checkbox/src/_checkbox.scss
+++ b/packages/checkbox/src/_checkbox.scss
@@ -7,66 +7,66 @@ $-background: css.get("checkbox", "background", css.get("form-control-background
 $-foreground: css.get("checkbox", "foreground", css.get("form-control-foreground"));
 
 #{core.bem("checkbox")} {
-  align-items: center;
+  position: relative;
   display: inline-flex;
   flex: 0 0 auto;
-  font-size: css.get("checkbox", "size", config.get("checkbox-size", "default"));
+  align-items: center;
   justify-content: center;
-  position: relative;
+  font-size: css.get("checkbox", "size", config.get("checkbox-size", "default"));
   vertical-align: middle;
 }
 
 #{core.bem("checkbox", "background")} {
   @include core.form-control-size;
 
-  align-items: center;
-  background-color: hsl(from $-accent h s l / css.get("checkbox", "background-opacity", css.get("form-control-background-opacity")));
-  border-radius: css.get("checkbox", "background-border-radius", css.get("form-control-background-border-radius"));
-  display: flex;
-  justify-content: center;
   position: relative;
   z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: css.get("checkbox", "background-border-radius", css.get("form-control-background-border-radius"));
+  background-color: hsl(from $-accent h s l / css.get("checkbox", "background-opacity", css.get("form-control-background-opacity")));
 }
 
 #{core.bem("checkbox", "box")} {
   @include core.size(css.get("checkbox", "box-size", 1.2em));
 
+  display: flex;
   align-items: center;
-  background-color: $-background;
+  justify-content: center;
   border: css.get("checkbox", "border-width", 2px) solid $-foreground;
   border-radius: css.get("checkbox", "border-radius", css.get("border-radius"));
   color: transparent;
-  display: flex;
-  justify-content: center;
+  background-color: $-background;
 }
 
 #{core.bem("checkbox", "icon")} {
   @include core.size(css.get("checkbox", "icon-size", 0.8em));
 
+  opacity: 0;
   background-color: $-background;
   mask-image: url(core.svg("check"));
-  mask-position: center calc(css.get("checkbox", "icon-size", 0.8em) * -1);
   mask-repeat: no-repeat;
+  mask-position: center calc(css.get("checkbox", "icon-size", 0.8em) * -1);
   mask-size: 100%;
-  opacity: 0;
 }
 
 #{core.bem("checkbox", "native")} {
   @include core.size(100%);
 
   cursor: pointer;
+  position: absolute;
+  z-index: 2;
+  top: 0;
   left: 0;
   opacity: 0;
-  position: absolute;
-  top: 0;
-  z-index: 2;
 
   &:hover + #{core.bem("checkbox", "background")} {
     background-color: hsl(from $-accent h s l / css.get("checkbox", "background-opacity-hover", css.get("form-control-background-opacity-hover")));
 
     #{core.bem("checkbox", "box")} {
-      background-color: $-background;
       border-color: $-accent;
+      background-color: $-background;
     }
   }
 
@@ -74,8 +74,8 @@ $-foreground: css.get("checkbox", "foreground", css.get("form-control-foreground
     background-color: hsl(from $-accent h s l / css.get("checkbox", "background-opacity-focus", css.get("form-control-background-opacity-focus")));
 
     #{core.bem("checkbox", "box")} {
-      background-color: $-background;
       border-color: $-accent;
+      background-color: $-background;
     }
   }
 
@@ -84,24 +84,24 @@ $-foreground: css.get("checkbox", "foreground", css.get("form-control-foreground
     background-color: hsl(from $-accent h s l / css.get("checkbox", "background-opacity-active", css.get("form-control-background-opacity-active")));
 
     #{core.bem("checkbox", "box")} {
-      background-color: $-background;
       border-color: $-accent;
+      background-color: $-background;
     }
   }
 
   &:checked + #{core.bem("checkbox", "background")},
   &:indeterminate + #{core.bem("checkbox", "background")} {
     #{core.bem("checkbox", "box")} {
-      background-color: $-accent;
       border-color: $-accent;
+      background-color: $-accent;
     }
 
     #{core.bem("checkbox", "icon")} {
-      mask-position: center center;
       opacity: 1;
+      mask-position: center center;
+      transition-timing-function: css.get("checkbox", "transition-timing-function", css.get("form-control-transition-timing-function"));
       transition-duration: css.get("checkbox", "transition-duration", css.get("form-control-transition-duration"));
       transition-property: opacity, mask-position;
-      transition-timing-function: css.get("checkbox", "transition-timing-function", css.get("form-control-transition-timing-function"));
     }
   }
 

--- a/packages/core/src/scss/library/_arrow.scss
+++ b/packages/core/src/scss/library/_arrow.scss
@@ -8,18 +8,18 @@
 ///   Valid options: "up", "down", "left", "right".
 ///
 @mixin arrow($direction: "down") {
-  border-width: css.get("arrow", "size", 6px 4px);
-  border-bottom-width: 0;
-  border-color: css.get("arrow", "color", currentcolor) transparent transparent;
-  border-radius: css.get("arrow", "radius", 2px);
-  border-style: solid;
+  pointer-events: none;
+  transform-origin: center;
   display: inline-block;
   flex-grow: 0;
   flex-shrink: 0;
-  height: 0;
-  pointer-events: none;
-  transform-origin: center;
   width: 0;
+  height: 0;
+  border-color: css.get("arrow", "color", currentcolor) transparent transparent;
+  border-style: solid;
+  border-width: css.get("arrow", "size", 6px 4px);
+  border-bottom-width: 0;
+  border-radius: css.get("arrow", "radius", 2px);
 
   @if $direction == "up" {
     transform: rotate(180deg);

--- a/packages/core/src/scss/library/_backdrop.scss
+++ b/packages/core/src/scss/library/_backdrop.scss
@@ -6,9 +6,9 @@
 ///   The component specific override option to add in the CSS variable chain.
 ///
 @mixin backdrop($component) {
-  background-color: css.get($component, "backdrop-color", css.get("backdrop-color"));
   content: "";
+  position: fixed;
   inset: 0;
   opacity: 0;
-  position: fixed;
+  background-color: css.get($component, "backdrop-color", css.get("backdrop-color"));
 }

--- a/packages/core/src/scss/library/_form-control.scss
+++ b/packages/core/src/scss/library/_form-control.scss
@@ -20,11 +20,11 @@
     padding: css.get($component, "padding", css.get("form-control-padding"));
   }
 
-  border-radius: css.get($component, "border-radius", css.get("form-control-border-radius"));
   border-width: css.get($component, "border-width", css.get("form-control-border-width"));
+  border-radius: css.get($component, "border-radius", css.get("form-control-border-radius"));
+  transition-timing-function: css.get($component, "transition-timing-function", css.get("form-control-transition-timing-function"));
   transition-duration: css.get($component, "transition-duration", css.get("form-control-transition-duration"));
   transition-property: css.get($component, "transition-property", css.get("form-control-transition-property"));
-  transition-timing-function: css.get($component, "transition-timing-function", css.get("form-control-transition-timing-function"));
 }
 
 /// Output the width and height with the form-control-size CSS variable value.

--- a/packages/core/src/scss/library/_loading-spinner.scss
+++ b/packages/core/src/scss/library/_loading-spinner.scss
@@ -17,16 +17,16 @@ $-output-spin-animation: true;
   @include size(css.get("loading", "size", 1em));
 
   @if $position == absolute or $position == fixed {
-    left: calc(50% - calc(css.get("loading", "size", 1em) * 0.5));
     top: calc(50% - calc(css.get("loading", "size", 1em) * 0.5));
+    left: calc(50% - calc(css.get("loading", "size", 1em) * 0.5));
   }
 
-  animation: spin css.get("loading", "duration", 0.6s) infinite linear;
+  position: $position;
+  display: inline-block;
   border: css.get("loading", "border", 2px solid);
   border-color: css.get("loading", "color", currentcolor) css.get("loading", "color", currentcolor) transparent transparent;
   border-radius: css.get("border-radius-circle");
-  display: inline-block;
-  position: $position;
+  animation: spin css.get("loading", "duration", 0.6s) infinite linear;
 
   // Only output the spin animation once
   @if $-output-spin-animation {

--- a/packages/core/src/scss/library/_scroll-flex.scss
+++ b/packages/core/src/scss/library/_scroll-flex.scss
@@ -1,8 +1,8 @@
 /// Output styles for a scrollable flex container.
 @mixin scroll-flex {
+  position: relative;
+  overflow: auto;
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  overflow: auto;
-  position: relative;
 }

--- a/packages/core/src/scss/library/_size.scss
+++ b/packages/core/src/scss/library/_size.scss
@@ -9,10 +9,10 @@
 ///
 @mixin size($width, $height: $width, $prefix: null) {
   @if $prefix {
-    #{$prefix}-height: $height;
     #{$prefix}-width: $width;
+    #{$prefix}-height: $height;
   } @else {
-    height: $height;
     width: $width;
+    height: $height;
   }
 }

--- a/packages/core/src/scss/library/_sr-only.scss
+++ b/packages/core/src/scss/library/_sr-only.scss
@@ -1,10 +1,10 @@
 /// Styles for displaying content meant only for screen readers.
 @mixin sr-only {
-  clip-path: inset(50%);
+  position: absolute;
+  overflow: hidden;
+  width: 1px;
   height: 1px;
   margin: -1px;
-  overflow: hidden;
   padding: 0;
-  position: absolute;
-  width: 1px;
+  clip-path: inset(50%);
 }

--- a/packages/dialog/src/_dialog.scss
+++ b/packages/dialog/src/_dialog.scss
@@ -5,19 +5,19 @@
 #{core.bem("dialog")} {
   @include core.focus-ring-base;
 
-  background: css.get("dialog", "background", css.get("background"));
-  background-clip: padding-box;
-  border: css.get("dialog", "border", css.get("border"));
-  border-radius: css.get("dialog", "border-radius", css.get("border-radius"));
-  box-shadow: css.get("dialog", "box-shadow", css.get("box-shadow-4"));
-  color: css.get("dialog", "foreground", css.get("foreground"));
+  position: relative;
+  overflow: auto;
   display: flex;
   flex-direction: column;
-  overflow: auto;
-  position: relative;
+  border: css.get("dialog", "border", css.get("border"));
+  border-radius: css.get("dialog", "border-radius", css.get("border-radius"));
+  color: css.get("dialog", "foreground", css.get("foreground"));
+  background: css.get("dialog", "background", css.get("background"));
+  background-clip: padding-box;
+  box-shadow: css.get("dialog", "box-shadow", css.get("box-shadow-4"));
+  transition-timing-function: css.get("dialog", "transition-timing-function", css.get("transition-timing-function"));
   transition-duration: css.get("dialog", "transition-duration", css.get("transition-duration"));
   transition-property: css.get("dialog", "transition-duration", (outline, border-color));
-  transition-timing-function: css.get("dialog", "transition-timing-function", css.get("transition-timing-function"));
 
   &:focus-visible,
   &[role="alertdialog"] {
@@ -44,18 +44,18 @@
 
 #{core.bem("dialog", "header")},
 #{core.bem("dialog", "footer")} {
-  align-items: center;
-  background: css.get("dialog", "background", css.get("background"));
+  position: sticky;
+  z-index: 1;
   display: flex;
   gap: css.get("dialog", "gap", 0.5em);
-  position: sticky;
+  align-items: center;
   vertical-align: middle;
-  z-index: 1;
+  background: css.get("dialog", "background", css.get("background"));
 }
 
 #{core.bem("dialog", "header")} {
-  border-bottom: css.get("dialog", "sep-border", css.get("border"));
   top: 0;
+  border-bottom: css.get("dialog", "sep-border", css.get("border"));
 }
 
 #{core.bem("dialog", "body")} {
@@ -67,14 +67,14 @@
 }
 
 #{core.bem("dialog", "footer")} {
-  border-top: css.get("dialog", "sep-border", css.get("border"));
   bottom: 0;
+  border-top: css.get("dialog", "sep-border", css.get("border"));
 }
 
 #{core.bem("dialog", "title")} {
-  color: css.get("dialog", "title-color", css.get("foreground"));
   flex-grow: 1;
   font-size: css.get("dialog", "title-font-size", css.get("font-size-lg"));
   font-weight: css.get("dialog", "title-font-weight", css.get("font-weight-semi-bold"));
   line-height: css.get("dialog", "title-line-height", inherit);
+  color: css.get("dialog", "title-color", css.get("foreground"));
 }

--- a/packages/drawer/src/scss/_drawer.scss
+++ b/packages/drawer/src/scss/_drawer.scss
@@ -3,38 +3,38 @@
 @use "@vrembem/core/css";
 
 #{core.bem(config.get("drawer-classes", "frame"))} {
+  position: relative;
+  overflow: hidden auto;
   display: flex;
   height: css.get("drawer", "frame-height", 100vh);
-  overflow: hidden auto;
-  position: relative;
 }
 
 #{core.bem(config.get("drawer-classes", "main"))} {
+  position: relative;
+  overflow: auto;
   flex: 1 1 auto;
   height: 100%;
-  overflow: auto;
-  position: relative;
 }
 
 #{core.bem("drawer")} {
-  inset: 0 auto 0 0;
-  max-width: css.get("drawer", "max-width", 80%);
   position: absolute;
-  width: css.get("drawer", "width", 18em);
   z-index: css.get("drawer", "z-index", 900);
+  inset: 0 auto 0 0;
+  width: css.get("drawer", "width", 18em);
+  max-width: css.get("drawer", "max-width", 80%);
 }
 
 #{core.bem("drawer", "dialog")} {
   @include css.override("dialog", config.get("drawer-dialog-override"));
 
-  border-bottom: none;
-  border-radius: 0;
-  border-top: none;
-  display: flex;
-  flex-direction: column;
+  position: absolute;
   inset: 0;
   overflow: auto;
-  position: absolute;
+  display: flex;
+  flex-direction: column;
+  border-top: none;
+  border-bottom: none;
+  border-radius: 0;
 }
 
 #{core.bem("drawer", "container")} {

--- a/packages/drawer/src/scss/_drawer_modal.scss
+++ b/packages/drawer/src/scss/_drawer_modal.scss
@@ -3,29 +3,29 @@
 @use "@vrembem/core/css";
 
 #{core.bem("drawer", null, "modal")} {
-  @include css.override("drawer", "z-index", 950);
-
-  inset: 0;
-  max-width: none;
   position: fixed;
-  visibility: hidden;
+  inset: 0;
   width: auto;
+  max-width: none;
+  visibility: hidden;
+
+  &::before {
+    @include core.backdrop("drawer");
+  }
 
   #{core.bem("drawer", "dialog")} {
     @include css.override("dialog", config.get("drawer-modal-dialog-override"));
 
     inset: 0 auto 0 0;
-    max-width: css.get("drawer", "max-width", 80%);
     width: css.get("drawer", "width", 18em);
+    max-width: css.get("drawer", "max-width", 80%);
   }
 
   &#{core.bem("drawer", null, "switch")} #{core.bem("drawer", "dialog")} {
     inset: 0 0 0 auto;
   }
 
-  &::before {
-    @include core.backdrop("drawer");
-  }
+  @include css.override("drawer", "z-index", 950);
 }
 
 #{core.bem("drawer", null, "modal")}.is-opening,

--- a/packages/grid/src/_grid.scss
+++ b/packages/grid/src/_grid.scss
@@ -4,10 +4,10 @@
 
 #{core.bem("grid")} {
   display: grid;
-  gap: css.get("grid", "gap-y", "gap", config.get("grid-gap", "default")) css.get("grid", "gap-x", "gap", config.get("grid-gap", "default"));
   grid-auto-flow: css.get("grid", "flow", config.get("grid-flow", "default"));
   grid-template-columns: repeat(css.get("grid", "cols", config.get("grid-cols", "default")), minmax(0, 1fr));
   grid-template-rows: repeat(css.get("grid", "rows", config.get("grid-rows", "default")), minmax(0, 1fr));
+  gap: css.get("grid", "gap-y", "gap", config.get("grid-gap", "default")) css.get("grid", "gap-x", "gap", config.get("grid-gap", "default"));
 }
 
 #{core.bem("grid", null, "inline")} {

--- a/packages/icon/src/_icon.scss
+++ b/packages/icon/src/_icon.scss
@@ -6,11 +6,11 @@
 #{core.bem("icon")} {
   @include mix.style(config.get("icon-style", "default"));
 
-  box-sizing: content-box;
   display: inline-block;
   flex-shrink: 0;
-  font-size: css.get("icon", "size", core.resolve-nth(config.get("icon-size", "default"), 1));
-  height: 1em;
-  vertical-align: top;
+  box-sizing: content-box;
   width: 1em;
+  height: 1em;
+  font-size: css.get("icon", "size", core.resolve-nth(config.get("icon-size", "default"), 1));
+  vertical-align: top;
 }

--- a/packages/input/src/_input.scss
+++ b/packages/input/src/_input.scss
@@ -3,25 +3,27 @@
 @use "./mixins" as mix;
 
 #{core.bem("input")} {
-  @include mix.base;
-
-  background-color: css.get("input", "background", css.get("background"));
   border-color: css.get("input", "border-color", css.get("border-color-dark"));
-  box-shadow: css.get("input", "box-shadow", inset 0 0.1rem 0.2rem rgb(0 0 0 / 10%));
   color: css.get("input", "foreground", css.get("foreground"));
+  background-color: css.get("input", "background", css.get("background"));
+  box-shadow: css.get("input", "box-shadow", inset 0 0.1rem 0.2rem rgb(0 0 0 / 10%));
+
+  &::placeholder {
+    color: css.get("input", "foreground-placeholder", css.get("foreground-lighter"));
+  }
 
   &:hover {
-    background-color: css.get("input", "background-hover", "background", css.get("background"));
     border-color: css.get("input", "border-color-hover", "border-color", css.get("border-color-darker"));
-    box-shadow: css.get("input", "box-shadow-hover", inset 0 0.1rem 0.2rem rgb(0 0 0 / 10%));
     color: css.get("input", "foreground-hover", "foreground", css.get("foreground"));
+    background-color: css.get("input", "background-hover", "background", css.get("background"));
+    box-shadow: css.get("input", "box-shadow-hover", inset 0 0.1rem 0.2rem rgb(0 0 0 / 10%));
   }
 
   &:focus {
-    background-color: css.get("input", "background-focus", "background", css.get("background"));
     border-color: css.get("input", "border-color-focus", "border-color", css.get("input", "accent", css.get("form-control-accent")));
-    box-shadow: css.get("input", "box-shadow-focus", none);
     color: css.get("input", "foreground-focus", "foreground", css.get("foreground"));
+    background-color: css.get("input", "background-focus", "background", css.get("background"));
+    box-shadow: css.get("input", "box-shadow-focus", none);
   }
 
   &:focus-visible {
@@ -33,11 +35,9 @@
   }
 
   &:disabled {
-    background-color: css.get("input", "background-disabled", css.get("background-darker"));
     pointer-events: none;
+    background-color: css.get("input", "background-disabled", css.get("background-darker"));
   }
 
-  &::placeholder {
-    color: css.get("input", "foreground-placeholder", css.get("foreground-lighter"));
-  }
+  @include mix.base;
 }

--- a/packages/input/src/_input_type.scss
+++ b/packages/input/src/_input_type.scss
@@ -2,12 +2,12 @@
 @use "@vrembem/core/css";
 
 #{core.bem("input", null, "type", "select")} {
-  background-image: css.get("input", "select-icon");
-  background-position: calc(100% - 0.75em) center;
-  background-repeat: no-repeat;
   cursor: pointer;
-  padding-right: 2em;
   position: relative;
+  padding-right: 2em;
+  background-image: css.get("input", "select-icon");
+  background-repeat: no-repeat;
+  background-position: calc(100% - 0.75em) center;
 
   &:read-only {
     background-color: css.get("input", "background", css.get("background"));

--- a/packages/input/src/_mixins.scss
+++ b/packages/input/src/_mixins.scss
@@ -8,11 +8,11 @@
   @include core.form-control-properties("input");
   @include core.focus-ring-base;
 
-  appearance: none;
-  border-style: solid;
-  display: block;
-  font-family: inherit;
-  max-width: 100%;
   position: relative;
+  display: block;
   width: 100%;
+  max-width: 100%;
+  border-style: solid;
+  font-family: inherit;
+  appearance: none;
 }

--- a/packages/menu/src/_menu.scss
+++ b/packages/menu/src/_menu.scss
@@ -4,71 +4,71 @@
 @use "./mixins" as mix;
 
 #{core.bem("menu")} {
-  align-items: stretch;
   display: flex;
   flex-direction: column;
-  font-size: css.get("menu", "size", css.get("form-control-size"));
   gap: css.get("menu", "gap", 1px);
+  align-items: stretch;
+  font-size: css.get("menu", "size", css.get("form-control-size"));
   line-height: css.get("menu", "line-height", css.get("form-control-line-height"));
   list-style: none;
 }
 
 #{core.bem("menu", "sep")} {
-  align-self: stretch;
-  background: css.get("menu", "sep-background", css.get("border-color"));
   flex: 0 0 auto;
+  align-self: stretch;
+  width: auto;
   height: css.get("menu", "sep-size", 1px);
   margin: css.get("menu", "sep-gap", 0.5em) 0;
-  width: auto;
+  background: css.get("menu", "sep-background", css.get("border-color"));
 }
 
 #{core.bem("menu", "action")} {
   @include mix.action-base;
 
-  background-color: css.get("menu", "background", transparent);
   border-color: css.get("menu", "border-color", transparent);
-  box-shadow: css.get("menu", "box-shadow", none);
   color: css.get("menu", "foreground", css.get("foreground"));
+  background-color: css.get("menu", "background", transparent);
+  box-shadow: css.get("menu", "box-shadow", none);
 
   &:hover {
-    background-color: css.get("menu", "background-hover", "background", css.get("background-hover"));
     border-color: css.get("menu", "border-color-hover", "border-color", transparent);
-    box-shadow: css.get("menu", "box-shadow-hover", "box-shadow", none);
     color: css.get("menu", "foreground-hover", "foreground", css.get("foreground"));
+    background-color: css.get("menu", "background-hover", "background", css.get("background-hover"));
+    box-shadow: css.get("menu", "box-shadow-hover", "box-shadow", none);
   }
 
   &:focus {
-    background-color: css.get("menu", "background-focus", "background-hover", "background", css.get("background-hover"));
     border-color: css.get("menu", "border-color-focus", "border-color-hover", "border-color", transparent);
-    box-shadow: css.get("menu", "box-shadow-focus", "box-shadow-hover", "box-shadow", none);
     color: css.get("menu", "foreground-focus", "foreground-hover", "foreground", css.get("foreground"));
+    background-color: css.get("menu", "background-focus", "background-hover", "background", css.get("background-hover"));
+    box-shadow: css.get("menu", "box-shadow-focus", "box-shadow-hover", "box-shadow", none);
   }
 
   &:focus-visible {
     @include core.focus-ring-color(css.get("menu", "accent", css.get("form-control-accent")));
 
-    background-color: css.get("menu", "background-focus-visible", "background-focus", "background-hover", "background", css.get("background-hover"));
     border-color: css.get("menu", "border-color-focus-visible", "border-color-focus", "border-color-hover", "border-color", css.get("menu", "accent", css.get("form-control-accent")));
-    box-shadow: css.get("menu", "box-shadow-focus-visible", "box-shadow-focus", "box-shadow-hover", "box-shadow", none);
     color: css.get("menu", "foreground-focus-visible", "foreground-focus", "foreground-hover", "foreground", css.get("foreground"));
+    background-color: css.get("menu", "background-focus-visible", "background-focus", "background-hover", "background", css.get("background-hover"));
+    box-shadow: css.get("menu", "box-shadow-focus-visible", "box-shadow-focus", "box-shadow-hover", "box-shadow", none);
   }
 
   &:active {
-    background-color: css.get("menu", "background-active", "background", css.get("background-active"));
     border-color: css.get("menu", "border-color-active", "border-color", transparent);
-    box-shadow: css.get("menu", "box-shadow-active", "box-shadow", none);
     color: css.get("menu", "foreground-active", "foreground", css.get("foreground"));
+    background-color: css.get("menu", "background-active", "background", css.get("background-active"));
+    box-shadow: css.get("menu", "box-shadow-active", "box-shadow", none);
   }
 
   &:disabled:not(.is-active) {
-    background-color: css.get("menu", "disabled-background", none);
-    color: css.get("menu", "disabled-foreground", css.get("foreground-lighter"));
     pointer-events: none;
+    color: css.get("menu", "disabled-foreground", css.get("foreground-lighter"));
+    background-color: css.get("menu", "disabled-background", none);
   }
 
   &.is-active {
-    background-color: css.get("menu", "active-background", none);
     color: css.get("menu", "active-foreground", palette.get("primary"));
+    background-color: css.get("menu", "active-background", none);
   }
 }
 

--- a/packages/menu/src/_menu_inline.scss
+++ b/packages/menu/src/_menu_inline.scss
@@ -3,13 +3,13 @@
 @use "@vrembem/core/css";
 
 #{core.bem("menu", null, "inline")} {
-  align-items: center;
   flex-direction: row;
+  align-items: center;
 
   #{core.bem("menu", "sep")} {
+    width: css.get("menu", "sep-size", 1px);
     height: auto;
     margin: 0 css.get("menu", "sep-gap", 0.5em);
-    width: css.get("menu", "sep-size", 1px);
   }
 
   #{core.bem("menu", "action")} {
@@ -21,13 +21,13 @@
 @each $bp, $value in config.get("menu-inline-breakpoints") {
   @include core.media-min($value) {
     #{core.bem("menu", null, "inline", $bp: $bp)} {
-      align-items: center;
       flex-direction: row;
+      align-items: center;
 
       #{core.bem("menu", "sep")} {
+        width: css.get("menu", "sep-size", 1px);
         height: auto;
         margin: 0 css.get("menu", "sep-gap", 0.5em);
-        width: css.get("menu", "sep-size", 1px);
       }
 
       #{core.bem("menu", "action")} {

--- a/packages/menu/src/_mixins.scss
+++ b/packages/menu/src/_mixins.scss
@@ -9,17 +9,17 @@
   @include core.form-control-properties("menu");
   @include core.focus-ring-base;
 
-  align-items: center;
-  background-clip: border-box;
-  border-style: solid;
   cursor: pointer;
+  position: relative;
   display: flex;
+  gap: css.get("menu", "action-gap", 0.5em);
+  align-items: center;
+  justify-content: flex-start;
+  width: 100%;
+  border-style: solid;
   font-family: inherit;
   font-weight: inherit;
-  gap: css.get("menu", "action-gap", 0.5em);
-  justify-content: flex-start;
-  position: relative;
   text-decoration: none;
   white-space: normal;
-  width: 100%;
+  background-clip: border-box;
 }

--- a/packages/modal/src/scss/_modal.scss
+++ b/packages/modal/src/scss/_modal.scss
@@ -3,16 +3,16 @@
 @use "@vrembem/core/css";
 
 #{core.bem("modal")} {
-  align-items: center;
+  position: fixed;
+  z-index: css.get("modal", "z-index", 1000);
+  inset: 0;
   display: flex;
   flex-direction: column;
-  height: 0;
-  inset: 0;
+  align-items: center;
   justify-content: center;
-  position: fixed;
-  visibility: hidden;
   width: 0;
-  z-index: css.get("modal", "z-index", 1000);
+  height: 0;
+  visibility: hidden;
 
   &::before {
     @include core.backdrop("modal");
@@ -22,14 +22,14 @@
 #{core.bem("modal", "dialog")} {
   @include css.override("dialog", config.get("modal-dialog-override"));
 
-  display: flex;
-  flex-direction: column;
-  max-width: css.get("modal", "max-width", 100%);
-  opacity: 0;
-  overflow: auto;
   position: relative;
   transform: translateY(calc(css.get("modal", "travel", 5em) * -1));
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
   width: css.get("modal", "width", config.get("modal-size", "default"));
+  max-width: css.get("modal", "max-width", 100%);
+  opacity: 0;
 }
 
 #{core.bem("modal", "container")} {
@@ -39,10 +39,10 @@
 #{core.bem("modal")}.is-opening,
 #{core.bem("modal")}.is-opened,
 #{core.bem("modal")}.is-closing {
+  width: 100%;
   height: 100%;
   padding: css.get("modal", "margin", 1em);
   visibility: visible;
-  width: 100%;
 }
 
 #{core.bem("modal")}.is-opening,
@@ -52,9 +52,9 @@
   }
 
   #{core.bem("modal", "dialog")} {
+    transition-timing-function: css.get("modal", "transition-timing-function", css.get("transition-timing-function"));
     transition-duration: css.get("modal", "transition-duration", css.get("transition-duration"));
     transition-property: opacity, transform;
-    transition-timing-function: css.get("modal", "transition-timing-function", css.get("transition-timing-function"));
   }
 }
 
@@ -65,7 +65,7 @@
   }
 
   #{core.bem("modal", "dialog")} {
-    opacity: 1;
     transform: translateY(0);
+    opacity: 1;
   }
 }

--- a/packages/modal/src/scss/_modal_full.scss
+++ b/packages/modal/src/scss/_modal_full.scss
@@ -3,10 +3,10 @@
 
 #{core.bem("modal", null, "full")} {
   #{core.bem("modal", "dialog")} {
-    height: 100%;
-    max-width: none;
     transform: scale(css.get("modal", "full-scale", 0.75));
     width: 100%;
+    max-width: none;
+    height: 100%;
   }
 
   &.is-opening #{core.bem("modal", "dialog")},

--- a/packages/notice/src/_notice.scss
+++ b/packages/notice/src/_notice.scss
@@ -3,12 +3,12 @@
 @use "@vrembem/core/css";
 
 #{core.bem("notice")} {
-  background: hsl(from css.get("notice", "color", config.get("notice-color", "default")) h s css.get("notice", "background-lightness"));
+  padding: css.get("notice", "padding", 1em 1.25em);
   border: css.get("notice", "border", none);
   border-radius: css.get("notice", "border-radius", css.get("border-radius"));
-  box-shadow: css.get("notice", "box-shadow", none);
   color: hsl(from css.get("notice", "color", config.get("notice-color", "default")) h s css.get("notice", "foreground-lightness"));
-  padding: css.get("notice", "padding", 1em 1.25em);
+  background: hsl(from css.get("notice", "color", config.get("notice-color", "default")) h s css.get("notice", "background-lightness"));
+  box-shadow: css.get("notice", "box-shadow", none);
 
   > * + * {
     margin-top: css.get("notice", "spacing", 0.5em);

--- a/packages/popover/src/scss/_popover.scss
+++ b/packages/popover/src/scss/_popover.scss
@@ -5,35 +5,35 @@
 $-offset: calc(calc(css.get("popover", "offset") + 1) * 1px);
 
 #{core.bem("popover")} {
-  background: css.get("popover", "background", var.$background);
-  background-clip: padding-box;
-  border: css.get("popover", "border", var.$border);
-  border-radius: css.get("popover", "border-radius", var.$border-radius);
-  box-shadow: css.get("popover", "box-shadow", var.$box-shadow);
-  color: css.get("popover", "foreground", var.$foreground);
-  display: block;
-  font-size: css.get("popover", "font-size", var.$font-size);
-  left: 0;
-  line-height: css.get("popover", "line-height", var.$line-height);
-  margin: 0;
-  max-width: css.get("popover", "max-width", var.$max-width);
-  opacity: 0;
-  padding: css.get("popover", "padding", var.$padding);
   pointer-events: none;
   position: absolute;
+  z-index: css.get("popover", "z-index", var.$z-index);
   top: 0;
+  left: 0;
+  display: block;
+  width: css.get("popover", "width", var.$width);
+  max-width: css.get("popover", "max-width", var.$max-width);
+  margin: 0;
+  padding: css.get("popover", "padding", var.$padding);
+  border: css.get("popover", "border", var.$border);
+  border-radius: css.get("popover", "border-radius", var.$border-radius);
+  font-size: css.get("popover", "font-size", var.$font-size);
+  line-height: css.get("popover", "line-height", var.$line-height);
+  color: css.get("popover", "foreground", var.$foreground);
+  opacity: 0;
+  background: css.get("popover", "background", var.$background);
+  background-clip: padding-box;
+  box-shadow: css.get("popover", "box-shadow", var.$box-shadow);
+  transition-timing-function: css.get("popover", "transition-timing-function", var.$transition-timing-function);
   transition-duration: css.get("popover", "transition-duration", var.$transition-duration);
   transition-property: css.get("popover", "transition-property", var.$transition-property);
-  transition-timing-function: css.get("popover", "transition-timing-function", var.$transition-timing-function);
-  width: css.get("popover", "width", var.$width);
-  z-index: css.get("popover", "z-index", var.$z-index);
 
   &::before {
     content: "";
-    height: $-offset;
-    inset: auto 0 100%;
     position: absolute;
+    inset: auto 0 100%;
     width: 100%;
+    height: $-offset;
   }
 
   &.is-virtual {
@@ -45,9 +45,9 @@ $-offset: calc(calc(css.get("popover", "offset") + 1) * 1px);
   }
 
   &.is-active {
-    opacity: 1;
     pointer-events: auto;
     z-index: calc(css.get("popover", "z-index", var.$z-index) + 1);
+    opacity: 1;
   }
 
   &:hover,
@@ -58,25 +58,25 @@ $-offset: calc(calc(css.get("popover", "offset") + 1) * 1px);
 }
 
 #{core.bem("popover")}[data-floating-placement^="top"]::before {
-  height: $-offset;
   inset: 100% 0 auto;
   width: 100%;
+  height: $-offset;
 }
 
 #{core.bem("popover")}[data-floating-placement^="bottom"]::before {
-  height: $-offset;
   inset: auto 0 100%;
   width: 100%;
+  height: $-offset;
 }
 
 #{core.bem("popover")}[data-floating-placement^="left"]::before {
-  height: 100%;
   inset: 0 auto 0 100%;
   width: $-offset;
+  height: 100%;
 }
 
 #{core.bem("popover")}[data-floating-placement^="right"]::before {
-  height: 100%;
   inset: 0 100% 0 auto;
   width: $-offset;
+  height: 100%;
 }

--- a/packages/popover/src/scss/_popover__arrow.scss
+++ b/packages/popover/src/scss/_popover__arrow.scss
@@ -6,17 +6,17 @@
 #{core.bem("popover", "arrow")}::after {
   @include core.size(css.get("popover", "arrow-size", var.$arrow-size));
 
-  background-color: inherit;
   position: absolute;
-  visibility: hidden;
   z-index: -1;
+  visibility: hidden;
+  background-color: inherit;
 }
 
 #{core.bem("popover", "arrow")}::after {
-  background-clip: padding-box;
   content: "";
   transform: rotate(45deg);
   visibility: visible;
+  background-clip: padding-box;
 }
 
 [data-floating-placement^="top"] > #{core.bem("popover", "arrow")} {

--- a/packages/radio/src/_radio.scss
+++ b/packages/radio/src/_radio.scss
@@ -7,63 +7,63 @@ $-background: css.get("radio", "background", css.get("form-control-background"))
 $-foreground: css.get("radio", "foreground", css.get("form-control-foreground")) !default;
 
 #{core.bem("radio")} {
-  align-items: center;
+  position: relative;
   display: inline-flex;
   flex: 0 0 auto;
-  font-size: css.get("radio", "size", config.get("radio-size", "default"));
+  align-items: center;
   justify-content: center;
-  position: relative;
+  font-size: css.get("radio", "size", config.get("radio-size", "default"));
   vertical-align: middle;
 }
 
 #{core.bem("radio", "background")} {
   @include core.form-control-size;
 
-  align-items: center;
-  background-color: hsl(from $-accent h s l / css.get("radio", "background-opacity", css.get("form-control-background-opacity")));
-  border-radius: css.get("radio", "background-border-radius", css.get("form-control-background-border-radius"));
-  display: flex;
-  justify-content: center;
   position: relative;
   z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: css.get("radio", "background-border-radius", css.get("form-control-background-border-radius"));
+  background-color: hsl(from $-accent h s l / css.get("radio", "background-opacity", css.get("form-control-background-opacity")));
 }
 
 #{core.bem("radio", "circle")} {
   @include core.size(css.get("radio", "circle-size", 1.25em));
 
+  display: flex;
   align-items: center;
-  background-color: $-background;
+  justify-content: center;
   border: css.get("radio", "border-width", 2px) solid $-foreground;
   border-radius: css.get("radio", "circle-size", 1.25em);
   color: transparent;
-  display: flex;
-  justify-content: center;
+  background-color: $-background;
 }
 
 #{core.bem("radio", "dot")} {
   @include core.size(0);
 
-  background-color: $-background;
   border-radius: css.get("radio", "dot-size", 0.5em);
   opacity: 0;
+  background-color: $-background;
 }
 
 #{core.bem("radio", "native")} {
   @include core.size(100%);
 
   cursor: pointer;
+  position: absolute;
+  z-index: 2;
+  top: 0;
   left: 0;
   opacity: 0;
-  position: absolute;
-  top: 0;
-  z-index: 2;
 
   &:hover + #{core.bem("radio", "background")} {
     background-color: hsl(from $-accent h s l / css.get("radio", "background-opacity-hover", css.get("form-control-background-opacity-hover")));
 
     #{core.bem("radio", "circle")} {
-      background-color: $-background;
       border-color: $-accent;
+      background-color: $-background;
     }
   }
 
@@ -71,8 +71,8 @@ $-foreground: css.get("radio", "foreground", css.get("form-control-foreground"))
     background-color: hsl(from $-accent h s l / css.get("radio", "background-opacity-focus", css.get("form-control-background-opacity-focus")));
 
     #{core.bem("radio", "circle")} {
-      background-color: $-background;
       border-color: $-accent;
+      background-color: $-background;
     }
   }
 
@@ -81,25 +81,25 @@ $-foreground: css.get("radio", "foreground", css.get("form-control-foreground"))
     background-color: hsl(from $-accent h s l / css.get("radio", "background-opacity-active", css.get("form-control-background-opacity-active")));
 
     #{core.bem("radio", "circle")} {
-      background-color: $-background;
       border-color: $-accent;
+      background-color: $-background;
     }
   }
 
   &:checked + #{core.bem("radio", "background")} {
     #{core.bem("radio", "circle")} {
-      background-color: $-accent;
       border-color: $-accent;
+      background-color: $-accent;
     }
 
     #{core.bem("radio", "dot")} {
       @include core.size(css.get("radio", "dot-size", 0.5em));
 
-      background-position: center center;
       opacity: 1;
+      background-position: center center;
+      transition-timing-function: css.get("radio", "transition-timing-function", css.get("form-control-transition-timing-function"));
       transition-duration: css.get("radio", "transition-duration", css.get("form-control-transition-duration"));
       transition-property: opacity, width, height;
-      transition-timing-function: css.get("radio", "transition-timing-function", css.get("form-control-transition-timing-function"));
     }
   }
 }

--- a/packages/section/src/_section.scss
+++ b/packages/section/src/_section.scss
@@ -3,40 +3,40 @@
 @use "./config" as var;
 
 #{core.bem("section")} {
-  background: css.get("section", "background");
-  color: css.get("section", "foreground");
+  position: relative;
   display: flex;
   flex-direction: column;
   padding: css.get("section", "padding");
-  position: relative;
+  color: css.get("section", "foreground");
+  background: css.get("section", "background");
 
   @include core.css-query("section", "padding", var.$padding, var.$breakpoints);
 }
 
 #{core.bem("section", "container")} {
-  margin: auto;
-  max-width: css.get("section", "max-width");
   position: relative;
-  width: 100%;
   z-index: 3;
+  width: 100%;
+  max-width: css.get("section", "max-width");
+  margin: auto;
 }
 
 #{core.bem("section", "image")},
 #{core.bem("section", "screen")} {
   @include core.size(100%);
 
-  inset: 0;
   position: absolute;
+  inset: 0;
 }
 
 #{core.bem("section", "image")} {
-  object-fit: cover;
-  opacity: css.get("section", "image-opacity");
   z-index: 1;
+  opacity: css.get("section", "image-opacity");
+  object-fit: cover;
 }
 
 #{core.bem("section", "screen")} {
-  background: css.get("section", "screen-background");
-  opacity: css.get("section", "screen-opacity");
   z-index: 2;
+  opacity: css.get("section", "screen-opacity");
+  background: css.get("section", "screen-background");
 }

--- a/packages/switch/src/_switch.scss
+++ b/packages/switch/src/_switch.scss
@@ -9,35 +9,35 @@ $-size: css.get("switch", "size", config.get("switch-size", "default"));
 $-thumb-size: calc(css.get("switch", "track-size", 1.25em) - calc(css.get("switch", "border-width", 2px) * 2));
 
 #{core.bem("switch")} {
-  align-items: center;
+  position: relative;
   display: inline-flex;
   flex: 0 0 auto;
-  font-size: $-size;
+  align-items: center;
   justify-content: center;
-  padding-left: calc(css.get("core", "form-control-size-calc") * 0.25);
   padding-right: calc(css.get("core", "form-control-size-calc") * 0.25);
-  position: relative;
+  padding-left: calc(css.get("core", "form-control-size-calc") * 0.25);
+  font-size: $-size;
   vertical-align: middle;
 }
 
 #{core.bem("switch", "background")} {
   @include core.form-control-size;
 
-  align-items: center;
-  display: flex;
-  justify-content: center;
   position: relative;
   z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
   &::after {
     @include core.form-control-size;
 
-    background-color: hsl(from $-accent h s l / css.get("switch", "background-opacity", css.get("form-control-background-opacity")));
-    border-radius: css.get("switch", "background-border-radius", css.get("form-control-background-border-radius"));
     content: "";
-    left: calc(calc(css.get("core", "form-control-size-calc") * 0.25) * -1);
     position: absolute;
     top: 0;
+    left: calc(calc(css.get("core", "form-control-size-calc") * 0.25) * -1);
+    border-radius: css.get("switch", "background-border-radius", css.get("form-control-background-border-radius"));
+    background-color: hsl(from $-accent h s l / css.get("switch", "background-opacity", css.get("form-control-background-opacity")));
     transition: left css.get("switch", "transition-duration", css.get("form-control-transition-duration")) css.get("switch", "transition-timing-function", css.get("form-control-transition-timing-function"));
   }
 }
@@ -45,36 +45,36 @@ $-thumb-size: calc(css.get("switch", "track-size", 1.25em) - calc(css.get("switc
 #{core.bem("switch", "track")} {
   @include core.size(100%, css.get("switch", "track-size", 1.25em));
 
-  background-color: hsl(from $-foreground h s l / 20%);
+  position: relative;
+  display: block;
   border: css.get("switch", "border-width", 2px) solid $-foreground;
   border-radius: css.get("switch", "border-radius", css.get("border-radius-circle"));
-  display: block;
-  position: relative;
+  background-color: hsl(from $-foreground h s l / 20%);
 }
 
 #{core.bem("switch", "thumb")} {
   @include core.size($-thumb-size);
 
-  background-color: $-background;
-  border-radius: css.get("switch", "border-radius", css.get("border-radius-circle"));
-  box-shadow: 0 0 0 css.get("switch", "border-width", 2px) $-foreground;
-  display: block;
-  left: 0;
   position: absolute;
-  top: 0;
-  transition: left css.get("switch", "transition-duration", css.get("form-control-transition-duration")) css.get("switch", "transition-timing-function", css.get("form-control-transition-timing-function"));
   z-index: 1;
+  top: 0;
+  left: 0;
+  display: block;
+  border-radius: css.get("switch", "border-radius", css.get("border-radius-circle"));
+  background-color: $-background;
+  box-shadow: 0 0 0 css.get("switch", "border-width", 2px) $-foreground;
+  transition: left css.get("switch", "transition-duration", css.get("form-control-transition-duration")) css.get("switch", "transition-timing-function", css.get("form-control-transition-timing-function"));
 }
 
 #{core.bem("switch", "native")} {
   @include core.size(100%);
 
   cursor: pointer;
+  position: absolute;
+  z-index: 2;
+  top: 0;
   left: 0;
   opacity: 0;
-  position: absolute;
-  top: 0;
-  z-index: 2;
 
   &:hover + #{core.bem("switch", "background")} {
     &::after {
@@ -113,13 +113,13 @@ $-thumb-size: calc(css.get("switch", "track-size", 1.25em) - calc(css.get("switc
     }
 
     #{core.bem("switch", "track")} {
-      background-color: $-accent;
       border-color: $-accent;
+      background-color: $-accent;
     }
 
     #{core.bem("switch", "thumb")} {
-      box-shadow: 0 0 0 css.get("switch", "border-width", 2px) $-accent;
       left: calc(100% - #{$-thumb-size});
+      box-shadow: 0 0 0 css.get("switch", "border-width", 2px) $-accent;
     }
   }
 }

--- a/packages/table/src/_mixins.scss
+++ b/packages/table/src/_mixins.scss
@@ -18,30 +18,30 @@
 
   thead,
   [rowspan] {
-    left: -9999px;
     position: absolute;
     top: -9999px;
+    left: -9999px;
   }
 
   [#{var.$mobile-label-attr}] {
-    padding-left: calc(css.get("table", "mobile-label-width") + css.get("table", "mobile-label-spacing"));
     position: relative;
+    padding-left: calc(css.get("table", "mobile-label-width") + css.get("table", "mobile-label-spacing"));
     white-space: normal;
 
     &::before {
-      background-color: css.get("table", "mobile-label-background");
-      bottom: 0;
-      color: css.get("table", "mobile-label-foreground");
       content: attr(#{var.$mobile-label-attr});
-      font-weight: css.get("font-weight-bold");
+      position: absolute;
+      top: 0;
+      bottom: 0;
       left: 0;
       overflow: hidden;
-      padding: css.get("table", "padding");
-      position: absolute;
-      text-overflow: ellipsis;
-      top: 0;
-      white-space: nowrap;
       width: css.get("table", "mobile-label-width");
+      padding: css.get("table", "padding");
+      font-weight: css.get("font-weight-bold");
+      color: css.get("table", "mobile-label-foreground");
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      background-color: css.get("table", "mobile-label-background");
     }
   }
 

--- a/packages/table/src/_table.scss
+++ b/packages/table/src/_table.scss
@@ -2,10 +2,10 @@
 @use "@vrembem/core/css";
 
 #{core.bem("table")} {
-  background-color: css.get("table", "background");
+  width: 100%;
   color: css.get("table", "foreground");
   text-align: left;
-  width: 100%;
+  background-color: css.get("table", "background");
 
   th,
   td,
@@ -20,6 +20,6 @@
 }
 
 #{core.bem("table", "auto")} {
-  white-space: nowrap;
   width: 0;
+  white-space: nowrap;
 }

--- a/packages/table/src/_table_hover.scss
+++ b/packages/table/src/_table_hover.scss
@@ -9,8 +9,8 @@
 
   tbody tr:hover,
   tbody tr:focus {
-    background-color: css.get("table", "background-hover");
-    color: css.get("table", "foreground-hover");
     z-index: 2;
+    color: css.get("table", "foreground-hover");
+    background-color: css.get("table", "background-hover");
   }
 }

--- a/packages/utility/src/modules/_margin.scss
+++ b/packages/utility/src/modules/_margin.scss
@@ -36,15 +36,15 @@ $-utility-spacing: config.get("utility-spacing");
 
   @each $key, $value in $-utility-spacing {
     #{fun.selector("margin", "x", $key)} {
-      margin-left: fun.maybe-important($value);
       margin-right: fun.maybe-important($value);
+      margin-left: fun.maybe-important($value);
     }
   }
 
   @each $key, $value in $-utility-spacing {
     #{fun.selector("margin", "y", $key)} {
-      margin-bottom: fun.maybe-important($value);
       margin-top: fun.maybe-important($value);
+      margin-bottom: fun.maybe-important($value);
     }
   }
 
@@ -69,12 +69,12 @@ $-utility-spacing: config.get("utility-spacing");
   }
 
   #{fun.selector("margin", "x", "auto")} {
-    margin-left: fun.maybe-important(auto);
     margin-right: fun.maybe-important(auto);
+    margin-left: fun.maybe-important(auto);
   }
 
   #{fun.selector("margin", "y", "auto")} {
-    margin-bottom: fun.maybe-important(auto);
     margin-top: fun.maybe-important(auto);
+    margin-bottom: fun.maybe-important(auto);
   }
 }

--- a/packages/utility/src/modules/_padding.scss
+++ b/packages/utility/src/modules/_padding.scss
@@ -36,15 +36,15 @@ $-utility-spacing: config.get("utility-spacing");
 
   @each $key, $value in $-utility-spacing {
     #{fun.selector("padding", "x", $key)} {
-      padding-left: fun.maybe-important($value);
       padding-right: fun.maybe-important($value);
+      padding-left: fun.maybe-important($value);
     }
   }
 
   @each $key, $value in $-utility-spacing {
     #{fun.selector("padding", "y", $key)} {
-      padding-bottom: fun.maybe-important($value);
       padding-top: fun.maybe-important($value);
+      padding-bottom: fun.maybe-important($value);
     }
   }
 }

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -1,10 +1,9 @@
 export default {
-  extends: ["stylelint-config-standard-scss"],
-  plugins: ["stylelint-prettier", "stylelint-order"],
+  extends: ["stylelint-config-standard-scss", "stylelint-config-clean-order"],
+  plugins: ["stylelint-prettier"],
   ignoreFiles: ["**/dev/**/*", "**/dist/**/*"],
   rules: {
     "prettier/prettier": true,
-    "order/properties-alphabetical-order": true,
     "function-url-quotes": null,
     "selector-class-pattern": [
       "^[a-z0-9-_:]+$",

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  extends: ["stylelint-config-standard-scss", "stylelint-config-clean-order"],
+  extends: ["stylelint-config-clean-order", "stylelint-config-standard-scss"],
   plugins: ["stylelint-prettier"],
   ignoreFiles: ["**/dev/**/*", "**/dist/**/*"],
   rules: {


### PR DESCRIPTION
## What changed?

After using the alphabetical order for some time now, I think it just makes more idiomatic sense to apply a CSS property order that groups properties in a logic way. This PR introduces the `stylelint-config-clean-order` package to accomplish this.
