### PR TITLE
Add custom element style support to form-control-choice components

### DIFF
--- a/docs/src/packages/core/sass-utilities.mdx
+++ b/docs/src/packages/core/sass-utilities.mdx
@@ -114,7 +114,7 @@ Output the styles for a backdrop pseudo element. The initial state of a backdrop
 
 <ReferenceBar type="function" returns="selector" />
 
-Output a valid BEM class selector using core prefixes and the provided parameters; block, element, modifier and modifier-value. Returns a valid BEM CSS selector using the provided parameters.
+Returns a valid BEM class selector using core prefixes and the provided parameters; block, element, modifier and modifier-value.
 
 #### Arguments
 
@@ -185,6 +185,41 @@ Output a valid BEM class selector using core prefixes and the provided parameter
 
 // Generate selector for modifier value
 .menu_size_lg {
+  // ...
+}
+```
+</Fragment>
+</CodeExample>
+
+## ce
+
+<ReferenceBar type="function" returns="string" />
+
+Returns a valid custom element selector using the core custom elements prefix and the provided component name.
+
+#### Arguments
+
+<ReferenceCard name="$component" type="string">
+  The component name.
+</ReferenceCard>
+
+#### Example
+
+<CodeExample tabs>
+<Fragment slot="tab-scss">
+```scss
+@use "@vrembem/core";
+
+// Generate custom element selector
+#{core.ce("checkbox")} {
+  // ...
+}
+```
+</Fragment>
+<Fragment slot="tab-css">
+```scss
+// Generate custom element selector
+vb-checkbox {
   // ...
 }
 ```

--- a/packages/checkbox/src/_checkbox.scss
+++ b/packages/checkbox/src/_checkbox.scss
@@ -6,7 +6,10 @@ $-color: css.get("checkbox", "color", css.get("form-control-choice-color"));
 $-color-checked: css.get("checkbox", "color-checked", css.get("form-control-choice-color-checked"));
 $-fill: css.get("checkbox", "fill", css.get("form-control-choice-fill"));
 
+#{core.ce("checkbox")},
 #{core.bem("checkbox")} {
+  @include core.form-control-size;
+
   position: relative;
   display: inline-flex;
   flex: 0 0 auto;
@@ -22,7 +25,7 @@ $-fill: css.get("checkbox", "fill", css.get("form-control-choice-fill"));
 }
 
 #{core.bem("checkbox", "background")} {
-  @include core.form-control-size;
+  @include core.size(100%);
 
   position: relative;
   z-index: 1;

--- a/packages/core/index.scss
+++ b/packages/core/index.scss
@@ -26,6 +26,7 @@
 @forward "./src/scss/library/arrow";
 @forward "./src/scss/library/backdrop";
 @forward "./src/scss/library/bem";
+@forward "./src/scss/library/ce";
 @forward "./src/scss/library/focus-ring";
 @forward "./src/scss/library/form-control";
 @forward "./src/scss/library/get-side";

--- a/packages/core/src/scss/_config.scss
+++ b/packages/core/src/scss/_config.scss
@@ -27,6 +27,10 @@ $default: (
   // @type string | map
   "prefix-tokens": "vb",
 
+  // The prefix to apply to custom element selectors, e.g.: <vb-checkbox></vb-checkbox>
+  // @type string
+  "prefix-custom-elements": "vb",
+
   // The palette to build CSS variables from
   // @type map
   "palette": (

--- a/packages/core/src/scss/library/_bem.scss
+++ b/packages/core/src/scss/library/_bem.scss
@@ -2,7 +2,7 @@
 @use "../utilities/escape-colon" as *;
 @use "../modules/config";
 
-/// Output a valid BEM class selector using core prefixes and the provided
+/// Returns a valid BEM class selector using core prefixes and the provided
 /// parameters; block, element, modifier and modifier-value.
 ///
 /// @param {string} $b

--- a/packages/core/src/scss/library/_ce.scss
+++ b/packages/core/src/scss/library/_ce.scss
@@ -1,0 +1,22 @@
+@use "../modules/config";
+
+/// Output a valid custom element name using the core custom elements prefix
+/// and the provided component name.
+///
+/// @param {string} $component
+///   The component name.
+///
+/// @return {string}
+///   A valid custom element name using the provided component name.
+///
+@function ce($component) {
+  $prefix: config.get("prefix-custom-elements");
+
+  @if $prefix and $prefix != "" {
+    $prefix: "#{$prefix}-";
+  }
+
+  $result: "#{$prefix}#{$component}";
+
+  @return $result;
+}

--- a/packages/core/src/scss/library/_ce.scss
+++ b/packages/core/src/scss/library/_ce.scss
@@ -1,13 +1,13 @@
 @use "../modules/config";
 
-/// Output a valid custom element name using the core custom elements prefix
-/// and the provided component name.
+/// Returns a valid custom element selector using the core custom elements
+/// prefix and the provided component name.
 ///
 /// @param {string} $component
 ///   The component name.
 ///
 /// @return {string}
-///   A valid custom element name using the provided component name.
+///   A valid custom element selector using the provided component name.
 ///
 @function ce($component) {
   $prefix: config.get("prefix-custom-elements");

--- a/packages/radio/src/_radio.scss
+++ b/packages/radio/src/_radio.scss
@@ -6,7 +6,10 @@ $-color: css.get("radio", "color", css.get("form-control-choice-color")) !defaul
 $-color-checked: css.get("radio", "color-checked", css.get("form-control-choice-color-checked"));
 $-fill: css.get("radio", "fill", css.get("form-control-choice-fill")) !default;
 
+#{core.ce("radio")},
 #{core.bem("radio")} {
+  @include core.form-control-size;
+
   position: relative;
   display: inline-flex;
   flex: 0 0 auto;
@@ -22,7 +25,7 @@ $-fill: css.get("radio", "fill", css.get("form-control-choice-fill")) !default;
 }
 
 #{core.bem("radio", "background")} {
-  @include core.form-control-size;
+  @include core.size(100%);
 
   position: relative;
   z-index: 1;

--- a/packages/switch/src/_switch.scss
+++ b/packages/switch/src/_switch.scss
@@ -12,12 +12,12 @@ $-thumb-size: calc(css.get("switch", "track-size", 1.25em) - calc(css.get("switc
 #{core.bem("switch")} {
   @include core.form-control-size;
 
-  box-sizing: content-box;
   position: relative;
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;
+  box-sizing: content-box;
   padding-right: calc(css.get("core", "form-control-size-calc") * 0.25);
   padding-left: calc(css.get("core", "form-control-size-calc") * 0.25);
   font-size: $-size;

--- a/packages/switch/src/_switch.scss
+++ b/packages/switch/src/_switch.scss
@@ -8,7 +8,11 @@ $-fill: css.get("switch", "fill", css.get("form-control-choice-fill"));
 $-size: css.get("switch", "size", config.get("switch-size", "default"));
 $-thumb-size: calc(css.get("switch", "track-size", 1.25em) - calc(css.get("switch", "border-width", 2px) * 2));
 
+#{core.ce("switch")},
 #{core.bem("switch")} {
+  @include core.form-control-size;
+
+  box-sizing: content-box;
   position: relative;
   display: inline-flex;
   flex: 0 0 auto;

--- a/packages/table/src/_table.scss
+++ b/packages/table/src/_table.scss
@@ -16,8 +16,8 @@
   }
 
   th {
-    color: css.get("table", "header-foreground", css.get("foreground"));
     font-weight: css.get("font-weight-bold");
+    color: css.get("table", "header-foreground", css.get("foreground"));
   }
 
   caption {


### PR DESCRIPTION
## What changed?

This PR add custom element style support to form-control-choice components by setting the width and height directly on the root component elements of checkbox, radio and switch components. This also introduces a new custom element selector function to core and applies them to the root choice components as well. This should fix layout shift issues as custom elements are being initialized.
