### PR TITLE
Improve the popover component and config module integration

### DIFF
--- a/docs/src/components/CodeBlock.astro
+++ b/docs/src/components/CodeBlock.astro
@@ -35,7 +35,7 @@ if (icon) classes.push("has-icon");
     )
   }
   <Popover
-    virtual={true}
+    followCursor={true}
     triggerClass="code-block__copy-button"
     popoverClass="popover_copy"
     aria-label="Copy code example to clipboard"

--- a/docs/src/components/Popover.astro
+++ b/docs/src/components/Popover.astro
@@ -2,7 +2,7 @@
 interface Props {
   id?: string;
   arrow?: boolean;
-  virtual?: boolean;
+  followCursor?: boolean;
   href?: string;
   label?: string;
   triggerClass?: string;
@@ -14,7 +14,7 @@ interface Props {
 const {
   id,
   arrow,
-  virtual,
+  followCursor,
   href,
   label,
   triggerClass = "link",
@@ -29,13 +29,12 @@ const triggerId = `popover-trigger-${uid}`;
 const popoverId = Astro.slots.has("default") ? `popover-${uid}` : null;
 const tooltipId = Astro.slots.has("tooltip") ? `popover-tooltip-${uid}` : null;
 
-const css = {};
+const css: Record<string, string> = {};
 if (placement) {
   css["--vb-popover-placement"] = placement;
 }
-if (virtual) {
-  popoverClass = `${popoverClass} is-virtual`.trim();
-  tooltipClass = `${tooltipClass} is-virtual`.trim();
+if (followCursor) {
+  css["--vb-popover-follow-cursor"] = "true";
 }
 ---
 

--- a/docs/src/modules/ReferenceTableEntry.js
+++ b/docs/src/modules/ReferenceTableEntry.js
@@ -52,9 +52,18 @@ export class ReferenceTableEntry extends CollectionEntry {
     if (this.config.get("expandable")) {
       // Set the height variable
       const padding = 42; // Kind of a magic number atm
+
+      // Set the expanded height
       this.expandHeight =
         this.table.offsetHeight + this.footer.offsetHeight + padding;
 
+      // If a header exists, add it to the height
+      const header = this.el.querySelector(".reference-table__header");
+      if (header) {
+        this.expandHeight = this.expandHeight + header.offsetHeight;
+      }
+
+      // Add toggle button event listener
       this.expandBtn.addEventListener("click", () => {
         this.expandToggle();
       });

--- a/docs/src/modules/usePopover.js
+++ b/docs/src/modules/usePopover.js
@@ -15,7 +15,7 @@ if (typeof window !== "undefined") {
     }
   });
 
-  window["popover"] = await popovers.mount();
+  window["popovers"] = await popovers.mount();
 }
 
 export { popovers };

--- a/docs/src/packages/core/plugins/css-config.mdx
+++ b/docs/src/packages/core/plugins/css-config.mdx
@@ -68,7 +68,7 @@ The following configurations can be used to customize the behavior of the `cssCo
   The unique name of the plugin.
 </ReferenceCard>
 
-<ReferenceCard name="sourceKey" type="string" defaults='"attr"'>
+<ReferenceCard name="sourceKey" type="string" defaults='"css"'>
   Determines the key under which CSS custom properties derived configuration data is stored in the entry's ConfigManager.
 </ReferenceCard>
 

--- a/docs/src/packages/notice.mdx
+++ b/docs/src/packages/notice.mdx
@@ -64,7 +64,7 @@ Notice uses CSS variables in a reference and fallback pattern. Variables are ref
   "--vb-notice-spacing": "0.5em",
   "--vb-notice-title-font-size": "var(--vb-font-size-lg)",
   "--vb-notice-title-line-height": "var(--vb-font-weight-semi-bold)",
-  "--vb-notice-title-font-weight": "var(--vb-line-height)"
+  "--vb-notice-title-font-weight": "inherit"
 }} />
 
 ## Basic usage

--- a/docs/src/packages/popover.mdx
+++ b/docs/src/packages/popover.mdx
@@ -5,7 +5,10 @@ package: "@vrembem/popover"
 category: component
 ---
 
-import DocBlock from "../components/DocBlock.astro";
+import CodeExpander from "../components/CodeExpander.astro";
+import ReferenceBar from "../components/ReferenceBar.astro";
+import ReferenceCard from "../components/ReferenceCard.astro";
+import ReferenceTable from "../components/ReferenceTable.astro";
 import Menu from "../examples/Menu.astro";
 import Icon from '../components/Icon.astro';
 
@@ -21,10 +24,129 @@ npm install @vrembem/popover
 
 <CodeExample lang="js">
   ```js
+  // Import the popover class
   import Popover from "@vrembem/popover";
-  const popover = new Popover({ autoMount: true });
+
+  // Instantiate the popover collection
+  const popovers = new Popover();
+
+  // Mount the popover collection
+  await popovers.mount();
   ```
 </CodeExample>
+
+## Options
+
+Popover is built as a Sass module to handle styles and CSS output, along with a corresponding JavaScript class for managing behavior and plugin integration. Below are the available configuration options.
+
+### JavaScript
+
+Popover comes with the following JavaScript configuration options that customize the behavior, accessibility, and integration of the popover collection.
+
+<CodeExpander lang="js">
+```js
+const popovers = new Popover({
+  // A valid CSS selector used to query the document for elements to include as
+  // entries in the popover collection.
+  // @type string
+  selector: ".popover",
+
+  // A valid CSS selector that should match a popover as a tooltip type
+  // @type string
+  selectorTooltip: ".popover_tooltip",
+
+  // A valid CSS selector for the arrow or carrot element of a popover
+  // @type string
+  selectorArrow: ".popover__arrow",
+
+  // A CSS class applied as the active state of a popover
+  // @type string
+  stateActive: "is-active",
+
+  // The preferred placement location of a popover if there is enough space
+  // @type string as Placement
+  placement: "bottom",
+
+  // The event that should trigger the popover
+  // @type string as "click" | "hover"
+  event: "click",
+
+  // A number represents the distance (gutter or margin) between the floating
+  // element and the reference element.
+  // @type number
+  offset: 8,
+
+  // A number representing the distance from the viewport edge before the
+  // popover is flipped to the opposite position.
+  // @type number
+  flipPadding: 10,
+
+  // A number representing the distance from the viewport edge before the
+  // popover is shifted to remain visible.
+  // @type number
+  shiftPadding: 10,
+
+  // This describes the padding between the arrow and the edges of the floating
+  // element. If your floating element has border-radius, this will prevent it
+  // from overflowing the corners.
+  // @type number
+  arrowPadding: 10,
+
+  // The number in milliseconds that a popover should delay before opening and
+  // closing. Open and close delays can be different by providing two values.
+  // Example: [200, 600], "200, 600", "200 600"
+  // @type number | string | (number | string)[]
+  toggleDelay: 0,
+
+  // Whether or not the popover should be positioned to follow the cursor.
+  // @type boolean
+  virtual: false
+});
+```
+</CodeExpander>
+
+### Sass
+
+Popover comes with the following Sass configuration options that can be set using either the [config module](/packages/core/config#using-config-module) or [Sass `with` clause](/packages/core/config#using-with-clause) methods.
+
+<CodeExample lang="scss">
+```scss
+@use "@vrembem/popover" with (
+  $config: (
+    // Map for outputting popover_size_[key] modifier variants
+    // @type map
+    "popover-size": (
+      "auto": "auto",
+      "sm": 12em,
+      "lg": 20em
+    )
+  )
+);
+```
+</CodeExample>
+
+### CSS Variables
+
+Popover uses CSS variables in a reference and fallback pattern. Variables are referenced in the component's styles but are not directly defined; instead, they are provided with sensible fallbacks.
+
+<ReferenceTable id="cssvar-popover" valueLabel="Fallback" expandable={true} data={{
+  "--vb-popover-z-index": "10",
+  "--vb-popover-width": "16em",
+  "--vb-popover-max-width": "calc(100vw - 2rem)",
+  "--vb-popover-padding": "0.5em",
+  "--vb-popover-border": "none",
+  "--vb-popover-border-radius": "var(--vb-border-radius)",
+  "--vb-popover-font-size": "var(--vb-font-size-sm)",
+  "--vb-popover-line-height": "inherit",
+  "--vb-popover-foreground": "var(--vb-foreground)",
+  "--vb-popover-background": "var(--vb-background)",
+  "--vb-popover-box-shadow": "var(--vb-box-shadow-2)",
+  "--vb-popover-transition-property": "opacity",
+  "--vb-popover-transition-timing-function": "var(--vb-transition-timing-function)",
+  "--vb-popover-transition-duration": "var(--vb-transition-duration-short)",
+  "--vb-popover-offset": "8",
+  "--vb-popover-arrow-size": "8px"
+}} />
 
 ## Basic usage
 
@@ -298,270 +420,78 @@ There are cases where a single popover trigger requires both a tooltip and a cli
   ```
 </CodeExample>
 
-## Customization
+## Reference
 
-Popovers are primarily customized using CSS variables but can also be modified using Sass variables. All CSS variables are given the Vrembem vendor prefix `"vb-"`. This can be changed by setting the `$prefix-variable` variable via the `core` module.
+`Popover` and `PopoverEntry` extend the [`Collection`](/packages/core/collection-api) and [`CollectionEntry`](/packages/core/collection-entry-api) classes, respectively, and inherit their APIs. This reference contains only popover-specific API properties and methods. Check out the [collections documentation](/packages/core#collections) for more information on inherited APIs.
 
-<DocBlock name="CSS Variables" src="popover/src/scss/_root.scss">
+### trigger
 
-```scss
-:root {
-  --vb-popover-offset: 8;
-  --vb-popover-overflow-padding: 10;
-  --vb-popover-flip-padding: 10;
-  --vb-popover-arrow-padding: 10;
-}
-```
-</DocBlock>
+<ReferenceBar type="HTMLElement | null" />
 
-<DocBlock name="SCSS Variables" src="popover/src/scss/_variables.scss">
+Stores a reference to a trigger element. When a click event popover is opened, the trigger is the element that was used to open it. Focus is returned to this element when the popover is closed.
 
-```scss
-@use "@vrembem/core";
-@use "@vrembem/core/css";
-@use "@vrembem/core/theme";
+### active
 
-$prefix-variable: core.$prefix-variable !default;
-$prefix-block: core.$prefix-block !default;
-$prefix-element: core.$prefix-element !default;
-$prefix-modifier: core.$prefix-modifier !default;
-$prefix-modifier-value: core.$prefix-modifier-value !default;
+<ReferenceBar type="PopoverEntry | undefined" />
 
-$event: null !default;
-$placement: null !default;
-$offset: 8 !default;
-$overflow-padding: 10 !default;
-$flip-padding: 10 !default;
+...
 
-$z-index: 10 !default;
-$width: 16em !default;
-$max-width: calc(100vw - 20px) !default;
-$padding: 0.5em !default;
-$border: null !default;
-$border-radius: core.$border-radius !default;
-$foreground: theme.get("foreground") !default;
-$background: theme.get("background") !default;
-$background-clip: padding-box !default;
-$shadow: css.get("box-shadow-2") !default;
-$font-size: core.$font-size-sm !default;
-$line-height: null !default;
+### activeHover
 
-$arrow-size: 12px !default;
-$arrow-padding: 10 !default;
-$arrow-border: core.$border !default;
+<ReferenceBar type="PopoverEntry | undefined" />
 
-$size-sm-width: 12em !default;
-$size-lg-width: 20em !default;
+...
 
-// Custom properties
-@include css.set("popover", (
-  "event": $event,
-  "placement": $placement,
-  "offset": $offset,
-  "overflow-padding": $overflow-padding,
-  "flip-padding": $flip-padding,
-  "arrow-padding": $arrow-padding
-));
-```
-</DocBlock>
+### virtual
 
-<DocBlock name="JS Config" src="popover/src/js/defaults.js">
+<ReferenceBar type="boolean" />
 
-  ```js
-  export default {
-    autoMount: false,
+...
 
-    // Selectors
-    selectorPopover: ".popover",
-    selectorArrow: ".popover__arrow",
+### open
 
-    // State classes
-    stateActive: "is-active",
+<ReferenceBar type="method" returns="Promise<PopoverEntry>" />
 
-    // Feature configurations
-    eventListeners: true,
-    eventType: "click",
-    placement: "bottom"
-  };
-  ```
-</DocBlock>
+...
 
-## JavaScript usage
+### close
 
-After the popover component has been instantiated the popover object is returned with a robust API to help manage all the popovers on your page.
+<ReferenceBar type="method" returns="Promise<PopoverEntry | PopoverEntry[]>" />
 
-<DocBlock name="popover.collection" type="property" returns="array" src="core/src/js/Collection.js" line="3">
-  Returns an array where all popover objects are stored when registered. Each popover object contains the following properties:
+...
 
-  ```scss
-  {
-    id: String, // The unique ID of the popover.
-    state: String, // The current state of the popover ('closed' or 'opened').
-    el: HTMLElement, // The popover HTML element.
-    trigger: HTMLElement, // The popover trigger HTML element.
-    popper: Object // The popper JS instance.
-    config: Object // Stores the popover configuration options.
-    open: Function // Method to open this popover.
-    close: Function // Method to close this popover.
-    deregister: Function // Method to deregister this popover.
-  }
-  ```
-</DocBlock>
+### entry.state
 
-<DocBlock name="popover.mount" type="method" returns="Object" src="popover/src/js/index.js" line="23" args={[
-  ["options", "Object (optional)", "An options object for passing custom configurations."]
-]}>
-  Mounts the popover instance. During mounting, the following processes are run:
+<ReferenceBar type='"closed" | "opened"' />
 
-  - Builds the popover collection by running `registerCollection()`
-  - Sets up the global event listeners by running `mountEventListeners()`
+...
 
-  <Fragment slot="example">
-    ```js
-    const popover = new Popover();
-    await popover.mount();
-    ```
-  </Fragment>
-</DocBlock>
+### entry.trigger
 
-<DocBlock name="popover.unmount" type="method" returns="Object" src="popover/src/js/index.js" line="43">
-  Destroys and cleans up the popover mount. During cleanup, the following processes are run:
+<ReferenceBar type="HTMLElement | null" />
 
-  - Deregister the popover collection by running `deregisterCollection()`
-  - Removes global event listeners by running `unmountEventListeners()`
+...
 
-  <Fragment slot="example">
-    ```js
-    const popover = new Popover();
-    await popover.mount();
-    // ...
-    await popover.unmount();
-    ```
-  </Fragment>
-</DocBlock>
+### entry.isTooltip
 
-<DocBlock name="popover.mountEventListeners" type="method" returns="Object" src="popover/src/js/index.js" line="60" args={[
-  ["processCollection", "Boolean", "Whether or not to process the event listeners of popover collection. Defaults to true."]
-]}>
-  Set document and collection entry event listeners.
+<ReferenceBar type="boolean" />
 
-  <Fragment slot="example">
-    ```js
-    const popover = new Popover({ eventListeners: false });
-    await popover.mount();
-    popover.mountEventListeners();
-    ```
-  </Fragment>
-</DocBlock>
+...
 
-<DocBlock name="popover.unmountEventListeners" type="method" returns="Object" src="popover/src/js/index.js" line="72" args={[
-  ["processCollection", "Boolean", "Whether or not to process the event listeners of popover collection. Defaults to true."]
-]}>
-  Remove document and collection entry event listeners.
+### entry.isHovered
 
-  <Fragment slot="example">
-    ```js
-    const popover = new Popover();
-    await popover.mount();
-    // ...
-    popover.unmountEventListeners();
-    ```
-  </Fragment>
-</DocBlock>
+<ReferenceBar type="boolean" />
 
-<DocBlock name="popover.register" type="method" returns="Object" src="popover/src/js/register.js" args={[
-  ["query", "String || Object", "A popover ID or an HTML element of either a popover or its trigger."]
-]}>
-Registers a popover into the collection. This also sets the initial state, creates the popper instance and attaches event listeners. Returns the popover object that got stored in the collection.
+...
 
-  <Fragment slot="example">
-    ```js
-    const result = await popover.register("popover-id");
-    // => Object { id: "popover-id", ... }
-    ```
-  </Fragment>
-</DocBlock>
+### entry.open
 
-<DocBlock name="popover.deregister" type="method" returns="Array" src="popover/src/js/deregister.js" args={[
-  ["query", "String || Object", "A popover ID or an HTML element of either a popover or its trigger."]
-]}>
-Deregister the popover from the collection. This closes the popover if it's opened, cleans up the popper instance, removes event listeners and then removes the entry from the collection. Returns the newly modified collection array.
+<ReferenceBar type="method" returns="Promise<PopoverEntry>" />
 
-  <Fragment slot="example">
-    ```js
-    const result = await popover.deregister("popover-id");
-    // => Array [{}, {}, ...]
-    ```
-  </Fragment>
-</DocBlock>
+...
 
-<DocBlock name="popover.registerCollection" type="method" returns="Array" src="core/src/js/Collection.js" line="26" args={[
-  ["items", "Array", "An array of popovers or popover IDs to register."]
-]}>
-Registers array of popovers to the collection. All popovers in array are run through the `register()` method. Returns the collection array.
+### entry.close
 
-  <Fragment slot="example">
-    ```js
-    const popovers = document.querySelectorAll(".popover");
-    const result = await popover.registerCollection(popovers);
-    // => Array [{}, {}, ...]
-    ```
-  </Fragment>
-</DocBlock>
+<ReferenceBar type="method" returns="Promise<PopoverEntry>" />
 
-<DocBlock name="popover.deregisterCollection" type="method" returns="Array" src="core/src/js/Collection.js" line="33">
-Deregister all popovers in the collections array. All popovers in collection are run through the `deregister()` method. Returns an empty collection array.
-
-  <Fragment slot="example">
-    ```js
-    const result = await popover.registerCollection();
-    // => Array []
-    ```
-  </Fragment>
-</DocBlock>
-
-<DocBlock name="popover.get" type="method" returns="Object || undefined" src="core/src/js/Collection.js" line="40" args={[
-  ["value", "String || Object", "The value to search for within the collection."],
-  ["key", "String (optional)", "The property key to search the value against (defaults to 'id')."]
-]}>
-  Used to retrieve a registered popover object from the collection. Query should match the key type to search by: e.g. to search by popover elements, pass the popover html node with a key of `'el'`. Defaults to `'id'`.
-
-  Returns the first element in the collection that matches the provided query and key. Otherwise, undefined is returned.
-
-  <Fragment slot="example">
-    ```js
-    const entry = popover.get("popover-id");
-    // => Object { id: "popover-id", ... }
-    ```
-  </Fragment>
-</DocBlock>
-
-<DocBlock name="popover.open" type="method" returns="Object" src="popover/src/js/open.js" args={[
-  ["id", "String", "The ID of the popover to open."],
-  ["transition", "Boolean (optional)", "Whether or not to animate the transition."],
-  ["focus", "Boolean (optional)", "Whether or not to handle focus management."]
-]}>
-  Opens a popover using the provided ID. Returns the popover object that was opened.
-
-  <Fragment slot="example">
-    ```js
-    const entry = await popover.open("popover-id");
-    // => Object { state: 'opened', ... }
-    ```
-  </Fragment>
-</DocBlock>
-
-<DocBlock name="popover.close" type="method" returns="Object" src="popover/src/js/close.js" args={[
-  ["id", "String", "The ID of the popover to close."],
-  ["transition", "Boolean (optional)", "Whether or not to animate the transition."],
-  ["focus", "Boolean (optional)", "Whether or not to handle focus management."]
-]}>
-  Close a popover using the provided ID. Can be called without an ID to close all open popovers. Returns the popover object or array of popover objects that were closed.
-
-  <Fragment slot="example">
-    ```js
-    const entry = await popover.close();
-    // => Array [{}, {}, ...]
-    ```
-  </Fragment>
-</DocBlock>
+...

--- a/docs/src/packages/popover.mdx
+++ b/docs/src/packages/popover.mdx
@@ -63,13 +63,13 @@ const popovers = new Popover({
   // @type string
   stateActive: "is-active",
 
+  // The default event type that triggers popovers
+  // @type string as "click" | "hover"
+  event: "click",
+
   // The preferred placement location of a popover if there is enough space
   // @type string as Placement
   placement: "bottom",
-
-  // The event that should trigger the popover
-  // @type string as "click" | "hover"
-  event: "click",
 
   // A number represents the distance (gutter or margin) between the floating
   // element and the reference element.
@@ -148,6 +148,18 @@ Popover uses CSS variables in a reference and fallback pattern. Variables are re
   "--vb-popover-arrow-size": "8px"
 }} />
 
+When using the [`cssConfig`](/packages/core/plugins/css-config) plugin, the following CSS variables can be used to set JavaScript configuration options.
+
+<ReferenceTable id="cssvar-popover-js" valueLabel="JS Equivalent" filter={false} data={{
+  "--vb-popover-event": "event",
+  "--vb-popover-offset": "offset",
+  "--vb-popover-flip-padding": "flipPadding",
+  "--vb-popover-shift-padding": "shiftPadding",
+  "--vb-popover-arrow-padding": "arrowPadding",
+  "--vb-popover-toggle-delay": "toggleDelay",
+  "--vb-popover-virtual": "virtual"
+}} />
+
 ## Basic usage
 
 The popover is a simple container component consisting of the `popover` class and an `id`. Popover triggers should have an `aria-controls` attribute set to the ID of the popover element.
@@ -188,24 +200,21 @@ Add an arrow to a popover using an empty `<div>` or `<span>` with the `popover__
 
 ### Event type
 
-There are two event types that can trigger a popover: `click` (the default) and `hover` (hover also applies focus events). You an set your preferred default event type by passing it as an option on instantiation or mount.
+There are two event types that can trigger a popover: `click` (the default) and `hover` (also applies focus events). Set the default event type using the `event` config option.
 
 <CodeExample lang="js">
 
   ```js
   // Set on instantiation
-  const popover = new Popover({
-    eventType: "click"
+  const popovers = new Popover({
+    event: "click"
   });
 
-  // Set on mount
-  popover.mount({
-    eventType: "hover"
-  });
+  popovers.mount();
   ```
 </CodeExample>
 
-Alternatively, this value can be overridden using the [`--vb-popover-event` CSS variable](#css-variables). This can be done either through your own custom CSS or using the `style` attribute.
+When using the [`cssConfig`](/packages/core/plugins/css-config) plugin, the event option can be provided using the `--vb-popover-event` CSS variable. This can be done either through your own custom CSS or using the `style` attribute.
 
 <CodeExample>
   <Fragment slot="output">
@@ -221,26 +230,36 @@ Alternatively, this value can be overridden using the [`--vb-popover-event` CSS 
   ```
 </CodeExample>
 
+**Available options**
+
+- `click`
+- `hover`
+
 ### Placement
 
-Popover uses the [Popper JS positioning engine](https://popper.js.org/) to determine the optimal place to display a popover. The default preference is `bottom` but can be changed by passing it as an option on instantiation or mount.
+Popover uses the [floating UI positioning engine](https://floating-ui.com/) to determine the optimal popover placement. The default popover placement is `bottom` but can be changed a new placement option.
 
 <CodeExample lang="js">
+```js
+// Set on instantiation
+const popover = new Popover({
+  placement: "top"
+});
 
-  ```js
-  // Set on instantiation
-  const popover = new Popover({
-    placement: "top"
-  });
-
-  // Set on mount
-  popover.mount({
-    placement: "bottom"
-  });
-  ```
+popover.mount();
+```
 </CodeExample>
 
-Alternatively, this value can be overridden using the [`--vb-popover-placement` CSS variable](#css-variables). This can be done either through your own custom CSS or using the `style` attribute.
+The available placement options include `top`, `right`, `bottom`, `left` along with `-start` and `-end` variants. 
+
+<CodeExample lang="ts">
+```ts
+// As imported from "@floating-ui/dom"
+type Placement = "bottom" | "top" | "right" | "left" | "bottom-start" | "bottom-end" | "top-start" | "top-end" | "right-start" | "right-end" | "left-start" | "left-end";
+```
+</CodeExample>
+
+When using the [`cssConfig`](/packages/core/plugins/css-config) plugin, the placement option can be provided using the `--vb-popover-placement` CSS variable. This can be done either through your own custom CSS or using the `style` attribute.
 
 <CodeExample>
   <Fragment slot="output">
@@ -257,68 +276,24 @@ Alternatively, this value can be overridden using the [`--vb-popover-placement` 
   ```
 </CodeExample>
 
-**Available variants**
+**Available options**
 
-- `auto`
-- `auto-start`
-- `auto-end`
-- `top`
-- `top-start`
-- `top-end`
 - `bottom`
 - `bottom-start`
 - `bottom-end`
-- `left`
-- `left-start`
-- `left-end`
+- `top`
+- `top-start`
+- `top-end`
 - `right`
 - `right-start`
 - `right-end`
+- `left`
+- `left-start`
+- `left-end`
 
-### CSS Variables
+## popover_size_[key]
 
-Popover provides CSS variables on the `:root` element for controlling the event type, preferred placement, offset and overflow-padding. They're consumed by the JavaScript implementation to set options dynamically. The following Sass variable are output as CSS variables:
-
-The advantage to having these values set by a CSS variable is that they can be given new values for specific use cases either in your own stylesheet or by setting the variables in a `style` attribute.
-
-<CodeExample>
-  <Fragment slot="output">
-    <div class="flex justify-content-between" style="--vb-popover-offset: 0;">
-      <div style="--vb-popover-placement: right;">
-        <button class="button button_icon button_color_secondary" aria-describedby="popover-5">
-          <span class="arrow-right"></span>
-        </button>
-        <div id="popover-5" class="popover">
-          <Menu name="edit-shortcuts" />
-          <span class="popover__arrow"></span>
-        </div>
-      </div>
-      <div style="--vb-popover-placement: left;">
-        <button class="button button_icon button_color_secondary" aria-describedby="popover-6">
-          <span class="arrow-left"></span>
-        </button>
-        <div id="popover-6" class="popover">
-          <Menu name="edit-shortcuts" />
-          <span class="popover__arrow"></span>
-        </div>
-      </div>
-    </div>
-  </Fragment>
-  ```html
-  <div style="--vb-popover-offset: 0;">
-    <div style="--vb-popover-placement: right;">
-      ...
-    </div>
-    <div style="--vb-popover-placement: left;">
-      ...
-    </div>
-  </div>
-  ```
-</CodeExample>
-
-## popover_size_[value]
-
-Adjusts the size of the popover. There are two options relative to the default size, `popover_size_sm` and `popover_size_lg`. Also available is `popover_size_auto` which allows the popover to adjust size based on its content.
+Adjust the size of a popover by increasing or decreasing its width. These modifiers are generated using key/value pairs of the `popover-size` config options map.
 
 <CodeExample>
   <div slot="output" class="flex">
@@ -388,7 +363,9 @@ Applies styles to create a popover tooltip. The default placement of a tooltip i
   ```
 </CodeExample>
 
-> For more information regarding tooltip accessibility and best practices, please see: [ARIA: tooltip role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role).
+<div class="notice">
+  For more information regarding tooltip accessibility and best practices, please see: [ARIA: tooltip role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role).
+</div>
 
 ### Multiple popovers
 

--- a/docs/src/packages/popover.mdx
+++ b/docs/src/packages/popover.mdx
@@ -63,6 +63,10 @@ const popovers = new Popover({
   // @type string
   stateActive: "is-active",
 
+  // A CSS class applied to popovers that are anchored to a virtual element
+  // @type string
+  stateVirtual: "is-virtual",
+
   // The default event type that triggers popovers
   // @type string as "click" | "hover"
   event: "click",
@@ -98,9 +102,9 @@ const popovers = new Popover({
   // @type number | string | (number | string)[]
   toggleDelay: 0,
 
-  // Whether or not the popover should be positioned to follow the cursor.
+  // Whether or not popovers should be anchored to the cursor.
   // @type boolean
-  virtual: false
+  followCursor: false
 });
 ```
 </CodeExpander>
@@ -157,7 +161,7 @@ When using the [`cssConfig`](/packages/core/plugins/css-config) plugin, the foll
   "--vb-popover-shift-padding": "shiftPadding",
   "--vb-popover-arrow-padding": "arrowPadding",
   "--vb-popover-toggle-delay": "toggleDelay",
-  "--vb-popover-virtual": "virtual"
+  "--vb-popover-follow-cursor": "followCursor"
 }} />
 
 ## Basic usage
@@ -397,6 +401,38 @@ There are cases where a single popover trigger requires both a tooltip and a cli
   ```
 </CodeExample>
 
+### Follow cursor
+
+Popovers can be anchored to the cursor element by setting the `followCursor` config option to `true`. When using the [`cssConfig`](/packages/core/plugins/css-config) plugin, the followCursor option can be provided using the `--vb-popover-follow-cursor` CSS variable.
+
+<CodeExample>
+  <Fragment slot="output">
+    <button type="button" class="button button_icon" aria-controls="popover-virtual">
+      <Icon name="coffee" />
+    </button>
+    <div 
+      id="popover-virtual" 
+      class="popover popover_tooltip" 
+      style="
+        --vb-popover-event: click;
+        --vb-popover-follow-cursor: true;
+      "
+    >
+      Virtual popover!
+    </div>
+  </Fragment>
+  ```html
+  <div 
+    id="unique-id" 
+    class="popover popover_tooltip" 
+    style="
+      --vb-popover-event: click;
+      --vb-popover-follow-cursor: true;
+    "
+  >...</div>
+  ```
+</CodeExample>
+
 ## Reference
 
 `Popover` and `PopoverEntry` extend the [`Collection`](/packages/core/collection-api) and [`CollectionEntry`](/packages/core/collection-entry-api) classes, respectively, and inherit their APIs. This reference contains only popover-specific API properties and methods. Check out the [collections documentation](/packages/core#collections) for more information on inherited APIs.
@@ -436,24 +472,6 @@ Returns the active hover popover if one exists. Otherwise, returns undefined. An
 if (popovers.activeHover) {
   // This block will run if a hover popover is active...
 }
-```
-</CodeExample>
-
-### virtual
-
-<ReferenceBar type="boolean" />
-
-Gets or sets the virtual element mode. When enabled, the popover tracks the cursor position using a `mousemove` listener on the document. When disabled, the listener is removed.
-
-#### Example
-
-<CodeExample lang="js">
-```js
-// Enable virtual element mode
-popovers.virtual = true;
-
-// Disable virtual element mode
-popovers.virtual = false;
 ```
 </CodeExample>
 

--- a/docs/src/packages/popover.mdx
+++ b/docs/src/packages/popover.mdx
@@ -434,64 +434,159 @@ Stores a reference to a trigger element. When a click event popover is opened, t
 
 <ReferenceBar type="PopoverEntry | undefined" />
 
-...
+Returns the active popover if one exists. Otherwise, returns undefined. An active popover is defined as one that currently has the `"opened"` state.
+
+#### Example
+
+<CodeExample lang="js">
+```js
+if (popovers.active) {
+  // This block will run if a popover is active...
+}
+```
+</CodeExample>
 
 ### activeHover
 
 <ReferenceBar type="PopoverEntry | undefined" />
 
-...
+Returns the active hover popover if one exists. Otherwise, returns undefined. An active hover popover is defined as one that is currently opened and has its event type set to `"hover"`.
+
+#### Example
+
+<CodeExample lang="js">
+```js
+if (popovers.activeHover) {
+  // This block will run if a hover popover is active...
+}
+```
+</CodeExample>
 
 ### virtual
 
 <ReferenceBar type="boolean" />
 
-...
+Gets or sets the virtual element mode. When enabled, the popover tracks the cursor position using a `mousemove` listener on the document. When disabled, the listener is removed.
+
+#### Example
+
+<CodeExample lang="js">
+```js
+// Enable virtual element mode
+popovers.virtual = true;
+
+// Disable virtual element mode
+popovers.virtual = false;
+```
+</CodeExample>
 
 ### open
 
 <ReferenceBar type="method" returns="Promise<PopoverEntry>" />
 
-...
+Opens a popover using the provided popover ID. It will throw an error if the provided ID does not match an existing popover entry.
+
+#### Arguments
+
+<ReferenceCard name="id" type="string">
+  The ID of the popover to open.
+</ReferenceCard>
+
+#### Example
+
+<CodeExample lang="js">
+```js
+await popovers.open("my-popover");
+// > Opens the popover with id="my-popover"
+
+await popovers.open("fake-popover");
+// > Uncaught Error: Popover entry not found in collection with id of "fake-popover"
+```
+</CodeExample>
 
 ### close
 
 <ReferenceBar type="method" returns="Promise<PopoverEntry | PopoverEntry[]>" />
 
-...
+Closes a popover using the provided popover ID. It will throw an error if the provided ID does not match an existing popover entry. If no ID is provided, all open popovers are closed.
+
+#### Arguments
+
+<ReferenceCard name="id" type="string">
+  The ID of the popover to close. If omitted, all open popovers are closed.
+</ReferenceCard>
+
+#### Example
+
+<CodeExample lang="js">
+```js
+await popovers.close("my-popover");
+// > Closes the popover with id="my-popover"
+
+await popovers.close();
+// > Closes all open popovers
+```
+</CodeExample>
 
 ### entry.state
 
 <ReferenceBar type='"closed" | "opened"' />
 
-...
+Stores the current state of the popover. Possible states include:
+
+- `opened`: The popover is currently open, and its content is visible.
+- `closed`: The popover is currently closed, and its content is hidden.
 
 ### entry.trigger
 
 <ReferenceBar type="HTMLElement | null" />
 
-...
+Stores a reference to the trigger element associated with the popover entry. The trigger is resolved during entry creation using the `aria-controls` or `aria-describedby` attribute that matches the popover's ID.
 
 ### entry.isTooltip
 
 <ReferenceBar type="boolean" />
 
-...
+Returns whether or not the popover is a tooltip. A popover is considered a tooltip if it matches the `selectorTooltip` config option or has the `role="tooltip"` attribute.
 
 ### entry.isHovered
 
 <ReferenceBar type="boolean" />
 
-...
+Returns whether or not the popover element or its trigger is currently being hovered over. This is used internally to manage hover event popovers and determine if the popover should remain open.
 
 ### entry.open
 
 <ReferenceBar type="method" returns="Promise<PopoverEntry>" />
 
-...
+Opens the popover if it is currently closed.
+
+#### Example
+
+<CodeExample lang="js">
+```js
+// Get the popover entry
+const entry = popovers.get("my-popover");
+
+// Open the popover
+await entry.open();
+```
+</CodeExample>
 
 ### entry.close
 
 <ReferenceBar type="method" returns="Promise<PopoverEntry>" />
 
-...
+Closes the popover if it is currently opened.
+
+#### Example
+
+<CodeExample lang="js">
+```js
+// Get the popover entry
+const entry = popovers.get("my-popover");
+
+// Close the popover
+await entry.close();
+```
+</CodeExample>

--- a/docs/src/styles/_code-expander.scss
+++ b/docs/src/styles/_code-expander.scss
@@ -77,7 +77,8 @@
     display: block;
   }
 
-  &:hover {
+  &:hover,
+  &:focus-within {
     border-color: palette.get("primary");
     box-shadow: 0 0 0 css.get("focus-ring-width") palette.get("primary", 50%, css.get("focus-ring-opacity"));
 

--- a/packages/core/src/js/Collection.ts
+++ b/packages/core/src/js/Collection.ts
@@ -1,6 +1,6 @@
 import { CollectionEntry, CollectionEntryConstructor } from "./CollectionEntry";
 import { EventEmitter, PluginArray, Plugin } from "./modules";
-import { dispatchLifecycleHook, dispatchProxyEntryHook } from "./helpers";
+import { root, dispatchLifecycleHook, dispatchProxyEntryHook } from "./helpers";
 import { maybeRunMethod } from "./utilities";
 
 export interface CollectionConfig<
@@ -37,6 +37,7 @@ export class Collection<
   entryClass: CollectionEntryConstructor<TEntry>;
   config: TConfig;
   plugins: PluginArray;
+  [root]?: Collection;
 
   constructor(options: Partial<TConfig> = {}) {
     this.config = { ...defaults, ...options } as TConfig;

--- a/packages/core/src/js/CollectionEntry.ts
+++ b/packages/core/src/js/CollectionEntry.ts
@@ -1,5 +1,6 @@
-import { getElement } from "./utilities";
 import { ConfigManager } from "./modules";
+import { root } from "./helpers";
+import { getElement } from "./utilities";
 
 export interface CollectionEntryConstructor<TEntry extends CollectionEntry> {
   new (parent: any, query: string | HTMLElement): TEntry;
@@ -10,6 +11,7 @@ export class CollectionEntry {
   el: HTMLElement;
   id: string;
   config = new ConfigManager();
+  [root]?: CollectionEntry;
 
   constructor(parent: any, query: string | HTMLElement) {
     this.parent = parent;

--- a/packages/core/src/js/helpers/dispatchProxyEntryHook.ts
+++ b/packages/core/src/js/helpers/dispatchProxyEntryHook.ts
@@ -1,3 +1,4 @@
+import { root } from "./private";
 import { maybeRunMethod } from "../utilities";
 import type { Collection } from "../Collection";
 import type { CollectionEntry } from "../CollectionEntry";
@@ -6,6 +7,9 @@ export async function dispatchProxyEntryHook<
   TParent extends Collection<TEntry>,
   TEntry extends CollectionEntry
 >(parent: TParent, entry: TEntry): Promise<TEntry> {
+  // Keep a reference to the original entry before it can be proxied
+  const original = entry;
+
   // Allow a collection to proxy entries
   let handler = await maybeRunMethod(parent, "proxyEntry", { parent, entry });
   if (handler) entry = new Proxy(entry, handler);
@@ -15,6 +19,11 @@ export async function dispatchProxyEntryHook<
     const context = { plugin, parent, entry };
     handler = await maybeRunMethod(plugin, "proxyEntry", context);
     if (handler) entry = new Proxy(entry, handler);
+  }
+
+  // Only stamp the root reference if a proxy was created
+  if (entry !== original) {
+    original[root] = original;
   }
 
   return entry;

--- a/packages/core/src/js/helpers/private.ts
+++ b/packages/core/src/js/helpers/private.ts
@@ -1,8 +1,31 @@
-import type { CollectionEntry } from "../CollectionEntry";
+import type { Collection } from "../Collection";
+import { CollectionEntry } from "../CollectionEntry";
 
-const priv = new Map<string, any>();
+/**
+ * A private store for collection and collection entry instances. Uses a WeakMap
+ * when storing data for collections and Map with uid (`name:id`) keys for
+ * collection entries. This ensures compatibility with proxied entries.
+ *
+ * - Setter: `_(instance, { ... })` — stores the object and returns `undefined`.
+ * - Getter: `_(instance)` — retrieves the previously stored object.
+ *
+ * @param {Collection | CollectionEntry} self
+ *   A collection or collection entry instance.
+ * @param {any} obj
+ *   The object to store. When omitted, retrieves the stored object.
+ *
+ * @returns The stored object when getting, or `undefined` when setting.
+ */
 
-export const _ = (self: CollectionEntry, obj?: Record<string, any>) => {
-  const uid = `${self.parent.name}:${self.id}`.toLowerCase();
-  return obj ? priv.set(uid, obj) : priv.get(uid)!;
-};
+const privMap = new Map<string, any>();
+const privWeakMap = new WeakMap<Collection, any>();
+
+export function _(self: Collection | CollectionEntry, obj?: any): any {
+  const hasArg = arguments.length > 1;
+  if (self instanceof CollectionEntry) {
+    const uid = `${self.parent.name}:${self.id}`.toLowerCase();
+    return hasArg ? void privMap.set(uid, obj) : privMap.get(uid);
+  } else {
+    return hasArg ? void privWeakMap.set(self, obj) : privWeakMap.get(self);
+  }
+}

--- a/packages/core/src/js/helpers/private.ts
+++ b/packages/core/src/js/helpers/private.ts
@@ -1,10 +1,11 @@
 import type { Collection } from "../Collection";
-import { CollectionEntry } from "../CollectionEntry";
+import type { CollectionEntry } from "../CollectionEntry";
 
 /**
- * A private store for collection and collection entry instances. Uses a WeakMap
- * when storing data for collections and Map with uid (`name:id`) keys for
- * collection entries. This ensures compatibility with proxied entries.
+ * A private store for Collection and CollectionEntry instances. Uses a WeakMap
+ * keyed by object identity. For entries that are wrapped in a proxy, a `root`
+ * Symbol property is used to resolve back to the original (unwrapped) entry,
+ * ensuring consistent WeakMap lookups regardless of proxy wrapping.
  *
  * - Setter: `_(instance, { ... })` — stores the object and returns `undefined`.
  * - Getter: `_(instance)` — retrieves the previously stored object.
@@ -16,16 +17,9 @@ import { CollectionEntry } from "../CollectionEntry";
  *
  * @returns The stored object when getting, or `undefined` when setting.
  */
-
-const privMap = new Map<string, any>();
-const privWeakMap = new WeakMap<Collection, any>();
-
+const priv = new WeakMap<Collection | CollectionEntry, any>();
+export const root = Symbol("root");
 export function _(self: Collection | CollectionEntry, obj?: any): any {
-  const hasArg = arguments.length > 1;
-  if (self instanceof CollectionEntry) {
-    const uid = `${self.parent.name}:${self.id}`.toLowerCase();
-    return hasArg ? void privMap.set(uid, obj) : privMap.get(uid);
-  } else {
-    return hasArg ? void privWeakMap.set(self, obj) : privWeakMap.get(self);
-  }
+  const key = self[root] || self;
+  return arguments.length > 1 ? void priv.set(key, obj) : priv.get(key);
 }

--- a/packages/core/src/js/modules/EventEmitter.ts
+++ b/packages/core/src/js/modules/EventEmitter.ts
@@ -5,29 +5,25 @@ export interface EventEntry {
   args: any[];
 }
 
-export interface EventMap {
-  [event: string]: EventEntry[];
-}
-
 export class EventEmitter {
-  readonly events: EventMap = {};
+  readonly events = new Map<string, EventEntry[]>();
 
   on(event: string, listener: EventListener, ...args: any[]): void {
-    if (!this.events[event]) {
-      this.events[event] = [];
+    if (!this.events.has(event)) {
+      this.events.set(event, []);
     }
-    const listenerExists = this.events[event].some(
-      (entry) => entry.listener === listener
-    );
-    if (!listenerExists) {
-      this.events[event].push({ listener, args });
+    const entries = this.events.get(event)!;
+    if (!entries.some((entry) => entry.listener === listener)) {
+      entries.push({ listener, args });
     }
   }
 
   off(event: string, listenerRef: EventListener): void {
-    if (!this.events[event]) return;
-    this.events[event] = this.events[event].filter(
-      (entry) => entry.listener !== listenerRef
+    const entries = this.events.get(event);
+    if (!entries) return;
+    this.events.set(
+      event,
+      entries.filter((entry) => entry.listener !== listenerRef)
     );
   }
 
@@ -35,8 +31,9 @@ export class EventEmitter {
     event = event.startsWith("on")
       ? event.slice(2, 3).toLowerCase() + event.slice(3)
       : event;
-    if (!this.events[event]) return;
-    for (const { listener, args: listenerArgs } of this.events[event]) {
+    const entries = this.events.get(event);
+    if (!entries) return;
+    for (const { listener, args: listenerArgs } of entries) {
       await listener(...args, ...listenerArgs);
     }
   }

--- a/packages/core/tests/modules/eventEmitter.test.js
+++ b/packages/core/tests/modules/eventEmitter.test.js
@@ -11,9 +11,9 @@ describe("EventEmitter", () => {
     const mockListener = vi.fn();
     emitter.on("testEvent", mockListener, "arg1", "arg2");
 
-    expect(emitter["events"]["testEvent"]).toHaveLength(1);
-    expect(emitter["events"]["testEvent"][0].listener).toBe(mockListener);
-    expect(emitter["events"]["testEvent"][0].args).toEqual(["arg1", "arg2"]);
+    expect(emitter.events.get("testEvent")).toHaveLength(1);
+    expect(emitter.events.get("testEvent")[0].listener).toBe(mockListener);
+    expect(emitter.events.get("testEvent")[0].args).toEqual(["arg1", "arg2"]);
   });
 
   it("should prevent duplicate listeners for the same event", () => {
@@ -21,7 +21,7 @@ describe("EventEmitter", () => {
     emitter.on("testEvent", mockListener);
     emitter.on("testEvent", mockListener); // Attempt to add a duplicate
 
-    expect(emitter["events"]["testEvent"]).toHaveLength(1);
+    expect(emitter.events.get("testEvent")).toHaveLength(1);
   });
 
   it("should allow different listeners for the same event", () => {
@@ -30,9 +30,9 @@ describe("EventEmitter", () => {
     emitter.on("testEvent", listenerOne);
     emitter.on("testEvent", listenerTwo);
 
-    expect(emitter["events"]["testEvent"]).toHaveLength(2);
-    expect(emitter["events"]["testEvent"][0].listener).toBe(listenerOne);
-    expect(emitter["events"]["testEvent"][1].listener).toBe(listenerTwo);
+    expect(emitter.events.get("testEvent")).toHaveLength(2);
+    expect(emitter.events.get("testEvent")[0].listener).toBe(listenerOne);
+    expect(emitter.events.get("testEvent")[1].listener).toBe(listenerTwo);
   });
 
   it("should remove a listener with off", () => {
@@ -40,7 +40,7 @@ describe("EventEmitter", () => {
     emitter.on("testEvent", mockListener);
     emitter.off("testEvent", mockListener);
 
-    expect(emitter["events"]["testEvent"]).toHaveLength(0);
+    expect(emitter.events.get("testEvent")).toHaveLength(0);
   });
 
   it("should handle off when the event does not exist", () => {

--- a/packages/core/tests/plugins/focusTrap.test.js
+++ b/packages/core/tests/plugins/focusTrap.test.js
@@ -32,8 +32,8 @@ describe("focusTrap", () => {
     await collection.mount();
     expect(collection.plugins.length).toBe(1);
     expect(typeof collection.plugins.get("focusTrap")).toBe("object");
-    expect(collection.events.opened.length).toBe(1);
-    expect(collection.events.closed.length).toBe(1);
+    expect(collection.events.get("opened").length).toBe(1);
+    expect(collection.events.get("closed").length).toBe(1);
   });
 
   it("should run plugin teardown method when collection unmounts", async () => {
@@ -43,8 +43,8 @@ describe("focusTrap", () => {
     expect(collection.plugins.length).toBe(1);
     await collection.unmount();
     expect(collection.plugins.get("focusTrap")).toBe(null);
-    expect(collection.events.opened.length).toBe(0);
-    expect(collection.events.closed.length).toBe(0);
+    expect(collection.events.get("opened").length).toBe(0);
+    expect(collection.events.get("closed").length).toBe(0);
   });
 
   it("should create focusTrap property on create entry lifecycle hook", async () => {

--- a/packages/drawer/src/js/Drawer.ts
+++ b/packages/drawer/src/js/Drawer.ts
@@ -7,7 +7,7 @@ import { close } from "./close";
 import { toggle } from "./toggle";
 
 export class Drawer extends Collection<DrawerEntry, DrawerConfig> {
-  entryClass = DrawerEntry;
+  readonly entryClass = DrawerEntry;
 
   constructor(options: Partial<DrawerConfig>) {
     super({ ...config, ...options });

--- a/packages/drawer/src/js/Drawer.ts
+++ b/packages/drawer/src/js/Drawer.ts
@@ -1,4 +1,4 @@
-import { Collection } from "@vrembem/core";
+import { Collection, _ } from "@vrembem/core";
 import { config, DrawerConfig } from "./config";
 import { DrawerEntry } from "./DrawerEntry";
 import { handleClick, handleKeydown } from "./handlers";
@@ -7,15 +7,19 @@ import { close } from "./close";
 import { toggle } from "./toggle";
 
 export class Drawer extends Collection<DrawerEntry, DrawerConfig> {
-  #handleClick: (event: MouseEvent) => Promise<void | DrawerEntry>;
-  #handleKeydown: (event: KeyboardEvent) => void;
   entryClass = DrawerEntry;
 
   constructor(options: Partial<DrawerConfig>) {
     super({ ...config, ...options });
     this.name = "Drawer";
-    this.#handleClick = handleClick.bind(this);
-    this.#handleKeydown = handleKeydown.bind(this);
+
+    // Set the initial state of private store
+    _(this, {
+      handlers: {
+        click: handleClick.bind(this),
+        keydown: handleKeydown.bind(this)
+      }
+    });
   }
 
   get activeModal(): DrawerEntry | undefined {
@@ -52,12 +56,12 @@ export class Drawer extends Collection<DrawerEntry, DrawerConfig> {
   }
 
   async afterMount() {
-    document.addEventListener("click", this.#handleClick, false);
-    document.addEventListener("keydown", this.#handleKeydown, false);
+    document.addEventListener("click", _(this).handlers.click);
+    document.addEventListener("keydown", _(this).handlers.keydown);
   }
 
   async afterUnmount() {
-    document.removeEventListener("click", this.#handleClick, false);
-    document.removeEventListener("keydown", this.#handleKeydown, false);
+    document.removeEventListener("click", _(this).handlers.click);
+    document.removeEventListener("keydown", _(this).handlers.keydown);
   }
 }

--- a/packages/drawer/src/js/DrawerEntry.ts
+++ b/packages/drawer/src/js/DrawerEntry.ts
@@ -13,7 +13,7 @@ export class DrawerEntry extends CollectionEntry {
   constructor(parent: Drawer, query: string | HTMLElement) {
     super(parent, query);
 
-    // Setup initial states of private variables
+    // Set the initial state of private store
     _(this, {
       mode: "indeterminate",
       state: "indeterminate",

--- a/packages/modal/src/js/Modal.ts
+++ b/packages/modal/src/js/Modal.ts
@@ -1,4 +1,4 @@
-import { Collection, StackArray, setGlobalState } from "@vrembem/core";
+import { Collection, StackArray, setGlobalState, _ } from "@vrembem/core";
 import { config, ModalConfig } from "./config";
 import { ModalEntry } from "./ModalEntry";
 import { handleClick, handleKeydown } from "./handlers";
@@ -9,8 +9,6 @@ import { replace } from "./replace";
 import { updateFocusState } from "./helpers/updateFocusState";
 
 export class Modal extends Collection<ModalEntry, ModalConfig> {
-  #handleClick: (event: MouseEvent) => void;
-  #handleKeydown: (event: KeyboardEvent) => void;
   entryClass = ModalEntry;
   trigger: HTMLElement | null;
   stack: StackArray<ModalEntry>;
@@ -19,8 +17,14 @@ export class Modal extends Collection<ModalEntry, ModalConfig> {
     super({ ...config, ...options });
     this.name = "Modal";
     this.trigger = null;
-    this.#handleClick = handleClick.bind(this);
-    this.#handleKeydown = handleKeydown.bind(this);
+
+    // Set the initial state of private store
+    _(this, {
+      handlers: {
+        click: handleClick.bind(this),
+        keydown: handleKeydown.bind(this)
+      }
+    });
 
     // Setup stack property using StackArray
     this.stack = new StackArray({
@@ -80,8 +84,8 @@ export class Modal extends Collection<ModalEntry, ModalConfig> {
   }
 
   async afterMount() {
-    document.addEventListener("click", this.#handleClick, false);
-    document.addEventListener("keydown", this.#handleKeydown, false);
+    document.addEventListener("click", _(this).handlers.click);
+    document.addEventListener("keydown", _(this).handlers.keydown);
   }
 
   async beforeUnmount() {
@@ -89,7 +93,7 @@ export class Modal extends Collection<ModalEntry, ModalConfig> {
   }
 
   async afterUnmount() {
-    document.removeEventListener("click", this.#handleClick, false);
-    document.removeEventListener("keydown", this.#handleKeydown, false);
+    document.removeEventListener("click", _(this).handlers.click);
+    document.removeEventListener("keydown", _(this).handlers.keydown);
   }
 }

--- a/packages/modal/src/js/Modal.ts
+++ b/packages/modal/src/js/Modal.ts
@@ -9,7 +9,7 @@ import { replace } from "./replace";
 import { updateFocusState } from "./helpers/updateFocusState";
 
 export class Modal extends Collection<ModalEntry, ModalConfig> {
-  entryClass = ModalEntry;
+  readonly entryClass = ModalEntry;
   trigger: HTMLElement | null;
   stack: StackArray<ModalEntry>;
 

--- a/packages/notice/src/_notice.scss
+++ b/packages/notice/src/_notice.scss
@@ -17,6 +17,6 @@
 
 #{core.bem("notice", "title")} {
   font-size: css.get("notice", "title-font-size", css.get("font-size-lg"));
-  font-weight: css.get("notice", "title-line-height", css.get("font-weight-semi-bold"));
-  line-height: css.get("notice", "title-font-weight", css.get("line-height"));
+  font-weight: css.get("notice", "title-font-weight", css.get("font-weight-semi-bold"));
+  line-height: css.get("notice", "title-line-height", inherit);
 }

--- a/packages/popover/index.html
+++ b/packages/popover/index.html
@@ -11,7 +11,7 @@
     import Popover from "./index.ts";
     import { teleport, cssConfig, attrConfig } from "@vrembem/core";
 
-    const popover = new Popover({
+    const popovers = new Popover({
       plugins: [
         cssConfig(),
         attrConfig(),
@@ -21,7 +21,7 @@
       ]
     });
 
-    window["popover"] = await popover.mount();
+    window["popovers"] = await popovers.mount();
   </script>
 </head>
 <body>

--- a/packages/popover/index.html
+++ b/packages/popover/index.html
@@ -63,12 +63,11 @@
 
       <h2 id="popover-virtual"><a href="#popover-virtual">virtual popover</a></h2>
 
-      <button class="button" aria-describedby="popover-virtual-1">Copy</button>
+      <button class="button" aria-describedby="popover-virtual">Follow cursor</button>
       <div 
-        id="popover-virtual-1" 
+        id="popover-virtual" 
         class="popover popover_tooltip"
-        data-config='{"virtual": true}'
-        style="--vb-popover-event: click;"
+        style="--vb-popover-event: click; --vb-popover-follow-cursor: true;"
       >
         Virtual popover...
       </div>

--- a/packages/popover/src/js/Popover.ts
+++ b/packages/popover/src/js/Popover.ts
@@ -6,7 +6,7 @@ import { open } from "./open";
 import { close, closeAll } from "./close";
 
 export class Popover extends Collection<PopoverEntry, PopoverConfig> {
-  entryClass = PopoverEntry;
+  readonly entryClass = PopoverEntry;
   trigger: HTMLElement | null = null;
 
   constructor(options: Partial<PopoverConfig>) {

--- a/packages/popover/src/js/Popover.ts
+++ b/packages/popover/src/js/Popover.ts
@@ -10,7 +10,7 @@ import { VirtualElement } from "@floating-ui/dom";
 export class Popover extends Collection<PopoverEntry, PopoverConfig> {
   #handleKeydown: (event: KeyboardEvent) => void;
   #handleMousemove: (event: MouseEvent) => void;
-  #virtual: boolean = false;
+  #virtual = false;
   entryClass = PopoverEntry;
   trigger: HTMLElement | null = null;
   virtualElement: VirtualElement | null = null;

--- a/packages/popover/src/js/Popover.ts
+++ b/packages/popover/src/js/Popover.ts
@@ -15,8 +15,8 @@ export class Popover extends Collection<PopoverEntry, PopoverConfig> {
 
     // Set the initial state of private store
     _(this, {
-      virtual: false,
-      virtualElement: null,
+      trackCursor: false,
+      cursorElement: null,
       handlers: {
         keydown: handleKeydown.bind(this),
         mousemove: handleMousemove.bind(this)
@@ -36,22 +36,6 @@ export class Popover extends Collection<PopoverEntry, PopoverConfig> {
     });
   }
 
-  get virtual(): boolean {
-    return _(this).virtual;
-  }
-
-  set virtual(value) {
-    if (value === _(this).virtual) return;
-
-    _(this).virtual = value;
-
-    if (value) {
-      document.addEventListener("mousemove", _(this).handlers.mousemove);
-    } else {
-      document.removeEventListener("mousemove", _(this).handlers.mousemove);
-    }
-  }
-
   async open(id: string): Promise<PopoverEntry> {
     const entry = this.getOrThrow(id);
     return open(entry);
@@ -68,14 +52,20 @@ export class Popover extends Collection<PopoverEntry, PopoverConfig> {
 
   async afterMount() {
     document.addEventListener("keydown", _(this).handlers.keydown);
+
+    // If the track cursor var has been toggled, apply the event listener to
+    // keep updated the cursor element.
+    if (_(this).trackCursor) {
+      document.addEventListener("mousemove", _(this).handlers.mousemove);
+    }
   }
 
   async beforeUnmount() {
     this.trigger = null;
-    this.virtual = false;
   }
 
   async afterUnmount() {
     document.removeEventListener("keydown", _(this).handlers.keydown);
+    document.removeEventListener("mousemove", _(this).handlers.mousemove);
   }
 }

--- a/packages/popover/src/js/Popover.ts
+++ b/packages/popover/src/js/Popover.ts
@@ -16,6 +16,7 @@ export class Popover extends Collection<PopoverEntry, PopoverConfig> {
     super({ ...config, ...options });
     this.name = "Popover";
 
+    // Set the initial state of private store
     _(this, {
       virtual: false,
       handlers: {

--- a/packages/popover/src/js/Popover.ts
+++ b/packages/popover/src/js/Popover.ts
@@ -55,7 +55,7 @@ export class Popover extends Collection<PopoverEntry, PopoverConfig> {
     return open(entry);
   }
 
-  async close(id: string): Promise<PopoverEntry | PopoverEntry[]> {
+  async close(id?: string): Promise<PopoverEntry | PopoverEntry[]> {
     const entry = id ? this.getOrThrow(id) : undefined;
     if (entry) {
       return close(entry);

--- a/packages/popover/src/js/Popover.ts
+++ b/packages/popover/src/js/Popover.ts
@@ -4,12 +4,10 @@ import { PopoverEntry } from "./PopoverEntry";
 import { handleKeydown, handleMousemove } from "./handlers";
 import { open } from "./open";
 import { close, closeAll } from "./close";
-import { VirtualElement } from "@floating-ui/dom";
 
 export class Popover extends Collection<PopoverEntry, PopoverConfig> {
   entryClass = PopoverEntry;
   trigger: HTMLElement | null = null;
-  virtualElement: VirtualElement | null = null;
 
   constructor(options: Partial<PopoverConfig>) {
     super({ ...config, ...options });
@@ -18,6 +16,7 @@ export class Popover extends Collection<PopoverEntry, PopoverConfig> {
     // Set the initial state of private store
     _(this, {
       virtual: false,
+      virtualElement: null,
       handlers: {
         keydown: handleKeydown.bind(this),
         mousemove: handleMousemove.bind(this)

--- a/packages/popover/src/js/Popover.ts
+++ b/packages/popover/src/js/Popover.ts
@@ -37,7 +37,7 @@ export class Popover extends Collection<PopoverEntry, PopoverConfig> {
     });
   }
 
-  get virtual() {
+  get virtual(): boolean {
     return _(this).virtual;
   }
 

--- a/packages/popover/src/js/Popover.ts
+++ b/packages/popover/src/js/Popover.ts
@@ -1,5 +1,4 @@
 import { Collection, _ } from "@vrembem/core";
-
 import { config, PopoverConfig } from "./config";
 import { PopoverEntry } from "./PopoverEntry";
 import { handleKeydown, handleMousemove } from "./handlers";

--- a/packages/popover/src/js/Popover.ts
+++ b/packages/popover/src/js/Popover.ts
@@ -1,4 +1,4 @@
-import { Collection } from "@vrembem/core";
+import { Collection, _ } from "@vrembem/core";
 
 import { config, PopoverConfig } from "./config";
 import { PopoverEntry } from "./PopoverEntry";
@@ -8,9 +8,6 @@ import { close, closeAll } from "./close";
 import { VirtualElement } from "@floating-ui/dom";
 
 export class Popover extends Collection<PopoverEntry, PopoverConfig> {
-  #handleKeydown: (event: KeyboardEvent) => void;
-  #handleMousemove: (event: MouseEvent) => void;
-  #virtual = false;
   entryClass = PopoverEntry;
   trigger: HTMLElement | null = null;
   virtualElement: VirtualElement | null = null;
@@ -18,8 +15,14 @@ export class Popover extends Collection<PopoverEntry, PopoverConfig> {
   constructor(options: Partial<PopoverConfig>) {
     super({ ...config, ...options });
     this.name = "Popover";
-    this.#handleKeydown = handleKeydown.bind(this);
-    this.#handleMousemove = handleMousemove.bind(this);
+
+    _(this, {
+      virtual: false,
+      handlers: {
+        keydown: handleKeydown.bind(this),
+        mousemove: handleMousemove.bind(this)
+      }
+    });
   }
 
   get active(): PopoverEntry | undefined {
@@ -35,18 +38,18 @@ export class Popover extends Collection<PopoverEntry, PopoverConfig> {
   }
 
   get virtual() {
-    return this.#virtual;
+    return _(this).virtual;
   }
 
   set virtual(value) {
-    if (value === this.#virtual) return;
+    if (value === _(this).virtual) return;
 
-    this.#virtual = value;
+    _(this).virtual = value;
 
     if (value) {
-      document.addEventListener("mousemove", this.#handleMousemove, false);
+      document.addEventListener("mousemove", _(this).handlers.mousemove);
     } else {
-      document.removeEventListener("mousemove", this.#handleMousemove, false);
+      document.removeEventListener("mousemove", _(this).handlers.mousemove);
     }
   }
 
@@ -65,7 +68,7 @@ export class Popover extends Collection<PopoverEntry, PopoverConfig> {
   }
 
   async afterMount() {
-    document.addEventListener("keydown", this.#handleKeydown, false);
+    document.addEventListener("keydown", _(this).handlers.keydown);
   }
 
   async beforeUnmount() {
@@ -74,6 +77,6 @@ export class Popover extends Collection<PopoverEntry, PopoverConfig> {
   }
 
   async afterUnmount() {
-    document.removeEventListener("keydown", this.#handleKeydown, false);
+    document.removeEventListener("keydown", _(this).handlers.keydown);
   }
 }

--- a/packages/popover/src/js/PopoverEntry.ts
+++ b/packages/popover/src/js/PopoverEntry.ts
@@ -10,7 +10,7 @@ import {
 import type { Popover } from "./Popover";
 
 type EventObject = {
-  el: string[];
+  el: ("el" | "trigger")[];
   type: string[];
   listener: (event: MouseEvent | Event) => void;
 };
@@ -101,7 +101,7 @@ export class PopoverEntry extends CollectionEntry {
         this.#eventListeners.forEach((evObj) => {
           evObj.el.forEach((el) => {
             evObj.type.forEach((type) => {
-              (this[el as "el" | "trigger"] as HTMLElement).addEventListener(
+              (this[el] as HTMLElement).addEventListener(
                 type,
                 evObj.listener,
                 false
@@ -126,7 +126,7 @@ export class PopoverEntry extends CollectionEntry {
         this.#eventListeners.forEach((evObj) => {
           evObj.el.forEach((el) => {
             evObj.type.forEach((type) => {
-              (this[el as "el" | "trigger"] as HTMLElement).addEventListener(
+              (this[el] as HTMLElement).addEventListener(
                 type,
                 evObj.listener,
                 false
@@ -145,7 +145,7 @@ export class PopoverEntry extends CollectionEntry {
       this.#eventListeners.forEach((evObj) => {
         evObj.el.forEach((el) => {
           evObj.type.forEach((type) => {
-            (this[el as "el" | "trigger"] as HTMLElement).removeEventListener(
+            (this[el] as HTMLElement).removeEventListener(
               type,
               evObj.listener,
               false

--- a/packages/popover/src/js/PopoverEntry.ts
+++ b/packages/popover/src/js/PopoverEntry.ts
@@ -9,10 +9,10 @@ import {
 } from "./handlers";
 import type { Popover } from "./Popover";
 
-type EventObject = {
-  el: ("el" | "trigger")[];
-  type: string[];
-  listener: (event: MouseEvent | Event) => void;
+type EventBinding = {
+  keys: ("el" | "trigger")[];
+  events: string[];
+  handler: (event: MouseEvent | Event) => void;
 };
 
 export class PopoverEntry extends CollectionEntry {
@@ -85,28 +85,28 @@ export class PopoverEntry extends CollectionEntry {
         // Setup event listeners object for hover
         _(this).events = [
           {
-            el: ["el", "trigger"],
-            type: ["mouseenter", "focus"],
-            listener: handleMouseEnter.bind(this.parent, this)
+            keys: ["el", "trigger"],
+            events: ["mouseenter", "focus"],
+            handler: handleMouseEnter.bind(this.parent, this)
           },
           {
-            el: ["el", "trigger"],
-            type: ["mouseleave", "focusout"],
-            listener: handleMouseLeave.bind(this.parent, this)
+            keys: ["el", "trigger"],
+            events: ["mouseleave", "focusout"],
+            handler: handleMouseLeave.bind(this.parent, this)
           },
           {
-            el: ["trigger"],
-            type: ["click"],
-            listener: handleTooltipClick.bind(null, this)
+            keys: ["trigger"],
+            events: ["click"],
+            handler: handleTooltipClick.bind(null, this)
           }
         ];
 
         // Loop through listeners and apply to the appropriate elements
-        _(this).events.forEach((eventObj: EventObject) => {
-          eventObj.el.forEach((el) => {
-            eventObj.type.forEach((type) => {
-              const target = this[el] as HTMLElement;
-              target.addEventListener(type, eventObj.listener);
+        _(this).events.forEach((eventObj: EventBinding) => {
+          eventObj.keys.forEach((key) => {
+            eventObj.events.forEach((event) => {
+              const target = this[key] as HTMLElement;
+              target.addEventListener(event, eventObj.handler);
             });
           });
         });
@@ -117,18 +117,18 @@ export class PopoverEntry extends CollectionEntry {
         // Setup event listeners object for click
         _(this).events = [
           {
-            el: ["trigger"],
-            type: ["click"],
-            listener: handleClick.bind(this.parent, this)
+            keys: ["trigger"],
+            events: ["click"],
+            handler: handleClick.bind(this.parent, this)
           }
         ];
 
         // Loop through listeners and apply to the appropriate elements
-        _(this).events.forEach((eventObj: EventObject) => {
-          eventObj.el.forEach((el) => {
-            eventObj.type.forEach((type) => {
-              const target = this[el] as HTMLElement;
-              target.addEventListener(type, eventObj.listener);
+        _(this).events.forEach((eventObj: EventBinding) => {
+          eventObj.keys.forEach((key) => {
+            eventObj.events.forEach((event) => {
+              const target = this[key] as HTMLElement;
+              target.addEventListener(event, eventObj.handler);
             });
           });
         });
@@ -140,11 +140,11 @@ export class PopoverEntry extends CollectionEntry {
     // If event listeners have been setup
     if (_(this).events) {
       // Loop through listeners and remove from the appropriate elements
-      _(this).events.forEach((eventObj: EventObject) => {
-        eventObj.el.forEach((el) => {
-          eventObj.type.forEach((type) => {
-            const target = this[el] as HTMLElement;
-            target.removeEventListener(type, eventObj.listener);
+      _(this).events.forEach((eventObj: EventBinding) => {
+        eventObj.keys.forEach((key) => {
+          eventObj.events.forEach((event) => {
+            const target = this[key] as HTMLElement;
+            target.removeEventListener(event, eventObj.handler);
           });
         });
       });

--- a/packages/popover/src/js/PopoverEntry.ts
+++ b/packages/popover/src/js/PopoverEntry.ts
@@ -17,17 +17,14 @@ type EventObject = {
 
 export class PopoverEntry extends CollectionEntry {
   #eventListeners: EventObject[] = [];
-  #isHovered: {
-    el: boolean;
-    trigger: boolean;
-  } = {
+  #isHovered = {
     el: false,
     trigger: false
   };
-  state: string = "closed";
+  state = "closed";
   trigger: HTMLElement | null = null;
   toggleDelayId: number | null = null;
-  floatingCleanup: () => void = () => {};
+  floatingCleanup = () => {};
 
   constructor(parent: Popover, query: string | HTMLElement) {
     super(parent, query);

--- a/packages/popover/src/js/PopoverEntry.ts
+++ b/packages/popover/src/js/PopoverEntry.ts
@@ -1,4 +1,4 @@
-import { CollectionEntry } from "@vrembem/core";
+import { CollectionEntry, _ } from "@vrembem/core";
 import { open } from "./open";
 import { close } from "./close";
 import {
@@ -16,11 +16,6 @@ type EventObject = {
 };
 
 export class PopoverEntry extends CollectionEntry {
-  #eventListeners: EventObject[] = [];
-  #isHovered = {
-    el: false,
-    trigger: false
-  };
   state = "closed";
   trigger: HTMLElement | null = null;
   toggleDelayId: number | null = null;
@@ -28,6 +23,15 @@ export class PopoverEntry extends CollectionEntry {
 
   constructor(parent: Popover, query: string | HTMLElement) {
     super(parent, query);
+
+    // Setup initial states of private variables
+    _(this, {
+      events: [] as EventObject[],
+      hovered: {
+        el: false,
+        trigger: false
+      }
+    });
   }
 
   get isTooltip(): boolean {
@@ -38,7 +42,7 @@ export class PopoverEntry extends CollectionEntry {
   }
 
   get isHovered(): boolean {
-    return this.#isHovered.el || this.#isHovered.trigger;
+    return _(this).hovered.el || _(this).hovered.trigger;
   }
 
   set isHovered(event: MouseEvent | FocusEvent) {
@@ -54,10 +58,10 @@ export class PopoverEntry extends CollectionEntry {
     // Store the hover state if the event target matches the el or trigger
     switch (event.target) {
       case this.el:
-        this.#isHovered.el = state;
+        _(this).hovered.el = state;
         break;
       case this.trigger:
-        this.#isHovered.trigger = state;
+        _(this).hovered.trigger = state;
         break;
     }
   }
@@ -72,14 +76,14 @@ export class PopoverEntry extends CollectionEntry {
 
   registerEventListeners() {
     // If event listeners aren't already setup
-    if (!this.#eventListeners.length) {
+    if (!_(this).events.length) {
       // Add event listeners based on event type
       const eventType = this.config.get("event");
 
       // If the event type is hover
       if (eventType === "hover") {
         // Setup event listeners object for hover
-        this.#eventListeners = [
+        _(this).events = [
           {
             el: ["el", "trigger"],
             type: ["mouseenter", "focus"],
@@ -98,12 +102,12 @@ export class PopoverEntry extends CollectionEntry {
         ];
 
         // Loop through listeners and apply to the appropriate elements
-        this.#eventListeners.forEach((evObj) => {
-          evObj.el.forEach((el) => {
-            evObj.type.forEach((type) => {
+        _(this).events.forEach((eventObj: EventObject) => {
+          eventObj.el.forEach((el) => {
+            eventObj.type.forEach((type) => {
               (this[el] as HTMLElement).addEventListener(
                 type,
-                evObj.listener,
+                eventObj.listener,
                 false
               );
             });
@@ -114,7 +118,7 @@ export class PopoverEntry extends CollectionEntry {
       // Else the event type is click
       else {
         // Setup event listeners object for click
-        this.#eventListeners = [
+        _(this).events = [
           {
             el: ["trigger"],
             type: ["click"],
@@ -123,12 +127,12 @@ export class PopoverEntry extends CollectionEntry {
         ];
 
         // Loop through listeners and apply to the appropriate elements
-        this.#eventListeners.forEach((evObj) => {
-          evObj.el.forEach((el) => {
-            evObj.type.forEach((type) => {
+        _(this).events.forEach((eventObj: EventObject) => {
+          eventObj.el.forEach((el) => {
+            eventObj.type.forEach((type) => {
               (this[el] as HTMLElement).addEventListener(
                 type,
-                evObj.listener,
+                eventObj.listener,
                 false
               );
             });
@@ -140,14 +144,14 @@ export class PopoverEntry extends CollectionEntry {
 
   deregisterEventListeners() {
     // If event listeners have been setup
-    if (this.#eventListeners) {
+    if (_(this).events) {
       // Loop through listeners and remove from the appropriate elements
-      this.#eventListeners.forEach((evObj) => {
-        evObj.el.forEach((el) => {
-          evObj.type.forEach((type) => {
+      _(this).events.forEach((eventObj: EventObject) => {
+        eventObj.el.forEach((el) => {
+          eventObj.type.forEach((type) => {
             (this[el] as HTMLElement).removeEventListener(
               type,
-              evObj.listener,
+              eventObj.listener,
               false
             );
           });
@@ -155,7 +159,7 @@ export class PopoverEntry extends CollectionEntry {
       });
 
       // Remove eventListeners object from collection
-      this.#eventListeners = [];
+      _(this).events = [];
     }
   }
 

--- a/packages/popover/src/js/PopoverEntry.ts
+++ b/packages/popover/src/js/PopoverEntry.ts
@@ -18,8 +18,6 @@ type EventBinding = {
 export class PopoverEntry extends CollectionEntry {
   state = "closed";
   trigger: HTMLElement | null = null;
-  toggleDelayId: number | null = null;
-  floatingCleanup = () => {};
 
   constructor(parent: Popover, query: string | HTMLElement) {
     super(parent, query);
@@ -30,7 +28,9 @@ export class PopoverEntry extends CollectionEntry {
       hovered: {
         el: false,
         trigger: false
-      }
+      },
+      toggleDelayId: null,
+      floatingCleanup: () => {}
     });
   }
 
@@ -193,7 +193,7 @@ export class PopoverEntry extends CollectionEntry {
     }
 
     // Clean up the floating UI instance
-    this.floatingCleanup();
+    _(this).floatingCleanup();
 
     // Remove event listeners
     this.deregisterEventListeners();

--- a/packages/popover/src/js/PopoverEntry.ts
+++ b/packages/popover/src/js/PopoverEntry.ts
@@ -2,18 +2,10 @@ import { CollectionEntry, _ } from "@vrembem/core";
 import { open } from "./open";
 import { close } from "./close";
 import {
-  handleClick,
-  handleTooltipClick,
-  handleMouseEnter,
-  handleMouseLeave
-} from "./handlers";
+  registerEventListeners,
+  deregisterEventListeners
+} from "./eventListeners";
 import type { Popover } from "./Popover";
-
-type EventBinding = {
-  keys: ("el" | "trigger")[];
-  events: string[];
-  handler: (event: MouseEvent | Event) => void;
-};
 
 export class PopoverEntry extends CollectionEntry {
   state: "closed" | "opened" = "closed";
@@ -74,86 +66,6 @@ export class PopoverEntry extends CollectionEntry {
     return close(this);
   }
 
-  registerEventListeners() {
-    // If event listeners aren't already setup
-    if (!_(this).events.length) {
-      // Add event listeners based on event type
-      const eventType = this.config.get("event");
-
-      // If the event type is hover
-      if (eventType === "hover") {
-        // Setup event listeners object for hover
-        _(this).events = [
-          {
-            keys: ["el", "trigger"],
-            events: ["mouseenter", "focus"],
-            handler: handleMouseEnter.bind(this.parent, this)
-          },
-          {
-            keys: ["el", "trigger"],
-            events: ["mouseleave", "focusout"],
-            handler: handleMouseLeave.bind(this.parent, this)
-          },
-          {
-            keys: ["trigger"],
-            events: ["click"],
-            handler: handleTooltipClick.bind(null, this)
-          }
-        ];
-
-        // Loop through listeners and apply to the appropriate elements
-        _(this).events.forEach((eventObj: EventBinding) => {
-          eventObj.keys.forEach((key) => {
-            eventObj.events.forEach((event) => {
-              const target = this[key] as HTMLElement;
-              target.addEventListener(event, eventObj.handler);
-            });
-          });
-        });
-      }
-
-      // Else the event type is click
-      else {
-        // Setup event listeners object for click
-        _(this).events = [
-          {
-            keys: ["trigger"],
-            events: ["click"],
-            handler: handleClick.bind(this.parent, this)
-          }
-        ];
-
-        // Loop through listeners and apply to the appropriate elements
-        _(this).events.forEach((eventObj: EventBinding) => {
-          eventObj.keys.forEach((key) => {
-            eventObj.events.forEach((event) => {
-              const target = this[key] as HTMLElement;
-              target.addEventListener(event, eventObj.handler);
-            });
-          });
-        });
-      }
-    }
-  }
-
-  deregisterEventListeners() {
-    // If event listeners have been setup
-    if (_(this).events) {
-      // Loop through listeners and remove from the appropriate elements
-      _(this).events.forEach((eventObj: EventBinding) => {
-        eventObj.keys.forEach((key) => {
-          eventObj.events.forEach((event) => {
-            const target = this[key] as HTMLElement;
-            target.removeEventListener(event, eventObj.handler);
-          });
-        });
-      });
-
-      // Remove eventListeners object from collection
-      _(this).events = [];
-    }
-  }
-
   async onCreateEntry() {
     // Get the trigger element
     this.trigger = document.querySelector(
@@ -176,7 +88,7 @@ export class PopoverEntry extends CollectionEntry {
 
   async onRegisterEntry() {
     // Setup event listeners
-    this.registerEventListeners();
+    registerEventListeners(this);
 
     // Set initial state based on the presence of the active class
     if (this.el.classList.contains(this.config.get("stateActive"))) {
@@ -196,6 +108,6 @@ export class PopoverEntry extends CollectionEntry {
     _(this).floatingCleanup();
 
     // Remove event listeners
-    this.deregisterEventListeners();
+    deregisterEventListeners(this);
   }
 }

--- a/packages/popover/src/js/PopoverEntry.ts
+++ b/packages/popover/src/js/PopoverEntry.ts
@@ -37,16 +37,13 @@ export class PopoverEntry extends CollectionEntry {
     return _(this).hovered.el || _(this).hovered.trigger;
   }
 
-  set isHovered(event: MouseEvent | FocusEvent) {
-    // The state can either be true, false or undefined based on event type
-    const state =
-      event.type == "mouseenter"
-        ? true
-        : event.type == "mouseleave"
-          ? false
-          : undefined;
+  setHovered(event: MouseEvent | FocusEvent) {
     // Guard in case the event type is not "mouseenter" or "mouseleave"
-    if (state == undefined) return;
+    if (event.type !== "mouseenter" && event.type !== "mouseleave") return;
+
+    // Set the boolean state
+    const state = event.type == "mouseenter";
+
     // Store the hover state if the event target matches the el or trigger
     switch (event.target) {
       case this.el:

--- a/packages/popover/src/js/PopoverEntry.ts
+++ b/packages/popover/src/js/PopoverEntry.ts
@@ -16,7 +16,7 @@ type EventBinding = {
 };
 
 export class PopoverEntry extends CollectionEntry {
-  state = "closed";
+  state: "closed" | "opened" = "closed";
   trigger: HTMLElement | null = null;
 
   constructor(parent: Popover, query: string | HTMLElement) {

--- a/packages/popover/src/js/PopoverEntry.ts
+++ b/packages/popover/src/js/PopoverEntry.ts
@@ -24,7 +24,7 @@ export class PopoverEntry extends CollectionEntry {
   constructor(parent: Popover, query: string | HTMLElement) {
     super(parent, query);
 
-    // Set the initial states of private variables
+    // Set the initial state of private store
     _(this, {
       events: [],
       hovered: {

--- a/packages/popover/src/js/PopoverEntry.ts
+++ b/packages/popover/src/js/PopoverEntry.ts
@@ -37,24 +37,6 @@ export class PopoverEntry extends CollectionEntry {
     return _(this).hovered.el || _(this).hovered.trigger;
   }
 
-  setHovered(event: MouseEvent | FocusEvent) {
-    // Guard in case the event type is not "mouseenter" or "mouseleave"
-    if (event.type !== "mouseenter" && event.type !== "mouseleave") return;
-
-    // Set the boolean state
-    const state = event.type == "mouseenter";
-
-    // Store the hover state if the event target matches the el or trigger
-    switch (event.target) {
-      case this.el:
-        _(this).hovered.el = state;
-        break;
-      case this.trigger:
-        _(this).hovered.trigger = state;
-        break;
-    }
-  }
-
   async open(): Promise<PopoverEntry> {
     return open(this);
   }

--- a/packages/popover/src/js/PopoverEntry.ts
+++ b/packages/popover/src/js/PopoverEntry.ts
@@ -69,6 +69,14 @@ export class PopoverEntry extends CollectionEntry {
     // Setup event listeners
     registerEventListeners(this);
 
+    // If this popover is set to anchor to he cursor
+    if (this.config.get("followCursor")) {
+      // Enable cursor tracking on the parent collection
+      _(this.parent).trackCursor = true;
+      // Add the virtual state class to the popover
+      this.el.classList.add(this.config.get("stateVirtual"));
+    }
+
     // Set initial state based on the presence of the active class
     if (this.el.classList.contains(this.config.get("stateActive"))) {
       await this.open();

--- a/packages/popover/src/js/PopoverEntry.ts
+++ b/packages/popover/src/js/PopoverEntry.ts
@@ -24,9 +24,9 @@ export class PopoverEntry extends CollectionEntry {
   constructor(parent: Popover, query: string | HTMLElement) {
     super(parent, query);
 
-    // Setup initial states of private variables
+    // Set the initial states of private variables
     _(this, {
-      events: [] as EventObject[],
+      events: [],
       hovered: {
         el: false,
         trigger: false
@@ -105,11 +105,8 @@ export class PopoverEntry extends CollectionEntry {
         _(this).events.forEach((eventObj: EventObject) => {
           eventObj.el.forEach((el) => {
             eventObj.type.forEach((type) => {
-              (this[el] as HTMLElement).addEventListener(
-                type,
-                eventObj.listener,
-                false
-              );
+              const target = this[el] as HTMLElement;
+              target.addEventListener(type, eventObj.listener);
             });
           });
         });
@@ -130,11 +127,8 @@ export class PopoverEntry extends CollectionEntry {
         _(this).events.forEach((eventObj: EventObject) => {
           eventObj.el.forEach((el) => {
             eventObj.type.forEach((type) => {
-              (this[el] as HTMLElement).addEventListener(
-                type,
-                eventObj.listener,
-                false
-              );
+              const target = this[el] as HTMLElement;
+              target.addEventListener(type, eventObj.listener);
             });
           });
         });
@@ -149,11 +143,8 @@ export class PopoverEntry extends CollectionEntry {
       _(this).events.forEach((eventObj: EventObject) => {
         eventObj.el.forEach((el) => {
           eventObj.type.forEach((type) => {
-            (this[el] as HTMLElement).removeEventListener(
-              type,
-              eventObj.listener,
-              false
-            );
+            const target = this[el] as HTMLElement;
+            target.removeEventListener(type, eventObj.listener);
           });
         });
       });

--- a/packages/popover/src/js/PopoverEntry.ts
+++ b/packages/popover/src/js/PopoverEntry.ts
@@ -69,7 +69,7 @@ export class PopoverEntry extends CollectionEntry {
     // Setup event listeners
     registerEventListeners(this);
 
-    // If this popover is set to anchor to he cursor
+    // Setup cursor anchor if enabled
     if (this.config.get("followCursor")) {
       // Enable cursor tracking on the parent collection
       _(this.parent).trackCursor = true;

--- a/packages/popover/src/js/PopoverEntry.ts
+++ b/packages/popover/src/js/PopoverEntry.ts
@@ -93,7 +93,7 @@ export class PopoverEntry extends CollectionEntry {
           {
             el: ["trigger"],
             type: ["click"],
-            listener: handleTooltipClick.bind(this.parent, this)
+            listener: handleTooltipClick.bind(null, this)
           }
         ];
 

--- a/packages/popover/src/js/close.ts
+++ b/packages/popover/src/js/close.ts
@@ -24,14 +24,6 @@ export async function close(entry: PopoverEntry): Promise<PopoverEntry> {
       entry.parent.trigger = null;
     }
 
-    // Dispatch custom closed event
-    entry.el.dispatchEvent(
-      new CustomEvent(entry.config.get("customEventPrefix") + "closed", {
-        detail: entry.parent,
-        bubbles: true
-      })
-    );
-
     // Emit the closed event
     await entry.parent.emit("closed", entry);
   }

--- a/packages/popover/src/js/close.ts
+++ b/packages/popover/src/js/close.ts
@@ -1,3 +1,4 @@
+import { _ } from "@vrembem/core";
 import type { Popover } from "./Popover";
 import type { PopoverEntry } from "./PopoverEntry";
 
@@ -14,7 +15,7 @@ export async function close(entry: PopoverEntry): Promise<PopoverEntry> {
     }
 
     // Clean up the floating UI instance
-    entry.floatingCleanup();
+    _(entry).floatingCleanup();
 
     // Update popover state
     entry.state = "closed";

--- a/packages/popover/src/js/config.ts
+++ b/packages/popover/src/js/config.ts
@@ -19,13 +19,13 @@ export const config = {
   // @type string
   stateActive: "is-active",
 
+  // The default event type that triggers popovers
+  // @type string as "click" | "hover"
+  event: "click" as "click" | "hover",
+
   // The preferred placement location of a popover if there is enough space
   // @type string as Placement
   placement: "bottom" as Placement,
-
-  // The event that should trigger the popover
-  // @type string as "click" | "hover"
-  event: "click" as "click" | "hover",
 
   // A number represents the distance (gutter or margin) between the floating
   // element and the reference element.

--- a/packages/popover/src/js/config.ts
+++ b/packages/popover/src/js/config.ts
@@ -19,6 +19,10 @@ export const config = {
   // @type string
   stateActive: "is-active",
 
+  // A CSS class applied to popovers that are anchored to a virtual element
+  // @type string
+  stateVirtual: "is-virtual",
+
   // The default event type that triggers popovers
   // @type string as "click" | "hover"
   event: "click" as "click" | "hover",
@@ -54,9 +58,9 @@ export const config = {
   // @type number | string | (number | string)[]
   toggleDelay: 0,
 
-  // Whether or not the popover should be positioned to follow the cursor.
+  // Whether or not popovers should be anchored to the cursor.
   // @type boolean
-  virtual: false
+  followCursor: false
 };
 
 export type PopoverConfig = CollectionConfig & typeof config;

--- a/packages/popover/src/js/config.ts
+++ b/packages/popover/src/js/config.ts
@@ -48,10 +48,10 @@ export const config: PopoverConfig = {
   // Custom properties and their defaults
   placement: "bottom",
   event: "click",
-  offset: 0,
-  flipPadding: 0,
-  shiftPadding: 0,
-  arrowPadding: 0,
+  offset: 8,
+  flipPadding: 10,
+  shiftPadding: 10,
+  arrowPadding: 10,
   toggleDelay: 0,
   virtual: false
 };

--- a/packages/popover/src/js/config.ts
+++ b/packages/popover/src/js/config.ts
@@ -1,57 +1,62 @@
 import type { CollectionConfig } from "@vrembem/core";
+import type { Placement } from "@floating-ui/dom";
 
-type PlacementOptions =
-  | "auto"
-  | "auto-start"
-  | "auto-end"
-  | "top"
-  | "top-start"
-  | "top-end"
-  | "bottom"
-  | "bottom-start"
-  | "bottom-end"
-  | "left"
-  | "left-start"
-  | "left-end"
-  | "right"
-  | "right-start"
-  | "right-end";
-
-export interface PopoverConfig extends CollectionConfig {
-  selector: string;
-  selectorTooltip: string;
-  selectorArrow: string;
-  stateActive: string;
-  customEventPrefix: string;
-  placement: PlacementOptions;
-  event: "click" | "hover";
-  offset: number;
-  flipPadding: number;
-  shiftPadding: number;
-  arrowPadding: number;
-  toggleDelay: number;
-  virtual: boolean;
-}
-
-export const config: PopoverConfig = {
-  // Selectors
+export const config = {
+  // A valid CSS selector used to query the document for elements to include as
+  // entries in the popover collection.
+  // @type string
   selector: ".popover",
+
+  // A valid CSS selector that should match a popover as a tooltip type
+  // @type string
   selectorTooltip: ".popover_tooltip",
+
+  // A valid CSS selector for the arrow or carrot element of a popover
+  // @type string
   selectorArrow: ".popover__arrow",
 
-  // State classes
+  // A CSS class applied as the active state of a popover
+  // @type string
   stateActive: "is-active",
 
-  // Events prefix
-  customEventPrefix: "popover:",
+  // The preferred placement location of a popover if there is enough space
+  // @type string as Placement
+  placement: "bottom" as Placement,
 
-  // Custom properties and their defaults
-  placement: "bottom",
-  event: "click",
+  // The event that should trigger the popover
+  // @type string as "click" | "hover"
+  event: "click" as "click" | "hover",
+
+  // A number represents the distance (gutter or margin) between the floating
+  // element and the reference element.
+  // @type number
   offset: 8,
+
+  // A number representing the distance from the viewport edge before the
+  // popover is flipped to the opposite position.
+  // @type number
   flipPadding: 10,
+
+  // A number representing the distance from the viewport edge before the
+  // popover is shifted to remain visible.
+  // @type number
   shiftPadding: 10,
+
+  // This describes the padding between the arrow and the edges of the floating
+  // element. If your floating element has border-radius, this will prevent it
+  // from overflowing the corners.
+  // @type number
   arrowPadding: 10,
+
+  // The number in milliseconds that a popover should delay before opening and
+  // closing. Open and close delays can be different by providing two values.
+  // Example: [200, 600], "200, 600", "200 600"
+  // @type number | string | (number | string)[];
   toggleDelay: 0,
+
+  // Whether or not the popover should be positioned to follow the cursor.
+  // @type boolean
   virtual: false
 };
+
+export type PopoverConfig = CollectionConfig & typeof config;

--- a/packages/popover/src/js/config.ts
+++ b/packages/popover/src/js/config.ts
@@ -51,7 +51,7 @@ export const config = {
   // The number in milliseconds that a popover should delay before opening and
   // closing. Open and close delays can be different by providing two values.
   // Example: [200, 600], "200, 600", "200 600"
-  // @type number | string | (number | string)[];
+  // @type number | string | (number | string)[]
   toggleDelay: 0,
 
   // Whether or not the popover should be positioned to follow the cursor.

--- a/packages/popover/src/js/eventListeners.ts
+++ b/packages/popover/src/js/eventListeners.ts
@@ -1,0 +1,94 @@
+import { _ } from "@vrembem/core";
+import {
+  handleClick,
+  handleTooltipClick,
+  handleMouseEnter,
+  handleMouseLeave
+} from "./handlers";
+import type { PopoverEntry } from "./PopoverEntry";
+
+type EventBinding = {
+  keys: ("el" | "trigger")[];
+  events: string[];
+  handler: (event: MouseEvent | Event) => void;
+};
+
+export function registerEventListeners(entry: PopoverEntry) {
+  // If event listeners aren't already setup
+  if (!_(entry).events.length) {
+    // Add event listeners based on event type
+    const eventType = entry.config.get("event");
+
+    // If the event type is hover
+    if (eventType === "hover") {
+      // Setup event listeners object for hover
+      _(entry).events = [
+        {
+          keys: ["el", "trigger"],
+          events: ["mouseenter", "focus"],
+          handler: handleMouseEnter.bind(entry.parent, entry)
+        },
+        {
+          keys: ["el", "trigger"],
+          events: ["mouseleave", "focusout"],
+          handler: handleMouseLeave.bind(entry.parent, entry)
+        },
+        {
+          keys: ["trigger"],
+          events: ["click"],
+          handler: handleTooltipClick.bind(null, entry)
+        }
+      ];
+
+      // Loop through listeners and apply to the appropriate elements
+      _(entry).events.forEach((eventObj: EventBinding) => {
+        eventObj.keys.forEach((key) => {
+          eventObj.events.forEach((event) => {
+            const target = entry[key] as HTMLElement;
+            target.addEventListener(event, eventObj.handler);
+          });
+        });
+      });
+    }
+
+    // Else the event type is click
+    else {
+      // Setup event listeners object for click
+      _(entry).events = [
+        {
+          keys: ["trigger"],
+          events: ["click"],
+          handler: handleClick.bind(entry.parent, entry)
+        }
+      ];
+
+      // Loop through listeners and apply to the appropriate elements
+      _(entry).events.forEach((eventObj: EventBinding) => {
+        eventObj.keys.forEach((key) => {
+          eventObj.events.forEach((event) => {
+            const target = entry[key] as HTMLElement;
+            target.addEventListener(event, eventObj.handler);
+          });
+        });
+      });
+    }
+  }
+}
+
+export function deregisterEventListeners(entry: PopoverEntry) {
+  // If event listeners have been setup
+  if (_(entry).events) {
+    // Loop through listeners and remove from the appropriate elements
+    _(entry).events.forEach((eventObj: EventBinding) => {
+      eventObj.keys.forEach((key) => {
+        eventObj.events.forEach((event) => {
+          const target = entry[key] as HTMLElement;
+          target.removeEventListener(event, eventObj.handler);
+        });
+      });
+    });
+
+    // Remove eventListeners object from collection
+    _(entry).events = [];
+  }
+}

--- a/packages/popover/src/js/eventListeners.ts
+++ b/packages/popover/src/js/eventListeners.ts
@@ -77,7 +77,7 @@ export function registerEventListeners(entry: PopoverEntry) {
 
 export function deregisterEventListeners(entry: PopoverEntry) {
   // If event listeners have been setup
-  if (_(entry).events) {
+  if (_(entry).events.length) {
     // Loop through listeners and remove from the appropriate elements
     _(entry).events.forEach((eventObj: EventBinding) => {
       eventObj.keys.forEach((key) => {

--- a/packages/popover/src/js/eventListeners.ts
+++ b/packages/popover/src/js/eventListeners.ts
@@ -9,8 +9,8 @@ import type { PopoverEntry } from "./PopoverEntry";
 
 type EventBinding = {
   keys: ("el" | "trigger")[];
-  events: string[];
-  handler: (event: MouseEvent | Event) => void;
+  events: ("mouseenter" | "mouseleave" | "focus" | "focusout" | "click")[];
+  handler: (event: MouseEvent | FocusEvent) => void;
 };
 
 export function registerEventListeners(entry: PopoverEntry) {

--- a/packages/popover/src/js/handlers.ts
+++ b/packages/popover/src/js/handlers.ts
@@ -1,3 +1,4 @@
+import { _ } from "@vrembem/core";
 import { getDelay } from "./helpers";
 import { closeAll, closeCheck } from "./close";
 import type { Popover } from "./Popover";
@@ -38,8 +39,8 @@ export function handleClick(
 
 export function handleTooltipClick(popover: PopoverEntry) {
   if (popover.isTooltip) {
-    if (popover.toggleDelayId) {
-      clearTimeout(popover.toggleDelayId);
+    if (_(popover).toggleDelayId) {
+      clearTimeout(_(popover).toggleDelayId);
     }
     popover.close();
   }
@@ -70,8 +71,8 @@ export function handleMouseEnter(
   }
 
   // Clear any existing toggle delays
-  if (popover.toggleDelayId) {
-    clearTimeout(popover.toggleDelayId);
+  if (_(popover).toggleDelayId) {
+    clearTimeout(_(popover).toggleDelayId);
   }
 
   // Guard to ensure a popover is not already open for this trigger
@@ -85,7 +86,7 @@ export function handleMouseEnter(
   if (this.activeHover) this.activeHover.close();
 
   // Set the toggle delay before opening the popover
-  popover.toggleDelayId = setTimeout(() => {
+  _(popover).toggleDelayId = setTimeout(() => {
     // If the popover still exists, open it
     if (popover.id) popover.open();
   }, delay);
@@ -104,12 +105,12 @@ export function handleMouseLeave(popover: PopoverEntry, event: Event) {
     if (popover.isHovered) return;
 
     // Clear any existing toggle delays
-    if (popover.toggleDelayId) {
-      clearTimeout(popover.toggleDelayId);
+    if (_(popover).toggleDelayId) {
+      clearTimeout(_(popover).toggleDelayId);
     }
 
     // Set the toggle delay before closing the popover
-    popover.toggleDelayId = setTimeout(
+    _(popover).toggleDelayId = setTimeout(
       () => closeCheck(popover),
       getDelay(popover, 1)
     );

--- a/packages/popover/src/js/handlers.ts
+++ b/packages/popover/src/js/handlers.ts
@@ -55,7 +55,7 @@ export function handleMouseEnter(
   event: Event
 ) {
   // Ensure that this is a mouse event
-  if (!(event instanceof MouseEvent)) return;
+  if (!(event instanceof MouseEvent) && !(event instanceof FocusEvent)) return;
 
   // Store our hover state
   popover.isHovered = event;
@@ -93,7 +93,7 @@ export function handleMouseEnter(
 
 export function handleMouseLeave(popover: PopoverEntry, event: Event) {
   // Ensure that this is a mouse event
-  if (!(event instanceof MouseEvent)) return;
+  if (!(event instanceof MouseEvent) && !(event instanceof FocusEvent)) return;
 
   // Add a tiny delay to ensure hover isn't being moved to the popover element
   setTimeout(() => {
@@ -137,7 +137,6 @@ export function handleKeydown(this: Popover, event: KeyboardEvent) {
 }
 
 export function handleDocumentClick(this: Popover, popover: PopoverEntry) {
-  const root = this;
   document.addEventListener("click", function _f(event) {
     // Guard if event target property is null
     const target = event.target as HTMLElement | null;

--- a/packages/popover/src/js/handlers.ts
+++ b/packages/popover/src/js/handlers.ts
@@ -1,5 +1,5 @@
 import { _ } from "@vrembem/core";
-import { getDelay } from "./helpers";
+import { getDelay, setHovered } from "./helpers";
 import { closeAll, closeCheck } from "./close";
 import type { Popover } from "./Popover";
 import type { PopoverEntry } from "./PopoverEntry";
@@ -59,7 +59,7 @@ export function handleMouseEnter(
   if (!(event instanceof MouseEvent) && !(event instanceof FocusEvent)) return;
 
   // Store our hover state
-  popover.setHovered(event);
+  setHovered(popover, event);
 
   // Guard to ensure only focus-visible triggers the tooltip on focus events
   if (
@@ -99,7 +99,7 @@ export function handleMouseLeave(popover: PopoverEntry, event: Event) {
   // Add a tiny delay to ensure hover isn't being moved to the popover element
   setTimeout(() => {
     // Update our hover state
-    popover.setHovered(event);
+    setHovered(popover, event);
 
     // Guard to prevent closing popover if either elements are being hovered
     if (popover.isHovered) return;

--- a/packages/popover/src/js/handlers.ts
+++ b/packages/popover/src/js/handlers.ts
@@ -59,7 +59,7 @@ export function handleMouseEnter(
   if (!(event instanceof MouseEvent) && !(event instanceof FocusEvent)) return;
 
   // Store our hover state
-  popover.isHovered = event;
+  popover.setHovered(event);
 
   // Guard to ensure only focus-visible triggers the tooltip on focus events
   if (
@@ -99,7 +99,7 @@ export function handleMouseLeave(popover: PopoverEntry, event: Event) {
   // Add a tiny delay to ensure hover isn't being moved to the popover element
   setTimeout(() => {
     // Update our hover state
-    popover.isHovered = event;
+    popover.setHovered(event);
 
     // Guard to prevent closing popover if either elements are being hovered
     if (popover.isHovered) return;

--- a/packages/popover/src/js/handlers.ts
+++ b/packages/popover/src/js/handlers.ts
@@ -4,8 +4,8 @@ import { closeAll, closeCheck } from "./close";
 import type { Popover } from "./Popover";
 import type { PopoverEntry } from "./PopoverEntry";
 
-function setVirtualElement(parent: Popover, { clientX, clientY }: MouseEvent) {
-  _(parent).virtualElement = {
+function setCursorElement(parent: Popover, { clientX, clientY }: MouseEvent) {
+  _(parent).cursorElement = {
     getBoundingClientRect() {
       return {
         width: 0,
@@ -30,7 +30,7 @@ export function handleClick(
     popover.close();
   } else {
     if (event instanceof MouseEvent) {
-      setVirtualElement(this, event);
+      setCursorElement(this, event);
     }
     this.trigger = popover.trigger;
     popover.open();
@@ -47,7 +47,7 @@ export function handleTooltipClick(popover: PopoverEntry) {
 }
 
 export function handleMousemove(this: Popover, event: MouseEvent) {
-  setVirtualElement(this, event);
+  setCursorElement(this, event);
 }
 
 export function handleMouseEnter(

--- a/packages/popover/src/js/handlers.ts
+++ b/packages/popover/src/js/handlers.ts
@@ -5,7 +5,7 @@ import type { Popover } from "./Popover";
 import type { PopoverEntry } from "./PopoverEntry";
 
 function setVirtualElement(parent: Popover, { clientX, clientY }: MouseEvent) {
-  parent.virtualElement = {
+  _(parent).virtualElement = {
     getBoundingClientRect() {
       return {
         width: 0,

--- a/packages/popover/src/js/helpers/getDelay.ts
+++ b/packages/popover/src/js/helpers/getDelay.ts
@@ -6,14 +6,9 @@ export function getDelay(popover: PopoverEntry, index: number): number {
 
   // Check if value is a string
   if (typeof value == "string") {
-    // Convert it to an array if value contains a comma
-    if (value.indexOf(",") > -1) {
-      value = value.split(",");
-    }
-    // Convert it to an array if value contains a space
-    if (value.indexOf(" ") > -1) {
-      value = value.split(" ");
-    }
+    // Convert string to an array if value contains a comma and/or space
+    const parts = value.split(/[\s,]+/).filter(Boolean);
+    value = parts.length > 1 ? parts : parts[0];
   }
 
   // Check if value is an array and get the index

--- a/packages/popover/src/js/helpers/getMiddlewareOptions.ts
+++ b/packages/popover/src/js/helpers/getMiddlewareOptions.ts
@@ -2,7 +2,7 @@ import { getPadding } from "./getPadding";
 import type { PopoverEntry } from "../PopoverEntry";
 import type { Padding } from "@floating-ui/dom";
 
-type getMiddlewareOptions = {
+type MiddlewareOptions = {
   offset: number;
   flip: {
     padding: Padding | number | undefined;
@@ -17,9 +17,7 @@ type getMiddlewareOptions = {
   };
 };
 
-export function getMiddlewareOptions(
-  popover: PopoverEntry
-): getMiddlewareOptions {
+export function getMiddlewareOptions(popover: PopoverEntry): MiddlewareOptions {
   return {
     offset: Number(popover.config.get("offset")),
     flip: {

--- a/packages/popover/src/js/helpers/getMiddlewareOptions.ts
+++ b/packages/popover/src/js/helpers/getMiddlewareOptions.ts
@@ -1,18 +1,19 @@
-import { getPadding, PaddingObject } from "./getPadding";
+import { getPadding } from "./getPadding";
 import type { PopoverEntry } from "../PopoverEntry";
+import type { Padding } from "@floating-ui/dom";
 
 type getMiddlewareOptions = {
   offset: number;
   flip: {
-    padding: PaddingObject | number | undefined;
+    padding: Padding | number | undefined;
   };
   shift: {
-    padding: PaddingObject | number | undefined;
+    padding: Padding | number | undefined;
   };
   arrow: {
     selector: string;
     element: HTMLElement | null;
-    padding: PaddingObject | number | undefined;
+    padding: Padding | number | undefined;
   };
 };
 

--- a/packages/popover/src/js/helpers/getPadding.ts
+++ b/packages/popover/src/js/helpers/getPadding.ts
@@ -1,15 +1,10 @@
-export type PaddingObject = {
-  top: number;
-  right: number;
-  bottom: number;
-  left: number;
-};
+import type { Padding } from "@floating-ui/dom";
 
 export function getPadding(
   value: string | number
-): PaddingObject | number | undefined {
+): Padding | number | undefined {
   // Initialize the padding var
-  let padding: PaddingObject | number | undefined;
+  let padding: Padding | number | undefined;
 
   // Split the value by spaces if it's a string and convert it into an array of numbers
   const array = (

--- a/packages/popover/src/js/helpers/index.ts
+++ b/packages/popover/src/js/helpers/index.ts
@@ -4,3 +4,4 @@ export * from "./getMiddlewareOptions";
 export * from "./getPadding";
 export * from "./getPopoverElements";
 export * from "./getPopoverID";
+export * from "./setHovered";

--- a/packages/popover/src/js/helpers/setHovered.ts
+++ b/packages/popover/src/js/helpers/setHovered.ts
@@ -1,0 +1,23 @@
+import { _ } from "@vrembem/core";
+import type { PopoverEntry } from "../PopoverEntry";
+
+export function setHovered(
+  entry: PopoverEntry,
+  event: MouseEvent | FocusEvent
+) {
+  // Guard in case the event type is not "mouseenter" or "mouseleave"
+  if (event.type !== "mouseenter" && event.type !== "mouseleave") return;
+
+  // Set the boolean state
+  const state = event.type == "mouseenter";
+
+  // Store the hover state if the event target matches the el or trigger
+  switch (event.target) {
+    case entry.el:
+      _(entry).hovered.el = state;
+      break;
+    case entry.trigger:
+      _(entry).hovered.trigger = state;
+      break;
+  }
+}

--- a/packages/popover/src/js/open.ts
+++ b/packages/popover/src/js/open.ts
@@ -72,7 +72,7 @@ export async function open(entry: PopoverEntry): Promise<PopoverEntry> {
       }
 
       // Get either the virtual element or the entry trigger
-      const refEl = isVirtual ? entry.parent.virtualElement : entry.trigger;
+      const refEl = isVirtual ? _(entry.parent).virtualElement : entry.trigger;
 
       // Setup the compute position API
       computePosition(refEl, entry.el, {

--- a/packages/popover/src/js/open.ts
+++ b/packages/popover/src/js/open.ts
@@ -57,22 +57,21 @@ export async function open(entry: PopoverEntry): Promise<PopoverEntry> {
       );
     }
 
-    // Check if this is a virtual trigger
-    const isVirtual = entry.config.get("virtual");
-
-    // Enable virtual element tracking on parent collection
-    if (isVirtual) entry.parent.virtual = true;
+    // Check if popover should be anchored to the cursor
+    const followCursor = entry.config.get("followCursor");
 
     // Define the update position function
     function updatePosition() {
       // Remove the mousemove event listener if popover is no longer opened
-      if (isVirtual && entry.state !== "opened") {
+      if (followCursor && entry.state !== "opened") {
         document.removeEventListener("mousemove", updatePosition);
         document.removeEventListener("scroll", updatePosition);
       }
 
-      // Get either the virtual element or the entry trigger
-      const refEl = isVirtual ? _(entry.parent).virtualElement : entry.trigger;
+      // Get either the cursor element or the entry trigger
+      const refEl = followCursor
+        ? _(entry.parent).cursorElement
+        : entry.trigger;
 
       // Setup the compute position API
       computePosition(refEl, entry.el, {
@@ -97,8 +96,8 @@ export async function open(entry: PopoverEntry): Promise<PopoverEntry> {
       });
     }
 
-    // If this is a virtual trigger, update the position on mouse move
-    if (isVirtual) {
+    // If this is a cursor anchored popover, update the position on mouse move
+    if (followCursor) {
       updatePosition();
       document.addEventListener("mousemove", updatePosition);
       document.addEventListener("scroll", updatePosition);

--- a/packages/popover/src/js/open.ts
+++ b/packages/popover/src/js/open.ts
@@ -1,3 +1,4 @@
+import { _ } from "@vrembem/core";
 import {
   computePosition,
   autoUpdate,
@@ -103,7 +104,7 @@ export async function open(entry: PopoverEntry): Promise<PopoverEntry> {
       document.addEventListener("scroll", updatePosition);
     } else {
       // Setup the autoUpdate of popover positioning and store the cleanup function
-      entry.floatingCleanup = autoUpdate(
+      _(entry).floatingCleanup = autoUpdate(
         entry.trigger,
         entry.el,
         updatePosition

--- a/packages/popover/src/js/open.ts
+++ b/packages/popover/src/js/open.ts
@@ -119,14 +119,6 @@ export async function open(entry: PopoverEntry): Promise<PopoverEntry> {
     handleDocumentClick.call(entry.parent, entry);
   }
 
-  // Dispatch custom opened event
-  entry.el.dispatchEvent(
-    new CustomEvent(entry.config.get("customEventPrefix") + "opened", {
-      detail: entry.parent,
-      bubbles: true
-    })
-  );
-
   // Emit the opened event
   await entry.parent.emit("opened", entry);
 

--- a/packages/popover/src/scss/_config.scss
+++ b/packages/popover/src/scss/_config.scss
@@ -1,40 +1,19 @@
 @use "@vrembem/core";
+@use "@vrembem/core/config";
 @use "@vrembem/core/css";
 
-$event: null !default;
-$placement: null !default;
-$offset: 8 !default;
-$flip-padding: 10 !default;
-$shift-padding: 10 !default;
-$z-index: 10 !default;
-$width: 16em !default;
-$max-width: calc(100vw - 20px) !default;
-$padding: 0.5em !default;
-$border: null !default;
-$border-radius: css.get("border-radius") !default;
-$foreground: css.get("foreground") !default;
-$background: css.get("background") !default;
-$box-shadow: css.get("box-shadow-2") !default;
-$font-size: css.get("font-size-sm") !default;
-$line-height: null !default;
-$transition-property: opacity !default;
-$transition-duration: css.get("transition-duration-short") !default;
-$transition-timing-function: css.get("transition-timing-function") !default;
-$arrow-size: 8px !default;
-$arrow-padding: 10 !default;
-$size-sm-width: 12em !default;
-$size-lg-width: 20em !default;
+$config: () !default;
 
-// Custom properties
-@include css.set(
-  "popover",
-  (
-    "event": $event,
-    "placement": $placement,
-    "offset": $offset,
-    "flip-padding": $flip-padding,
-    "shift-padding": $shift-padding,
-    "arrow-padding": $arrow-padding
-  ),
-  "required"
+// prettier-ignore
+$default: (
+  // Map for outputting popover_size_[key] modifier variants
+  // @type map
+  "popover-size": (
+    "auto": "auto",
+    "sm": 12em,
+    "lg": 20em
+  )
 );
+
+@include config.apply($config, $default);
+@include css.register("popover");

--- a/packages/popover/src/scss/_popover.scss
+++ b/packages/popover/src/scss/_popover.scss
@@ -35,12 +35,8 @@ $-offset: calc((css.get("popover", "offset", 8) + 1) * 1px);
     height: $-offset;
   }
 
-  &.is-virtual {
-    @include css.override("popover", "virtual", true);
-
-    &::before {
-      content: none;
-    }
+  &.is-virtual::before {
+    content: none;
   }
 
   &.is-active {

--- a/packages/popover/src/scss/_popover.scss
+++ b/packages/popover/src/scss/_popover.scss
@@ -1,32 +1,31 @@
 @use "@vrembem/core";
 @use "@vrembem/core/css";
-@use "./config" as var;
 
-$-offset: calc(calc(css.get("popover", "offset") + 1) * 1px);
+$-offset: calc((css.get("popover", "offset", 8) + 1) * 1px);
 
 #{core.bem("popover")} {
   pointer-events: none;
   position: absolute;
-  z-index: css.get("popover", "z-index", var.$z-index);
+  z-index: css.get("popover", "z-index", 10);
   top: 0;
   left: 0;
   display: block;
-  width: css.get("popover", "width", var.$width);
-  max-width: css.get("popover", "max-width", var.$max-width);
+  width: css.get("popover", "width", 16em);
+  max-width: css.get("popover", "max-width", calc(100vw - 2rem));
   margin: 0;
-  padding: css.get("popover", "padding", var.$padding);
-  border: css.get("popover", "border", var.$border);
-  border-radius: css.get("popover", "border-radius", var.$border-radius);
-  font-size: css.get("popover", "font-size", var.$font-size);
-  line-height: css.get("popover", "line-height", var.$line-height);
-  color: css.get("popover", "foreground", var.$foreground);
+  padding: css.get("popover", "padding", 0.5em);
+  border: css.get("popover", "border", none);
+  border-radius: css.get("popover", "border-radius", css.get("border-radius"));
+  font-size: css.get("popover", "font-size", css.get("font-size-sm"));
+  line-height: css.get("popover", "line-height", inherit);
+  color: css.get("popover", "foreground", css.get("foreground"));
   opacity: 0;
-  background: css.get("popover", "background", var.$background);
+  background: css.get("popover", "background", css.get("background"));
   background-clip: padding-box;
-  box-shadow: css.get("popover", "box-shadow", var.$box-shadow);
-  transition-timing-function: css.get("popover", "transition-timing-function", var.$transition-timing-function);
-  transition-duration: css.get("popover", "transition-duration", var.$transition-duration);
-  transition-property: css.get("popover", "transition-property", var.$transition-property);
+  box-shadow: css.get("popover", "box-shadow", css.get("box-shadow-2"));
+  transition-timing-function: css.get("popover", "transition-timing-function", css.get("transition-timing-function"));
+  transition-duration: css.get("popover", "transition-duration", css.get("transition-duration-short"));
+  transition-property: css.get("popover", "transition-property", opacity);
 
   &::before {
     content: "";
@@ -46,14 +45,14 @@ $-offset: calc(calc(css.get("popover", "offset") + 1) * 1px);
 
   &.is-active {
     pointer-events: auto;
-    z-index: calc(css.get("popover", "z-index", var.$z-index) + 1);
+    z-index: calc(css.get("popover", "z-index", 10) + 1);
     opacity: 1;
   }
 
   &:hover,
   &:focus,
   &:focus-within {
-    z-index: calc(css.get("popover", "z-index", var.$z-index) + 2);
+    z-index: calc(css.get("popover", "z-index", 10) + 2);
   }
 }
 

--- a/packages/popover/src/scss/_popover__arrow.scss
+++ b/packages/popover/src/scss/_popover__arrow.scss
@@ -1,10 +1,9 @@
 @use "@vrembem/core";
 @use "@vrembem/core/css";
-@use "./config" as var;
 
 #{core.bem("popover", "arrow")},
 #{core.bem("popover", "arrow")}::after {
-  @include core.size(css.get("popover", "arrow-size", var.$arrow-size));
+  @include core.size(css.get("popover", "arrow-size", 8px));
 
   position: absolute;
   z-index: -1;
@@ -20,7 +19,7 @@
 }
 
 [data-floating-placement^="top"] > #{core.bem("popover", "arrow")} {
-  bottom: calc(css.get("popover", "arrow-size", var.$arrow-size) * -0.5);
+  bottom: calc(css.get("popover", "arrow-size", 8px) * -0.5);
 
   &::after {
     transform: rotate(-135deg);
@@ -28,7 +27,7 @@
 }
 
 [data-floating-placement^="bottom"] > #{core.bem("popover", "arrow")} {
-  top: calc(css.get("popover", "arrow-size", var.$arrow-size) * -0.5);
+  top: calc(css.get("popover", "arrow-size", 8px) * -0.5);
 
   &::after {
     transform: rotate(45deg);
@@ -36,7 +35,7 @@
 }
 
 [data-floating-placement^="left"] > #{core.bem("popover", "arrow")} {
-  right: calc(css.get("popover", "arrow-size", var.$arrow-size) * -0.5);
+  right: calc(css.get("popover", "arrow-size", 8px) * -0.5);
 
   &::after {
     transform: rotate(135deg);
@@ -44,7 +43,7 @@
 }
 
 [data-floating-placement^="right"] > #{core.bem("popover", "arrow")} {
-  left: calc(css.get("popover", "arrow-size", var.$arrow-size) * -0.5);
+  left: calc(css.get("popover", "arrow-size", 8px) * -0.5);
 
   &::after {
     transform: rotate(-45deg);

--- a/packages/popover/src/scss/_popover_size.scss
+++ b/packages/popover/src/scss/_popover_size.scss
@@ -1,15 +1,9 @@
 @use "@vrembem/core";
+@use "@vrembem/core/config";
 @use "@vrembem/core/css";
-@use "./config" as var;
 
-#{core.bem("popover", null, "size", "auto")} {
-  @include css.override("popover", "width", auto);
-}
-
-#{core.bem("popover", null, "size", "sm")} {
-  @include css.override("popover", "width", var.$size-sm-width);
-}
-
-#{core.bem("popover", null, "size", "lg")} {
-  @include css.override("popover", "width", var.$size-lg-width);
+@each $key, $value in config.get("popover-size", "variants") {
+  #{core.bem("popover", null, "size", $key)} {
+    @include css.override("popover", "width", $value);
+  }
 }


### PR DESCRIPTION
## What changed?

This PR primarily refactors the popover component to the new CSS variable pattern and config module integration. This pattern applies CSS variable references along with sensible fallbacks replacing the initial Sass variable solution for component customization. The documentation has also been updated to reflect these changes.

An additional API refactor this PR introduces is the renaming of `virtual` config option to `followCursor`. This better describes what this options does and further renames internal logic to more clearly describe the methods and variables this feature tracks.

Lastly, this PR also refactors and expands the private store module to now use WeakMaps as well as Symbols for storing private data of both collections and their entries. This has been made proxy friendly by storing the root reference of entries using symbols as the property key. All JS components have been updated to use private store where applicable. 

**Additional changes**

- `core`: `EventEmitter` has been refactored to use Maps instead of a generic object for managing stored events and their listeners.
- `Drawer`: Moved private (`#`) event handler refs into private store.
- `Modal`: Moved private (`#`) event handler refs into private store.
- `Notice`: Fixed broken notice title styles.
- `Popover`: Improved logic of `getDelay` helper.
- `Popover`: Removed custom events in favor of event system.
- `Popover`: Improved config types by allowing for more inference where possible and using floating-ui types where applicable, such as the `Padding` type.
- `docs`: Fixed a bug in `ReferenceTable` component where the height of the header was not being added for expandable tables.
- `docs`: Updated singular var name of popover collection to plural.
