### PR TITLE
Implement CSS @layer for cascade layers

### DIFF
--- a/docs/src/packages/utility.mdx
+++ b/docs/src/packages/utility.mdx
@@ -56,7 +56,7 @@ Utility comes with the following Sass configuration options that can be set usin
 
     // Whether or not utility styles should be output with the !important flag
     // @type boolean
-    "utility-important": true,
+    "utility-important": false,
 
     // A map of border-radius utilities to output
     // @type map
@@ -227,20 +227,6 @@ It's also possible to provide a prefix to all utility classes using the `utility
 ```scss
 @include config.set("utility-prefix", "u");
 // Result: .display-none > .u-display-none
-```
-</ReferenceCard>
-
-Vrembem utilities are set with the `!important` flag by default. This can be toggled using the `utility-important` configuration option.
-
-<ReferenceCard ref="config" name="utility-important" type="boolean" defaults='true'>
-  Whether or not utility styles should be output with the `!important` flag
-
-```scss
-@include config.set("utility-important", true);
-// > background: black !important;
-
-@include config.set("utility-important", false);
-// > background: black;
 ```
 </ReferenceCard>
 

--- a/docs/src/styles/_drawer_aside.scss
+++ b/docs/src/styles/_drawer_aside.scss
@@ -2,43 +2,45 @@
 @use "@vrembem/core/css";
 @use "@vrembem/core/palette";
 
-.drawer_aside {
-  position: fixed;
-  visibility: hidden;
-
-  .drawer__dialog {
-    background-color: css.get("background-shift");
-    outline: none;
-  }
-
-  .drawer__container {
-    overscroll-behavior: contain;
-    padding: css.get("layout", "padding");
-  }
-}
-
-/**
- * Inline aside
- */
-
-@include core.media-min("aside") {
+@layer components {
   .drawer_aside {
-    z-index: 2;
-    box-sizing: content-box;
-    width: calc(css.get("layout", "aside-width") + css.get("layout", "padding"));
-    padding-right: max(0px, calc((100% - (css.get("layout", "width") + (css.get("layout", "padding") * 2))) / 2));
-    visibility: visible;
+    position: fixed;
+    visibility: hidden;
 
     .drawer__dialog {
-      inset: 0 auto auto 0;
-      width: calc(css.get("layout", "aside-width") + css.get("layout", "padding"));
-      max-height: 100vh;
-      background-color: transparent;
+      background-color: css.get("background-shift");
+      outline: none;
     }
 
     .drawer__container {
-      scroll-behavior: smooth;
-      padding: calc(css.get("layout", "navibar-height") + css.get("layout", "content-padding-y")) css.get("layout", "padding") calc(css.get("layout", "footer-height") + css.get("layout", "content-padding-y")) css.get("focus-ring-width");
+      overscroll-behavior: contain;
+      padding: css.get("layout", "padding");
+    }
+  }
+
+  /**
+  * Inline aside
+  */
+
+  @include core.media-min("aside") {
+    .drawer_aside {
+      z-index: 2;
+      box-sizing: content-box;
+      width: calc(css.get("layout", "aside-width") + css.get("layout", "padding"));
+      padding-right: max(0px, calc((100% - (css.get("layout", "width") + (css.get("layout", "padding") * 2))) / 2));
+      visibility: visible;
+
+      .drawer__dialog {
+        inset: 0 auto auto 0;
+        width: calc(css.get("layout", "aside-width") + css.get("layout", "padding"));
+        max-height: 100vh;
+        background-color: transparent;
+      }
+
+      .drawer__container {
+        scroll-behavior: smooth;
+        padding: calc(css.get("layout", "navibar-height") + css.get("layout", "content-padding-y")) css.get("layout", "padding") calc(css.get("layout", "footer-height") + css.get("layout", "content-padding-y")) css.get("focus-ring-width");
+      }
     }
   }
 }

--- a/docs/src/styles/_drawer_sidebar.scss
+++ b/docs/src/styles/_drawer_sidebar.scss
@@ -1,72 +1,74 @@
 @use "@vrembem/core";
 @use "@vrembem/core/css";
 
-.drawer_sidebar {
-  position: fixed;
-  visibility: hidden;
-
-  .drawer__dialog {
-    background-color: css.get("background-shift");
-    outline: none;
-  }
-
-  .drawer__container {
-    overscroll-behavior: contain;
-    padding: css.get("layout", "padding");
-  }
-}
-
-/**
- * Inline sidebar
- */
-
-@include core.media-min("sidebar") {
+@layer components {
   .drawer_sidebar {
-    z-index: 2;
-    box-sizing: content-box;
-    width: calc(css.get("layout", "sidebar-width") + css.get("layout", "padding"));
-    padding-left: max(0px, calc((100% - (css.get("layout", "width") + (css.get("layout", "padding") * 2))) / 2));
-    visibility: visible;
-    background-color: css.get("background-shift");
-
-    // Fold shadow
-    &::after {
-      pointer-events: none;
-      content: "";
-      position: absolute;
-      z-index: 2;
-      inset: 0 0 auto auto;
-      width: 2rem;
-      height: 100%;
-      background: linear-gradient(268deg, rgb(0 0 0 / 8%) 0, rgb(0 0 0 / 0%) 2rem);
-    }
+    position: fixed;
+    visibility: hidden;
 
     .drawer__dialog {
-      inset: 0 0 0 auto;
-      width: calc(css.get("layout", "sidebar-width") + css.get("layout", "padding"));
-      background-color: transparent;
+      background-color: css.get("background-shift");
+      outline: none;
     }
 
     .drawer__container {
-      padding: css.get("layout", "navibar-height") css.get("layout", "padding") css.get("layout", "padding");
+      overscroll-behavior: contain;
+      padding: css.get("layout", "padding");
     }
+  }
 
-    // Scrolling mask
-    .drawer__mask {
-      position: sticky;
+  /**
+  * Inline sidebar
+  */
+
+  @include core.media-min("sidebar") {
+    .drawer_sidebar {
       z-index: 2;
-      inset: calc((css.get("layout", "navibar-height") + css.get("layout", "padding")) * -1) 0 auto 0;
-      flex-shrink: 0;
-      height: calc(css.get("layout", "navibar-height") + css.get("layout", "padding"));
-      margin: calc((css.get("layout", "navibar-height") + css.get("layout", "padding")) * -1) calc(css.get("layout", "padding") * -1) css.get("layout", "padding") calc(css.get("layout", "padding") * -1);
+      box-sizing: content-box;
+      width: calc(css.get("layout", "sidebar-width") + css.get("layout", "padding"));
+      padding-left: max(0px, calc((100% - (css.get("layout", "width") + (css.get("layout", "padding") * 2))) / 2));
+      visibility: visible;
       background-color: css.get("background-shift");
 
+      // Fold shadow
       &::after {
+        pointer-events: none;
         content: "";
         position: absolute;
-        inset: 100% 0 auto;
-        margin: 0 css.get("layout", "padding");
-        border-bottom: 1px solid css.get("border-color");
+        z-index: 2;
+        inset: 0 0 auto auto;
+        width: 2rem;
+        height: 100%;
+        background: linear-gradient(268deg, rgb(0 0 0 / 8%) 0, rgb(0 0 0 / 0%) 2rem);
+      }
+
+      .drawer__dialog {
+        inset: 0 0 0 auto;
+        width: calc(css.get("layout", "sidebar-width") + css.get("layout", "padding"));
+        background-color: transparent;
+      }
+
+      .drawer__container {
+        padding: css.get("layout", "navibar-height") css.get("layout", "padding") css.get("layout", "padding");
+      }
+
+      // Scrolling mask
+      .drawer__mask {
+        position: sticky;
+        z-index: 2;
+        inset: calc((css.get("layout", "navibar-height") + css.get("layout", "padding")) * -1) 0 auto 0;
+        flex-shrink: 0;
+        height: calc(css.get("layout", "navibar-height") + css.get("layout", "padding"));
+        margin: calc((css.get("layout", "navibar-height") + css.get("layout", "padding")) * -1) calc(css.get("layout", "padding") * -1) css.get("layout", "padding") calc(css.get("layout", "padding") * -1);
+        background-color: css.get("background-shift");
+
+        &::after {
+          content: "";
+          position: absolute;
+          inset: 100% 0 auto;
+          margin: 0 css.get("layout", "padding");
+          border-bottom: 1px solid css.get("border-color");
+        }
       }
     }
   }

--- a/docs/src/styles/app.scss
+++ b/docs/src/styles/app.scss
@@ -1,3 +1,6 @@
+// Import the Vrembem defined layers
+@forward "vrembem/layers";
+
 // Configure Vrembem
 @forward "./config";
 

--- a/packages/base/index.scss
+++ b/packages/base/index.scss
@@ -1,14 +1,24 @@
+@use "sass:meta";
 @forward "./src/config";
 @forward "./src/functions";
-@forward "./src/modules/global";
-@forward "./src/modules/headings";
-@forward "./src/modules/link";
-@forward "./src/modules/list";
-@forward "./src/modules/code";
-@forward "./src/modules/pre";
-@forward "./src/modules/blockquote";
-@forward "./src/modules/separator";
-@forward "./src/modules/arrow";
-@forward "./src/modules/loading-spinner";
-@forward "./src/modules/sr-only";
-@forward "./src/modules/type";
+
+$-output: true;
+
+@if $-output {
+  $-output: false !global;
+
+  @layer base {
+    @include meta.load-css("./src/modules/global");
+    @include meta.load-css("./src/modules/headings");
+    @include meta.load-css("./src/modules/link");
+    @include meta.load-css("./src/modules/list");
+    @include meta.load-css("./src/modules/code");
+    @include meta.load-css("./src/modules/pre");
+    @include meta.load-css("./src/modules/blockquote");
+    @include meta.load-css("./src/modules/separator");
+    @include meta.load-css("./src/modules/arrow");
+    @include meta.load-css("./src/modules/loading-spinner");
+    @include meta.load-css("./src/modules/sr-only");
+    @include meta.load-css("./src/modules/type");
+  }
+}

--- a/packages/base/index.scss
+++ b/packages/base/index.scss
@@ -2,23 +2,17 @@
 @forward "./src/config";
 @forward "./src/functions";
 
-$-output: true;
-
-@if $-output {
-  $-output: false !global;
-
-  @layer base {
-    @include meta.load-css("./src/modules/global");
-    @include meta.load-css("./src/modules/headings");
-    @include meta.load-css("./src/modules/link");
-    @include meta.load-css("./src/modules/list");
-    @include meta.load-css("./src/modules/code");
-    @include meta.load-css("./src/modules/pre");
-    @include meta.load-css("./src/modules/blockquote");
-    @include meta.load-css("./src/modules/separator");
-    @include meta.load-css("./src/modules/arrow");
-    @include meta.load-css("./src/modules/loading-spinner");
-    @include meta.load-css("./src/modules/sr-only");
-    @include meta.load-css("./src/modules/type");
-  }
+@layer base {
+  @include meta.load-css("./src/modules/global");
+  @include meta.load-css("./src/modules/headings");
+  @include meta.load-css("./src/modules/link");
+  @include meta.load-css("./src/modules/list");
+  @include meta.load-css("./src/modules/code");
+  @include meta.load-css("./src/modules/pre");
+  @include meta.load-css("./src/modules/blockquote");
+  @include meta.load-css("./src/modules/separator");
+  @include meta.load-css("./src/modules/arrow");
+  @include meta.load-css("./src/modules/loading-spinner");
+  @include meta.load-css("./src/modules/sr-only");
+  @include meta.load-css("./src/modules/type");
 }

--- a/packages/button/build.scss
+++ b/packages/button/build.scss
@@ -1,9 +1,0 @@
-@use "./index";
-@use "@vrembem/core/css";
-@use "@vrembem/core/theme";
-
-:root {
-  @include css.output("button");
-}
-
-@include theme.output("button");

--- a/packages/button/index.scss
+++ b/packages/button/index.scss
@@ -1,7 +1,11 @@
+@use "sass:meta";
 @forward "./src/config";
 @forward "./src/mixins";
-@forward "./src/button";
-@forward "./src/button_block";
-@forward "./src/button_color";
-@forward "./src/button_icon";
-@forward "./src/button_size";
+
+@layer components {
+  @include meta.load-css("./src/button");
+  @include meta.load-css("./src/button_block");
+  @include meta.load-css("./src/button_color");
+  @include meta.load-css("./src/button_icon");
+  @include meta.load-css("./src/button_size");
+}

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -31,8 +31,8 @@
     "build": "npm-run-all clean styles",
     "clean": "del dev && del dist",
     "styles": "npm-run-all styles:dev styles:dist",
-    "styles:dev": "sass build.scss dev/index.css --load-path=../../node_modules",
-    "styles:dist": "sass build.scss dist/index.css --load-path=../../node_modules --style=compressed",
+    "styles:dev": "sass index.scss dev/index.css --load-path=../../node_modules",
+    "styles:dist": "sass index.scss dist/index.css --load-path=../../node_modules --style=compressed",
     "watch": "npm run watch:styles",
     "watch:styles": "concurrently 'npm run styles:dev -- --watch' 'npm run styles:dist -- --watch'"
   },

--- a/packages/button/src/_button_color.scss
+++ b/packages/button/src/_button_color.scss
@@ -1,4 +1,3 @@
-@use "sass:map";
 @use "sass:meta";
 @use "@vrembem/core";
 @use "@vrembem/core/config";

--- a/packages/card/build.scss
+++ b/packages/card/build.scss
@@ -1,9 +1,0 @@
-@use "./index";
-@use "@vrembem/core/css";
-@use "@vrembem/core/theme";
-
-:root {
-  @include css.output("card");
-}
-
-@include theme.output("card");

--- a/packages/card/index.scss
+++ b/packages/card/index.scss
@@ -1,2 +1,6 @@
+@use "sass:meta";
 @forward "./src/config";
-@forward "./src/card";
+
+@layer components {
+  @include meta.load-css("./src/card");
+}

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -31,8 +31,8 @@
     "build": "npm-run-all clean styles",
     "clean": "del dev && del dist",
     "styles": "npm-run-all styles:dev styles:dist",
-    "styles:dev": "sass build.scss dev/index.css --load-path=../../node_modules",
-    "styles:dist": "sass build.scss dist/index.css --load-path=../../node_modules --style=compressed",
+    "styles:dev": "sass index.scss dev/index.css --load-path=../../node_modules",
+    "styles:dist": "sass index.scss dist/index.css --load-path=../../node_modules --style=compressed",
     "watch": "npm run watch:styles",
     "watch:styles": "concurrently 'npm run styles:dev -- --watch' 'npm run styles:dist -- --watch'"
   },

--- a/packages/checkbox/build.scss
+++ b/packages/checkbox/build.scss
@@ -1,9 +1,0 @@
-@use "./index";
-@use "@vrembem/core/css";
-@use "@vrembem/core/theme";
-
-:root {
-  @include css.output("checkbox");
-}
-
-@include theme.output("checkbox");

--- a/packages/checkbox/index.scss
+++ b/packages/checkbox/index.scss
@@ -1,3 +1,7 @@
+@use "sass:meta";
 @forward "./src/config";
-@forward "./src/checkbox";
-@forward "./src/checkbox_size";
+
+@layer components {
+  @include meta.load-css("./src/checkbox");
+  @include meta.load-css("./src/checkbox_size");
+}

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -31,8 +31,8 @@
     "build": "npm-run-all clean styles",
     "clean": "del dev && del dist",
     "styles": "npm-run-all styles:dev styles:dist",
-    "styles:dev": "sass build.scss dev/index.css --load-path=../../node_modules",
-    "styles:dist": "sass build.scss dist/index.css --load-path=../../node_modules --style=compressed",
+    "styles:dev": "sass index.scss dev/index.css --load-path=../../node_modules",
+    "styles:dist": "sass index.scss dist/index.css --load-path=../../node_modules --style=compressed",
     "watch": "npm run watch:styles",
     "watch:styles": "concurrently 'npm run styles:dev -- --watch' 'npm run styles:dist -- --watch'"
   },

--- a/packages/core/build.scss
+++ b/packages/core/build.scss
@@ -1,1 +1,0 @@
-@forward "./tokens";

--- a/packages/core/build/layers.scss
+++ b/packages/core/build/layers.scss
@@ -1,0 +1,1 @@
+@forward "../layers";

--- a/packages/core/layers.scss
+++ b/packages/core/layers.scss
@@ -1,0 +1,1 @@
+@layer tokens, base, components, utilities;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,10 +20,15 @@
       "import": "./dist/index.js",
       "require": "./dist/index.umd.cjs"
     },
+    "./layers": {
+      "sass": "./layers.scss",
+      "import": "./dist/layers.css",
+      "default": "./dist/layers.css"
+    },
     "./tokens": {
       "sass": "./tokens.scss",
-      "import": "./dist/index.css",
-      "default": "./dist/index.css"
+      "import": "./dist/tokens.css",
+      "default": "./dist/tokens.css"
     },
     "./reset": {
       "sass": "./reset.scss",
@@ -44,6 +49,7 @@
     "src",
     "index.ts",
     "index.scss",
+    "layers.scss",
     "tokens.scss",
     "reset.scss",
     "config.scss",

--- a/packages/core/reset.scss
+++ b/packages/core/reset.scss
@@ -1,2 +1,5 @@
 @use "@vrembem/core";
-@include core.reset;
+
+@layer base {
+  @include core.reset;
+}

--- a/packages/core/src/scss/library/_loading-spinner.scss
+++ b/packages/core/src/scss/library/_loading-spinner.scss
@@ -29,6 +29,8 @@ $-output-spin-animation: true;
 
   // Only output the spin animation once
   @if $-output-spin-animation {
+    $-output-spin-animation: false !global;
+
     @keyframes spin {
       from {
         transform: rotate(0deg);
@@ -38,7 +40,5 @@ $-output-spin-animation: true;
         transform: rotate(360deg);
       }
     }
-
-    $-output-spin-animation: false !global;
   }
 }

--- a/packages/core/tokens.scss
+++ b/packages/core/tokens.scss
@@ -1,7 +1,9 @@
 @use "@vrembem/core";
 
-:root {
-  @include core.css-output;
-}
+@layer tokens {
+  :root {
+    @include core.css-output;
+  }
 
-@include core.theme-output;
+  @include core.theme-output;
+}

--- a/packages/dialog/build.scss
+++ b/packages/dialog/build.scss
@@ -1,9 +1,0 @@
-@use "./index";
-@use "@vrembem/core/css";
-@use "@vrembem/core/theme";
-
-:root {
-  @include css.output("dialog");
-}
-
-@include theme.output("dialog");

--- a/packages/dialog/index.scss
+++ b/packages/dialog/index.scss
@@ -1,2 +1,6 @@
+@use "sass:meta";
 @forward "./src/config";
-@forward "./src/dialog";
+
+@layer components {
+  @include meta.load-css("./src/dialog");
+}

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -31,8 +31,8 @@
     "build": "npm-run-all clean styles",
     "clean": "del dev && del dist",
     "styles": "npm-run-all styles:dev styles:dist",
-    "styles:dev": "sass build.scss dev/index.css --load-path=../../node_modules",
-    "styles:dist": "sass build.scss dist/index.css --load-path=../../node_modules --style=compressed",
+    "styles:dev": "sass index.scss dev/index.css --load-path=../../node_modules",
+    "styles:dist": "sass index.scss dist/index.css --load-path=../../node_modules --style=compressed",
     "watch": "npm run watch:styles",
     "watch:styles": "concurrently 'npm run styles:dev -- --watch' 'npm run styles:dist -- --watch'"
   },

--- a/packages/drawer/build.scss
+++ b/packages/drawer/build.scss
@@ -1,9 +1,0 @@
-@use "./index";
-@use "@vrembem/core/css";
-@use "@vrembem/core/theme";
-
-:root {
-  @include css.output("drawer");
-}
-
-@include theme.output("drawer");

--- a/packages/drawer/index.scss
+++ b/packages/drawer/index.scss
@@ -1,4 +1,8 @@
+@use "sass:meta";
 @forward "./src/scss/config";
-@forward "./src/scss/drawer";
-@forward "./src/scss/drawer_switch";
-@forward "./src/scss/drawer_modal";
+
+@layer components {
+  @include meta.load-css("./src/scss/drawer");
+  @include meta.load-css("./src/scss/drawer_switch");
+  @include meta.load-css("./src/scss/drawer_modal");
+}

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -41,8 +41,8 @@
     "scripts:dist": "vite build --outDir dist",
     "scripts:types": "tsc --project tsconfig.build.json",
     "styles": "npm-run-all styles:dev styles:dist",
-    "styles:dev": "sass build.scss dev/index.css --load-path=../../node_modules",
-    "styles:dist": "sass build.scss dist/index.css --load-path=../../node_modules --style=compressed",
+    "styles:dev": "sass index.scss dev/index.css --load-path=../../node_modules",
+    "styles:dist": "sass index.scss dist/index.css --load-path=../../node_modules --style=compressed",
     "watch": "concurrently --kill-others 'npm run watch:scripts' 'npm run watch:styles'",
     "watch:scripts": "concurrently 'npm run scripts:dev -- --watch' 'npm run scripts:dist -- --watch'",
     "watch:styles": "concurrently 'npm run styles:dev -- --watch' 'npm run styles:dist -- --watch'"

--- a/packages/flex/build.scss
+++ b/packages/flex/build.scss
@@ -1,9 +1,0 @@
-@use "./index";
-@use "@vrembem/core/css";
-@use "@vrembem/core/theme";
-
-:root {
-  @include css.output("flex");
-}
-
-@include theme.output("flex");

--- a/packages/flex/index.scss
+++ b/packages/flex/index.scss
@@ -1,7 +1,11 @@
+@use "sass:meta";
 @forward "./src/config";
-@forward "./src/flex";
-@forward "./src/flex_gap";
-@forward "./src/flex_wrap";
-@forward "./src/flex_direction";
-@forward "./src/flex_items";
-@forward "./src/flex-item";
+
+@layer components {
+  @include meta.load-css("./src/flex");
+  @include meta.load-css("./src/flex_gap");
+  @include meta.load-css("./src/flex_wrap");
+  @include meta.load-css("./src/flex_direction");
+  @include meta.load-css("./src/flex_items");
+  @include meta.load-css("./src/flex-item");
+}

--- a/packages/flex/package.json
+++ b/packages/flex/package.json
@@ -31,8 +31,8 @@
     "build": "npm-run-all clean styles",
     "clean": "del dev && del dist",
     "styles": "npm-run-all styles:dev styles:dist",
-    "styles:dev": "sass build.scss dev/index.css --load-path=../../node_modules",
-    "styles:dist": "sass build.scss dist/index.css --load-path=../../node_modules --style=compressed",
+    "styles:dev": "sass index.scss dev/index.css --load-path=../../node_modules",
+    "styles:dist": "sass index.scss dist/index.css --load-path=../../node_modules --style=compressed",
     "watch": "npm run watch:styles",
     "watch:styles": "concurrently 'npm run styles:dev -- --watch' 'npm run styles:dist -- --watch'"
   },

--- a/packages/grid/build.scss
+++ b/packages/grid/build.scss
@@ -1,9 +1,0 @@
-@use "./index";
-@use "@vrembem/core/css";
-@use "@vrembem/core/theme";
-
-:root {
-  @include css.output("grid");
-}
-
-@include theme.output("grid");

--- a/packages/grid/index.scss
+++ b/packages/grid/index.scss
@@ -1,8 +1,12 @@
+@use "sass:meta";
 @forward "./src/config";
-@forward "./src/grid";
-@forward "./src/grid_cols";
-@forward "./src/grid_rows";
-@forward "./src/grid_gap";
-@forward "./src/grid_flow";
-@forward "./src/grid-col";
-@forward "./src/grid-row";
+
+@layer components {
+  @include meta.load-css("./src/grid");
+  @include meta.load-css("./src/grid_cols");
+  @include meta.load-css("./src/grid_rows");
+  @include meta.load-css("./src/grid_gap");
+  @include meta.load-css("./src/grid_flow");
+  @include meta.load-css("./src/grid-col");
+  @include meta.load-css("./src/grid-row");
+}

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -31,8 +31,8 @@
     "build": "npm-run-all clean styles",
     "clean": "del dev && del dist",
     "styles": "npm-run-all styles:dev styles:dist",
-    "styles:dev": "sass build.scss dev/index.css --load-path=../../node_modules",
-    "styles:dist": "sass build.scss dist/index.css --load-path=../../node_modules --style=compressed",
+    "styles:dev": "sass index.scss dev/index.css --load-path=../../node_modules",
+    "styles:dist": "sass index.scss dist/index.css --load-path=../../node_modules --style=compressed",
     "watch": "npm run watch:styles",
     "watch:styles": "concurrently 'npm run styles:dev -- --watch' 'npm run styles:dist -- --watch'"
   },

--- a/packages/icon/build.scss
+++ b/packages/icon/build.scss
@@ -1,9 +1,0 @@
-@use "./index";
-@use "@vrembem/core/css";
-@use "@vrembem/core/theme";
-
-:root {
-  @include css.output("icon");
-}
-
-@include theme.output("icon");

--- a/packages/icon/index.scss
+++ b/packages/icon/index.scss
@@ -1,5 +1,9 @@
+@use "sass:meta";
 @forward "./src/config";
 @forward "./src/mixins";
-@forward "./src/icon";
-@forward "./src/icon_size";
-@forward "./src/icon_style";
+
+@layer components {
+  @include meta.load-css("./src/icon");
+  @include meta.load-css("./src/icon_size");
+  @include meta.load-css("./src/icon_style");
+}

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -31,8 +31,8 @@
     "build": "npm-run-all clean styles",
     "clean": "del dev && del dist",
     "styles": "npm-run-all styles:dev styles:dist",
-    "styles:dev": "sass build.scss dev/index.css --load-path=../../node_modules",
-    "styles:dist": "sass build.scss dist/index.css --load-path=../../node_modules --style=compressed",
+    "styles:dev": "sass index.scss dev/index.css --load-path=../../node_modules",
+    "styles:dist": "sass index.scss dist/index.css --load-path=../../node_modules --style=compressed",
     "watch": "npm run watch:styles",
     "watch:styles": "concurrently 'npm run styles:dev -- --watch' 'npm run styles:dist -- --watch'"
   },

--- a/packages/input/build.scss
+++ b/packages/input/build.scss
@@ -1,0 +1,11 @@
+@forward "./index";
+@use "@vrembem/core/css";
+@use "@vrembem/core/theme";
+
+@layer tokens {
+  :root {
+    @include css.output("input");
+  }
+
+  @include theme.output("input");
+}

--- a/packages/input/build.scss
+++ b/packages/input/build.scss
@@ -1,4 +1,4 @@
-@forward "./index";
+@use "./index";
 @use "@vrembem/core/css";
 @use "@vrembem/core/theme";
 

--- a/packages/input/build.scss
+++ b/packages/input/build.scss
@@ -1,9 +1,0 @@
-@use "./index";
-@use "@vrembem/core/css";
-@use "@vrembem/core/theme";
-
-:root {
-  @include css.output("input");
-}
-
-@include theme.output("input");

--- a/packages/input/index.scss
+++ b/packages/input/index.scss
@@ -1,6 +1,10 @@
+@use "sass:meta";
 @forward "./src/config";
-@forward "./src/input";
-@forward "./src/input_auto";
-@forward "./src/input_size";
-@forward "./src/input_state";
-@forward "./src/input_type";
+
+@layer components {
+  @include meta.load-css("./src/input");
+  @include meta.load-css("./src/input_auto");
+  @include meta.load-css("./src/input_size");
+  @include meta.load-css("./src/input_state");
+  @include meta.load-css("./src/input_type");
+}

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -31,8 +31,8 @@
     "build": "npm-run-all clean styles",
     "clean": "del dev && del dist",
     "styles": "npm-run-all styles:dev styles:dist",
-    "styles:dev": "sass build.scss dev/index.css --load-path=../../node_modules",
-    "styles:dist": "sass build.scss dist/index.css --load-path=../../node_modules --style=compressed",
+    "styles:dev": "sass index.scss dev/index.css --load-path=../../node_modules",
+    "styles:dist": "sass index.scss dist/index.css --load-path=../../node_modules --style=compressed",
     "watch": "npm run watch:styles",
     "watch:styles": "concurrently 'npm run styles:dev -- --watch' 'npm run styles:dist -- --watch'"
   },

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -31,8 +31,8 @@
     "build": "npm-run-all clean styles",
     "clean": "del dev && del dist",
     "styles": "npm-run-all styles:dev styles:dist",
-    "styles:dev": "sass index.scss dev/index.css --load-path=../../node_modules",
-    "styles:dist": "sass index.scss dist/index.css --load-path=../../node_modules --style=compressed",
+    "styles:dev": "sass build.scss dev/index.css --load-path=../../node_modules",
+    "styles:dist": "sass build.scss dist/index.css --load-path=../../node_modules --style=compressed",
     "watch": "npm run watch:styles",
     "watch:styles": "concurrently 'npm run styles:dev -- --watch' 'npm run styles:dist -- --watch'"
   },

--- a/packages/menu/build.scss
+++ b/packages/menu/build.scss
@@ -1,9 +1,0 @@
-@use "./index";
-@use "@vrembem/core/css";
-@use "@vrembem/core/theme";
-
-:root {
-  @include css.output("menu");
-}
-
-@include theme.output("menu");

--- a/packages/menu/index.scss
+++ b/packages/menu/index.scss
@@ -1,6 +1,10 @@
+@use "sass:meta";
 @forward "./src/config";
 @forward "./src/mixins";
-@forward "./src/menu";
-@forward "./src/menu_full";
-@forward "./src/menu_inline";
-@forward "./src/menu_size";
+
+@layer components {
+  @include meta.load-css("./src/menu");
+  @include meta.load-css("./src/menu_full");
+  @include meta.load-css("./src/menu_inline");
+  @include meta.load-css("./src/menu_size");
+}

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -31,8 +31,8 @@
     "build": "npm-run-all clean styles",
     "clean": "del dev && del dist",
     "styles": "npm-run-all styles:dev styles:dist",
-    "styles:dev": "sass build.scss dev/index.css --load-path=../../node_modules",
-    "styles:dist": "sass build.scss dist/index.css --load-path=../../node_modules --style=compressed",
+    "styles:dev": "sass index.scss dev/index.css --load-path=../../node_modules",
+    "styles:dist": "sass index.scss dist/index.css --load-path=../../node_modules --style=compressed",
     "watch": "npm run watch:styles",
     "watch:styles": "concurrently 'npm run styles:dev -- --watch' 'npm run styles:dist -- --watch'"
   },

--- a/packages/modal/build.scss
+++ b/packages/modal/build.scss
@@ -1,9 +1,0 @@
-@use "./index";
-@use "@vrembem/core/css";
-@use "@vrembem/core/theme";
-
-:root {
-  @include css.output("modal");
-}
-
-@include theme.output("modal");

--- a/packages/modal/index.scss
+++ b/packages/modal/index.scss
@@ -1,5 +1,9 @@
+@use "sass:meta";
 @forward "./src/scss/config";
-@forward "./src/scss/modal";
-@forward "./src/scss/modal_full";
-@forward "./src/scss/modal_pos";
-@forward "./src/scss/modal_size";
+
+@layer components {
+  @include meta.load-css("./src/scss/modal");
+  @include meta.load-css("./src/scss/modal_full");
+  @include meta.load-css("./src/scss/modal_pos");
+  @include meta.load-css("./src/scss/modal_size");
+}

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -41,8 +41,8 @@
     "scripts:dist": "vite build --outDir dist",
     "scripts:types": "tsc --project tsconfig.build.json",
     "styles": "npm-run-all styles:dev styles:dist",
-    "styles:dev": "sass build.scss dev/index.css --load-path=../../node_modules",
-    "styles:dist": "sass build.scss dist/index.css --load-path=../../node_modules --style=compressed",
+    "styles:dev": "sass index.scss dev/index.css --load-path=../../node_modules",
+    "styles:dist": "sass index.scss dist/index.css --load-path=../../node_modules --style=compressed",
     "watch": "concurrently --kill-others 'npm run watch:scripts' 'npm run watch:styles'",
     "watch:scripts": "concurrently 'npm run scripts:dev -- --watch' 'npm run scripts:dist -- --watch'",
     "watch:styles": "concurrently 'npm run styles:dev -- --watch' 'npm run styles:dist -- --watch'"

--- a/packages/notice/build.scss
+++ b/packages/notice/build.scss
@@ -1,9 +1,0 @@
-@use "./index";
-@use "@vrembem/core/css";
-@use "@vrembem/core/theme";
-
-:root {
-  @include css.output("notice");
-}
-
-@include theme.output("notice");

--- a/packages/notice/index.scss
+++ b/packages/notice/index.scss
@@ -1,3 +1,7 @@
+@use "sass:meta";
 @forward "./src/config";
-@forward "./src/notice";
-@forward "./src/notice_color";
+
+@layer components {
+  @include meta.load-css("./src/notice");
+  @include meta.load-css("./src/notice_color");
+}

--- a/packages/notice/package.json
+++ b/packages/notice/package.json
@@ -31,8 +31,8 @@
     "build": "npm-run-all clean styles",
     "clean": "del dev && del dist",
     "styles": "npm-run-all styles:dev styles:dist",
-    "styles:dev": "sass build.scss dev/index.css --load-path=../../node_modules",
-    "styles:dist": "sass build.scss dist/index.css --load-path=../../node_modules --style=compressed",
+    "styles:dev": "sass index.scss dev/index.css --load-path=../../node_modules",
+    "styles:dist": "sass index.scss dist/index.css --load-path=../../node_modules --style=compressed",
     "watch": "npm run watch:styles",
     "watch:styles": "concurrently 'npm run styles:dev -- --watch' 'npm run styles:dist -- --watch'"
   },

--- a/packages/popover/build.scss
+++ b/packages/popover/build.scss
@@ -1,9 +1,0 @@
-@use "./index";
-@use "@vrembem/core/css";
-@use "@vrembem/core/theme";
-
-:root {
-  @include css.output("popover");
-}
-
-@include theme.output("popover");

--- a/packages/popover/index.scss
+++ b/packages/popover/index.scss
@@ -1,5 +1,9 @@
+@use "sass:meta";
 @forward "./src/scss/config";
-@forward "./src/scss/popover";
-@forward "./src/scss/popover__arrow";
-@forward "./src/scss/popover_size";
-@forward "./src/scss/popover_tooltip";
+
+@layer components {
+  @include meta.load-css("./src/scss/popover");
+  @include meta.load-css("./src/scss/popover__arrow");
+  @include meta.load-css("./src/scss/popover_size");
+  @include meta.load-css("./src/scss/popover_tooltip");
+}

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -41,8 +41,8 @@
     "scripts:dist": "vite build --outDir dist",
     "scripts:types": "tsc --project tsconfig.build.json",
     "styles": "npm-run-all styles:dev styles:dist",
-    "styles:dev": "sass build.scss dev/index.css --load-path=../../node_modules",
-    "styles:dist": "sass build.scss dist/index.css --load-path=../../node_modules --style=compressed",
+    "styles:dev": "sass index.scss dev/index.css --load-path=../../node_modules",
+    "styles:dist": "sass index.scss dist/index.css --load-path=../../node_modules --style=compressed",
     "watch": "concurrently --kill-others 'npm run watch:scripts' 'npm run watch:styles'",
     "watch:scripts": "concurrently 'npm run scripts:dev -- --watch' 'npm run scripts:dist -- --watch'",
     "watch:styles": "concurrently 'npm run styles:dev -- --watch' 'npm run styles:dist -- --watch'"

--- a/packages/radio/build.scss
+++ b/packages/radio/build.scss
@@ -1,9 +1,0 @@
-@use "./index";
-@use "@vrembem/core/css";
-@use "@vrembem/core/theme";
-
-:root {
-  @include css.output("radio");
-}
-
-@include theme.output("radio");

--- a/packages/radio/index.scss
+++ b/packages/radio/index.scss
@@ -1,3 +1,7 @@
+@use "sass:meta";
 @forward "./src/config";
-@forward "./src/radio";
-@forward "./src/radio_size";
+
+@layer components {
+  @include meta.load-css("./src/radio");
+  @include meta.load-css("./src/radio_size");
+}

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -31,8 +31,8 @@
     "build": "npm-run-all clean styles",
     "clean": "del dev && del dist",
     "styles": "npm-run-all styles:dev styles:dist",
-    "styles:dev": "sass build.scss dev/index.css --load-path=../../node_modules",
-    "styles:dist": "sass build.scss dist/index.css --load-path=../../node_modules --style=compressed",
+    "styles:dev": "sass index.scss dev/index.css --load-path=../../node_modules",
+    "styles:dist": "sass index.scss dist/index.css --load-path=../../node_modules --style=compressed",
     "watch": "npm run watch:styles",
     "watch:styles": "concurrently 'npm run styles:dev -- --watch' 'npm run styles:dist -- --watch'"
   },

--- a/packages/section/build.scss
+++ b/packages/section/build.scss
@@ -1,9 +1,0 @@
-@use "./index";
-@use "@vrembem/core/css";
-@use "@vrembem/core/theme";
-
-:root {
-  @include css.output("section");
-}
-
-@include theme.output("section");

--- a/packages/section/index.scss
+++ b/packages/section/index.scss
@@ -1,3 +1,7 @@
+@use "sass:meta";
 @forward "./src/config";
-@forward "./src/section";
-@forward "./src/section_padding";
+
+@layer components {
+  @include meta.load-css("./src/section");
+  @include meta.load-css("./src/section_padding");
+}

--- a/packages/section/package.json
+++ b/packages/section/package.json
@@ -31,8 +31,8 @@
     "build": "npm-run-all clean styles",
     "clean": "del dev && del dist",
     "styles": "npm-run-all styles:dev styles:dist",
-    "styles:dev": "sass build.scss dev/index.css --load-path=../../node_modules",
-    "styles:dist": "sass build.scss dist/index.css --load-path=../../node_modules --style=compressed",
+    "styles:dev": "sass index.scss dev/index.css --load-path=../../node_modules",
+    "styles:dist": "sass index.scss dist/index.css --load-path=../../node_modules --style=compressed",
     "watch": "npm run watch:styles",
     "watch:styles": "concurrently 'npm run styles:dev -- --watch' 'npm run styles:dist -- --watch'"
   },

--- a/packages/switch/build.scss
+++ b/packages/switch/build.scss
@@ -1,9 +1,0 @@
-@use "./index";
-@use "@vrembem/core/css";
-@use "@vrembem/core/theme";
-
-:root {
-  @include css.output("switch");
-}
-
-@include theme.output("switch");

--- a/packages/switch/index.scss
+++ b/packages/switch/index.scss
@@ -1,3 +1,7 @@
+@use "sass:meta";
 @forward "./src/config";
-@forward "./src/switch";
-@forward "./src/switch_size";
+
+@layer components {
+  @include meta.load-css("./src/switch");
+  @include meta.load-css("./src/switch_size");
+}

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -31,8 +31,8 @@
     "build": "npm-run-all clean styles",
     "clean": "del dev && del dist",
     "styles": "npm-run-all styles:dev styles:dist",
-    "styles:dev": "sass build.scss dev/index.css --load-path=../../node_modules",
-    "styles:dist": "sass build.scss dist/index.css --load-path=../../node_modules --style=compressed",
+    "styles:dev": "sass index.scss dev/index.css --load-path=../../node_modules",
+    "styles:dist": "sass index.scss dist/index.css --load-path=../../node_modules --style=compressed",
     "watch": "npm run watch:styles",
     "watch:styles": "concurrently 'npm run styles:dev -- --watch' 'npm run styles:dist -- --watch'"
   },

--- a/packages/table/build.scss
+++ b/packages/table/build.scss
@@ -1,9 +1,0 @@
-@use "./index";
-@use "@vrembem/core/css";
-@use "@vrembem/core/theme";
-
-:root {
-  @include css.output("table");
-}
-
-@include theme.output("table");

--- a/packages/table/index.scss
+++ b/packages/table/index.scss
@@ -1,9 +1,13 @@
+@use "sass:meta";
 @forward "./src/config";
 @forward "./src/mixins";
-@forward "./src/table";
-@forward "./src/table_ellipsis";
-@forward "./src/table_hover";
-@forward "./src/table_mobile";
-@forward "./src/table_padding";
-@forward "./src/table_striped";
-@forward "./src/table_style";
+
+@layer components {
+  @include meta.load-css("./src/table");
+  @include meta.load-css("./src/table_ellipsis");
+  @include meta.load-css("./src/table_hover");
+  @include meta.load-css("./src/table_mobile");
+  @include meta.load-css("./src/table_padding");
+  @include meta.load-css("./src/table_striped");
+  @include meta.load-css("./src/table_style");
+}

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -31,8 +31,8 @@
     "build": "npm-run-all clean styles",
     "clean": "del dev && del dist",
     "styles": "npm-run-all styles:dev styles:dist",
-    "styles:dev": "sass build.scss dev/index.css --load-path=../../node_modules",
-    "styles:dist": "sass build.scss dist/index.css --load-path=../../node_modules --style=compressed",
+    "styles:dev": "sass index.scss dev/index.css --load-path=../../node_modules",
+    "styles:dist": "sass index.scss dist/index.css --load-path=../../node_modules --style=compressed",
     "watch": "npm run watch:styles",
     "watch:styles": "concurrently 'npm run styles:dev -- --watch' 'npm run styles:dist -- --watch'"
   },

--- a/packages/utility/index.scss
+++ b/packages/utility/index.scss
@@ -1,31 +1,34 @@
+@use "sass:meta";
 @forward "./src/config";
 @forward "./src/functions";
 
-// Appearance (5)
-@forward "./src/modules/background"; // 312
-@forward "./src/modules/foreground"; // 296
-@forward "./src/modules/border"; // 52
-@forward "./src/modules/border-radius"; // 112
-@forward "./src/modules/box-shadow"; // 28
+@layer utilities {
+  // Appearance (5)
+  @include meta.load-css("./src/modules/background");
+  @include meta.load-css("./src/modules/foreground");
+  @include meta.load-css("./src/modules/border");
+  @include meta.load-css("./src/modules/border-radius");
+  @include meta.load-css("./src/modules/box-shadow");
 
-// Display and spacing (4)
-@forward "./src/modules/display"; // 163
-@forward "./src/modules/margin"; // 210
-@forward "./src/modules/padding"; // 180
-@forward "./src/modules/spacing"; // 24
+  // Display and spacing (4)
+  @include meta.load-css("./src/modules/display");
+  @include meta.load-css("./src/modules/margin");
+  @include meta.load-css("./src/modules/padding");
+  @include meta.load-css("./src/modules/spacing");
 
-// Grid and flex (6)
-@forward "./src/modules/gap"; // 72
-@forward "./src/modules/justify"; // 60
-@forward "./src/modules/align"; // 60
-@forward "./src/modules/place"; // 60
-@forward "./src/modules/order"; // 36
-@forward "./src/modules/flex"; // 104
+  // Grid and flex (6)
+  @include meta.load-css("./src/modules/gap");
+  @include meta.load-css("./src/modules/justify");
+  @include meta.load-css("./src/modules/align");
+  @include meta.load-css("./src/modules/place");
+  @include meta.load-css("./src/modules/order");
+  @include meta.load-css("./src/modules/flex");
 
-// Miscellaneous (6)
-@forward "./src/modules/position"; // 20
-@forward "./src/modules/overflow"; // 60
-@forward "./src/modules/max-width"; // 28
-@forward "./src/modules/font"; // 80
-@forward "./src/modules/text"; // 68
-@forward "./src/modules/transition"; // 16
+  // Miscellaneous (6)
+  @include meta.load-css("./src/modules/position");
+  @include meta.load-css("./src/modules/overflow");
+  @include meta.load-css("./src/modules/max-width");
+  @include meta.load-css("./src/modules/font");
+  @include meta.load-css("./src/modules/text");
+  @include meta.load-css("./src/modules/transition");
+}

--- a/packages/utility/src/_config.scss
+++ b/packages/utility/src/_config.scss
@@ -26,7 +26,7 @@ $default: (
 
   // Whether or not utility styles should be output with the !important flag
   // @type boolean
-  "utility-important": true,
+  "utility-important": false,
 
   // A map of border-radius utilities to output
   // @type map

--- a/packages/vrembem/build/layers.scss
+++ b/packages/vrembem/build/layers.scss
@@ -1,0 +1,1 @@
+@forward "../layers";

--- a/packages/vrembem/index.scss
+++ b/packages/vrembem/index.scss
@@ -1,3 +1,4 @@
+@forward "@vrembem/core/layers";
 @forward "@vrembem/core" as core-*;
 @forward "@vrembem/base" as base-*;
 @forward "@vrembem/flex" as flex-*;

--- a/packages/vrembem/layers.scss
+++ b/packages/vrembem/layers.scss
@@ -1,0 +1,1 @@
+@forward "@vrembem/core/layers";

--- a/packages/vrembem/package.json
+++ b/packages/vrembem/package.json
@@ -25,6 +25,11 @@
       "import": "./dist/styles.css",
       "default": "./dist/styles.css"
     },
+    "./layers": {
+      "sass": "./layers.scss",
+      "import": "./dist/layers.css",
+      "default": "./dist/layers.css"
+    },
     "./tokens": {
       "sass": "./tokens.scss",
       "import": "./dist/tokens.css",
@@ -55,6 +60,7 @@
     "index.ts",
     "index.scss",
     "styles.scss",
+    "layers.scss",
     "tokens.scss",
     "base.scss",
     "components.scss",


### PR DESCRIPTION
## What changed?

This PR implements the `@layer` CSS rule by defining and wrapping all Vrembem packages with the layer they should reside in. This creates the following cascade order:

```css
@layer tokens, base, components, utilities;
```

As part of this update, core provides a new entry to output the pre-defined `@layer`'s rule. This can be used in both Sass and CSS contexts but is not defined by default. This allows consumers to optionally create their own layers rules as needed.

### Example 1

In this example, consumers can ensure that their own application styles are overriden by Vrembem utilities but also that their custom styles override the rest of the library layers by adding a custom layer in between components and utilities.

```css
@layer tokens, base, components, app, utilities;
@import "vrembem";

@layer app {
  ...
}
```

### Example 2

In this example, the entire Vrembem library is imported into its own library layer and kept separate from the user defined layers order.

```css
@layer lib, app;
@import "vrembem" layer(lib);

@layer app {
  ...
}
```

### Example 3

In this example, we import the Vrembem defined `@layer` order. The consumer's custom styles can just write their styles or apply layer wrappers to place them in the correct layer space.

```css
@import "vrembem/layer";
@import "vrembem";

@layer components {
  .custom-component {
    ...
  }
}

.unlayered-styles {
  ...
}
```

**Additional changes**

- `all`: Removed build flow from packages that don't define their own CSS variables. This currently applies to all packages except `input`.
- `core`: Fixed package entry for tokens output.
- `utility`: Important flags are now disabled by default.
- `docs`: Updated documentation styles to incorporate the use of Vrembem defined layers order.
