### PR TITLE
Fix text alignment of button and menu action base styles

### DIFF
--- a/packages/button/src/_mixins.scss
+++ b/packages/button/src/_mixins.scss
@@ -18,8 +18,8 @@
   align-items: center;
   justify-content: center;
   border-style: solid;
-  font-family: inherit;
-  font-weight: inherit;
+  font: inherit;
+  text-align: center;
   text-decoration: none;
   white-space: nowrap;
   background-clip: border-box;

--- a/packages/menu/src/_mixins.scss
+++ b/packages/menu/src/_mixins.scss
@@ -17,8 +17,8 @@
   justify-content: flex-start;
   width: 100%;
   border-style: solid;
-  font-family: inherit;
-  font-weight: inherit;
+  font: inherit;
+  text-align: inherit;
   text-decoration: none;
   white-space: normal;
   background-clip: border-box;


### PR DESCRIPTION
## What changed?

This PR fixes the base styles of button and menu action styles by applying align-text and setting font to inherit for both.
