### PR TITLE
Rename the css module to tokens

### DIFF
--- a/docs/src/packages/button.mdx
+++ b/docs/src/packages/button.mdx
@@ -50,9 +50,9 @@ Button comes with the following Sass configuration options that can be set using
     // @type map
     "button-size": (
       "breakpoints": true,
-      "sm": css.get("form-control-size-sm"),
-      "md": css.get("form-control-size"),
-      "lg": css.get("form-control-size-lg")
+      "sm": tokens.get("form-control-size-sm"),
+      "md": tokens.get("form-control-size"),
+      "lg": tokens.get("form-control-size-lg")
     )
   )
 );

--- a/docs/src/packages/checkbox.mdx
+++ b/docs/src/packages/checkbox.mdx
@@ -33,10 +33,10 @@ Checkbox comes with the following Sass configuration options that can be set usi
     // @type map
     "checkbox-size": (
       "breakpoints": true,
-      "default": css.get("form-control-size"),
-      "sm": css.get("form-control-size-sm"),
-      "md": css.get("form-control-size"),
-      "lg": css.get("form-control-size-lg")
+      "default": tokens.get("form-control-size"),
+      "sm": tokens.get("form-control-size-sm"),
+      "md": tokens.get("form-control-size"),
+      "lg": tokens.get("form-control-size-lg")
     )
   )
 );

--- a/docs/src/packages/core.mdx
+++ b/docs/src/packages/core.mdx
@@ -63,10 +63,6 @@ Core comes with the following Sass configuration options that can be set using e
       "important": hsl(0deg 80% 50%)
     ),
 
-    // The default color lightness to use when referencing a color
-    // @type number
-    "palette-default": null,
-
     // A prefix to apply to theme names. Provided value is automatically suffixed
     // with a "-" character when applied.
     // @type string
@@ -95,9 +91,9 @@ Core comes with the following Sass configuration options that can be set using e
 Vrembem uses Sass modules to manage global configuration and custom properties throughout the library.
 
 - [`@vrembem/core/config`](/packages/core/config): Used to setup global configuration options. This is available across all components to set things like BEM naming syntax, prefixes, and output options.
-- [`@vrembem/core/css`](/packages/core/css): Used to define, manage, and output global and component-level custom properties.
-- [`@vrembem/core/palette`](/packages/core/palette): Used to build and return color palette values by leveraging both config and CSS modules.
-- [`@vrembem/core/theme`](/packages/core/theme): Used to define, manage, and output global and component-level themes powered by custom properties.
+- [`@vrembem/core/tokens`](/packages/core/tokens): Used to define, manage, and output global and component-level design tokens expressed as CSS variables.
+- [`@vrembem/core/palette`](/packages/core/palette): Used to build and return color palette values by leveraging both the config and tokens module.
+- [`@vrembem/core/theme`](/packages/core/theme): Used to define, manage, and output global and component-level themes powered by the tokens module.
 
 ### Theme state
 

--- a/docs/src/packages/core/config.mdx
+++ b/docs/src/packages/core/config.mdx
@@ -3,15 +3,16 @@ title: core/config
 description: "Used to setup global configuration options. This is available across all components to set things like BEM naming syntax, prefixes, and output options."
 parent: core
 group: sass-modules
+order: 1
 ---
 
 import ReferenceCard from "../../components/ReferenceCard.astro";
 import ReferenceBar from "../../components/ReferenceBar.astro";
 
 <CodeExample lang="scss">
-  ```scss
-  @use "@vrembem/core/config";
-  ```
+```scss
+@use "@vrembem/core/config";
+```
 </CodeExample>
 
 ## Basic usage
@@ -25,33 +26,33 @@ There are two primary methods to configure options in the config module. The fir
 To use the configuration module directly, import the `core/config` module. Once imported you can use the API to `set` and `get` values in the configuration map.
 
 <CodeExample label="_config.scss">
-  ```scss
-  // 1. Import the module
-  @use "@vrembem/core/config";
+```scss
+// 1. Import the module
+@use "@vrembem/core/config";
 
-  // 2. Set a configuration value
-  @include config.set("theme-prefix", "theme");
+// 2. Set a configuration value
+@include config.set("theme-prefix", "theme");
 
-  // 3. Get a configuration value
-  @debug config.get("theme-prefix"); // => "theme"
-  ```
+// 3. Get a configuration value
+@debug config.get("theme-prefix"); // => "theme"
+```
 </CodeExample>
 
 Changes to the global config should be done in a file that is loaded before other Vrembem or custom components. This ensures that components use the correct configuration values.
 
 <CodeExample label="style.scss">
-  ```scss
-  // 1. Make all your custom configurations
-  @use "./config";
+```scss
+// 1. Make all your custom configurations
+@use "./config";
 
-  // 2. Import components or other custom modules
-  @use "@vrembem/base";
-  @use "@vrembem/modal";
-  // ...
+// 2. Import components or other custom modules
+@use "@vrembem/base";
+@use "@vrembem/modal";
+// ...
 
-  // 3. Output CSS variables
-  @use "@vrembem/core/tokens";
-  ```
+// 3. Output CSS variables
+@use "@vrembem/core/tokens";
+```
 </CodeExample>
 
 ### Using with clause
@@ -59,21 +60,21 @@ Changes to the global config should be done in a file that is loaded before othe
 To set configuration options via the Sass `@use ... with` clause, define and set options in the `$config` map. Options set in the `$config` map are stored in the config module.
 
 <CodeExample label="app.scss">
-  ```scss
-  @use "@vrembem/core" with (
-    $config: (
-      "prefix-block": "vb"
-    )
-  );
-  @use "@vrembem/base" with (
-    $config: (
-      "base-output": false
-    )
-  );
+```scss
+@use "@vrembem/core" with (
+  $config: (
+    "prefix-block": "vb"
+  )
+);
+@use "@vrembem/base" with (
+  $config: (
+    "base-output": false
+  )
+);
 
-  @debug core.config-get("prefix-block"); // => "vb"
-  @debug core.config-get("base-output"); // => false
-  ```
+@debug core.config-get("prefix-block"); // => "vb"
+@debug core.config-get("base-output"); // => false
+```
 </CodeExample>
 
 Changes to the global config should be done before loading other Vrembem or custom components. This ensures that components use the correct configuration values.
@@ -97,13 +98,13 @@ Function to returns the value of an option in the configuration map.
 #### Example
 
 <CodeExample lang="scss">
-  ```scss
-  @debug config.get("theme-default");
-  // Debug: light
+```scss
+@debug config.get("theme-default");
+// Debug: light
 
-  @debug config.get("prefix-tokens");
-  // Debug: vb
-  ```
+@debug config.get("prefix-tokens");
+// Debug: vb
+```
 </CodeExample>
 
 ### config.set()
@@ -129,16 +130,16 @@ Set an option in the configuration map by providing a key and value to store, or
 #### Example
 
 <CodeExample lang="scss">
-  ```scss
-  // Set a single option
-  @include config.set("theme-default", "dark");
+```scss
+// Set a single option
+@include config.set("theme-default", "dark");
 
-  // Set multiple options using a map
-  @include config.set((
-    "prefix-tokens": "custom",
-    "theme-default": "light"
-  ));
-  ```
+// Set multiple options using a map
+@include config.set((
+  "prefix-tokens": "custom",
+  "theme-default": "light"
+));
+```
 </CodeExample>
 
 ### config.set-default()
@@ -160,18 +161,18 @@ An alias mixin for `config.set()` with predefined default argument to `true`. Ru
 #### Example
 
 <CodeExample lang="scss">
-  ```scss
-  // Set the default value of the provided key
-  @include config.set-default("theme-default", "light");
+```scss
+// Set the default value of the provided key
+@include config.set-default("theme-default", "light");
 
-  // This set call will override the default value of "light"
-  @include config.set("theme-default", "dark");
+// This set call will override the default value of "light"
+@include config.set("theme-default", "dark");
 
-  // This will have no effect since "theme-default" has already been set
-  @include config.set-default("theme-default", "high-contrast");
+// This will have no effect since "theme-default" has already been set
+@include config.set-default("theme-default", "high-contrast");
 
-  @debug config.get("theme-default"); // Debug: dark
-  ```
+@debug config.get("theme-default"); // Debug: dark
+```
 </CodeExample>
 
 ### config.merge()
@@ -205,10 +206,10 @@ Remove an option from the configuration map.
 #### Example
 
 <CodeExample lang="scss">
-  ```scss
-  // Remove the theme default option
-  @include config.remove("theme-default");
-  ```
+```scss
+// Remove the theme default option
+@include config.remove("theme-default");
+```
 </CodeExample>
 
 ### config.apply()
@@ -334,15 +335,15 @@ Log to console the entire or a specific value in the configuration map.
 #### Example
 
 <CodeExample lang="scss">
-  ```scss
-  @include config.log();
-  // Debug: 
-  // Config options map: (
-  //   "prefix-block": ,
-  //   "prefix-element": __,
-  //   "prefix-modifier": _,
-  //   "prefix-modifier-value": _,
-  //   ...
-  // )
-  ```
+```scss
+@include config.log();
+// Debug: 
+// Config options map: (
+//   "prefix-block": ,
+//   "prefix-element": __,
+//   "prefix-modifier": _,
+//   "prefix-modifier-value": _,
+//   ...
+// )
+```
 </CodeExample>

--- a/docs/src/packages/core/css-variables.mdx
+++ b/docs/src/packages/core/css-variables.mdx
@@ -24,12 +24,12 @@ Alternatively, custom properties can also be output manually using the `core/css
 <CodeExample lang="scss">
 ```scss
 @use "@vrembem/core"; // Includes all core CSS variable definitions
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/theme";
 
 // Output all registered CSS variables
 :root {
-  @include css.output;
+  @include tokens.output;
 }
 
 // Output all registered theme CSS variables

--- a/docs/src/packages/core/css-variables.mdx
+++ b/docs/src/packages/core/css-variables.mdx
@@ -11,33 +11,39 @@ import data from "../../data/cssvar-core.json";
 
 ## Output
 
-CSS variables are not automatically output when `@vrembem/core` is imported or used. To output core CSS variables, use the `@vrembem/core/tokens` export at the bottom of your Sass manifest file.
+CSS variables are not automatically output when `@vrembem/core` is imported or used. To output core CSS variables, use the `vrembem/tokens` entry at the end of your Sass manifest file.
 
 <CodeExample lang="scss">
 ```scss
-@forward "@vrembem/core/tokens";
+@forward "vrembem/tokens";
 ```
 </CodeExample>
 
-Alternatively, custom properties can also be output manually using the `core/css` and `core/theme` modules:
+Alternatively, custom properties can also be output manually using the `core/tokens` and `core/theme` modules:
 
 <CodeExample lang="scss">
 ```scss
-@use "@vrembem/core"; // Includes all core CSS variable definitions
+// Import core to bootstrap all modules
+@use "@vrembem/core";
+
+// Import core modules for use
 @use "@vrembem/core/tokens";
 @use "@vrembem/core/theme";
 
-// Output all registered CSS variables
-:root {
-  @include tokens.output;
-}
+// Wrap these in the tokens layer
+@layer tokens {
+  // Output all registered CSS variables
+  :root {
+    @include tokens.output;
+  }
 
-// Output all registered theme CSS variables
-@include theme.output;
+  // Output all registered theme CSS variables
+  @include theme.output;
+}
 ```
 </CodeExample>
 
-It is recommended to output CSS variables at the end of your Sass manifest file. This is to ensure that all uses of registered properties are included in the output.
+It is recommended to output CSS variables at the end of your Sass manifest file. This is to ensure that all defined properties are included in the output.
 
 ## Reference
 

--- a/docs/src/packages/core/css.mdx
+++ b/docs/src/packages/core/css.mdx
@@ -10,7 +10,7 @@ import ReferenceBar from "../../components/ReferenceBar.astro";
 
 <CodeExample lang="scss">
   ```scss
-  @use "@vrembem/core/css";
+  @use "@vrembem/core/tokens";
   ```
 </CodeExample>
 
@@ -18,7 +18,7 @@ import ReferenceBar from "../../components/ReferenceBar.astro";
 
 For most use-cases, `core/css` provides a straightforward API for managing custom properties. Define, reference and output custom properties both globally and on a per-component basis.
 
-### css.get()
+### tokens.get()
 
 <ReferenceBar type="function" />
 
@@ -40,8 +40,8 @@ Function to return a custom property reference that has been stored in the custo
   <Fragment slot="tab-scss">
     ```scss
     .block {
-      background: css.get("block", "background");
-      color: css.get("block", "foreground-hover", "foreground");
+      background: tokens.get("block", "background");
+      color: tokens.get("block", "foreground-hover", "foreground");
     }
     ```
   </Fragment>
@@ -56,7 +56,7 @@ Function to return a custom property reference that has been stored in the custo
 </CodeExample>
 
 
-### css.set()
+### tokens.set()
 
 <ReferenceBar type="mixin" />
 
@@ -85,10 +85,10 @@ Mixin to store custom properties for later definition and reference. Can also up
 <CodeExample lang="scss">
   ```scss
   // Set a single option
-  @include css.set("block", "accent", teal);
+  @include tokens.set("block", "accent", teal);
 
   // Set multiple options at once
-  @include css.set("block", (
+  @include tokens.set("block", (
     "background": darkGreen,
     "foreground": lightPink
   ));
@@ -96,7 +96,7 @@ Mixin to store custom properties for later definition and reference. Can also up
 </CodeExample>
 
 
-### css.output()
+### tokens.output()
 
 <ReferenceBar type="mixin" />
 
@@ -114,7 +114,7 @@ Output all custom properties of a provided component. Or output all custom prope
   <Fragment slot="tab-scss">
     ```scss
     :root {
-      @include css.output("block");
+      @include tokens.output("block");
     }
     ```
   </Fragment>
@@ -129,7 +129,7 @@ Output all custom properties of a provided component. Or output all custom prope
 </CodeExample>
 
 
-### css.override()
+### tokens.override()
 
 <ReferenceBar type="mixin" />
 
@@ -155,7 +155,7 @@ Mixin to override previously defined custom properties. This is primarily used i
   <Fragment slot="tab-scss">
     ```scss
     .block_modifier {
-      @include css.override("block", (
+      @include tokens.override("block", (
         "background": darkGreen,
         "foreground": lightPink
       ));
@@ -178,7 +178,7 @@ Mixin to override previously defined custom properties. This is primarily used i
 For more advanced use-cases, `core/css` provides a more primitive API for fine grained custom property management.
 
 
-### css.register()
+### tokens.register()
 
 <ReferenceBar type="mixin" />
 
@@ -196,11 +196,11 @@ Register a component in the custom properties map. This is used when a component
   <Fragment slot="tab-scss">
     ```scss
     // Register the component's namespace if there are no properties set.
-    @include css.register("block");
+    @include tokens.register("block");
 
     // Provide a fallback if a specific property has not been set.
     .block {
-      padding: css.get("block", "padding", 1em);
+      padding: tokens.get("block", "padding", 1em);
     }
     ```
   </Fragment>
@@ -214,11 +214,11 @@ Register a component in the custom properties map. This is used when a component
 </CodeExample>
 
 
-### css.define()
+### tokens.define()
 
 <ReferenceBar type="mixin" />
 
-Mixin to define a custom property using the provided property name and value. Automatically applied with prefix and component name if provided. This is used internally by `css.output` and `css.override`.
+Mixin to define a custom property using the provided property name and value. Automatically applied with prefix and component name if provided. This is used internally by `tokens.output` and `tokens.override`.
 
 #### Arguments
 
@@ -240,7 +240,7 @@ Mixin to define a custom property using the provided property name and value. Au
   <Fragment slot="tab-scss">
     ```scss
     .block {
-      @include css.define("block", "accent", orange);
+      @include tokens.define("block", "accent", orange);
     }
     ```
   </Fragment>
@@ -254,7 +254,7 @@ Mixin to define a custom property using the provided property name and value. Au
 </CodeExample>
 
 
-### css.reference()
+### tokens.reference()
 
 <ReferenceBar type="function" />
 
@@ -280,7 +280,7 @@ Function to create reference to a custom property using the provided component n
   <Fragment slot="tab-scss">
     ```scss
     .block {
-      background: css.reference("block", "accent", orange);
+      background: tokens.reference("block", "accent", orange);
     }
     ```
   </Fragment>
@@ -294,7 +294,7 @@ Function to create reference to a custom property using the provided component n
 </CodeExample>
 
 
-### css.has()
+### tokens.has()
 
 <ReferenceBar type="function" />
 
@@ -310,15 +310,15 @@ Function used to check if a custom property has been set.
 
 <CodeExample lang="scss">
   ```scss
-  @include css.set("block", "background", darkGreen);
+  @include tokens.set("block", "background", darkGreen);
 
-  @debug css.has("block", "background"); // Returns true
-  @debug css.has("block", "border"); // Returns false
+  @debug tokens.has("block", "background"); // Returns true
+  @debug tokens.has("block", "border"); // Returns false
   ```
 </CodeExample>
 
 
-### css.remove()
+### tokens.remove()
 
 <ReferenceBar type="mixin" />
 
@@ -335,12 +335,12 @@ Mixin used to remove a previously set custom property.
 <CodeExample lang="scss">
   ```scss
   // Remove the "background" property from the "block" component.
-  @include css.remove("block", "background");
+  @include tokens.remove("block", "background");
   ```
 </CodeExample>
 
 
-### css.log()
+### tokens.log()
 
 <ReferenceBar type="mixin" />
 
@@ -360,7 +360,7 @@ Log to console all custom properties, a component map or component theme. Provid
 
 <CodeExample lang="scss">
   ```scss
-  @include css.log("block");
+  @include tokens.log("block");
 
   // Debug output:
   // Custom properties of "block": (

--- a/docs/src/packages/core/palette.mdx
+++ b/docs/src/packages/core/palette.mdx
@@ -1,8 +1,9 @@
 ---
 title: core/palette
-description: "Used to build and return color palette values by leveraging both config and CSS modules."
+description: "Used to build and return color palette values by leveraging both the config and tokens module."
 parent: core
 group: sass-modules
+order: 3
 ---
 
 import ReferenceCard from "../../components/ReferenceCard.astro";
@@ -16,7 +17,7 @@ import ReferenceBar from "../../components/ReferenceBar.astro";
 
 ## Basic usage
 
-This module extends `core/css` by creating a custom properties color palette map under the `palette` namespace. It uses the core palette defined in the config `palette` map containing color names and values.
+This module extends `core/tokens` by creating a custom properties color palette map under the `palette` namespace. It uses the core palette defined in the config `palette` map containing color names and values.
 
 The palette module sets up a watcher on the `palette` map of `core/config`. Whenever the `palette` value is updated the palette module rebuilds stored CSS variables.
 

--- a/docs/src/packages/core/theme.mdx
+++ b/docs/src/packages/core/theme.mdx
@@ -1,17 +1,18 @@
 ---
 title: core/theme
-description: "Used to define, manage, and output global and component-level themes powered by custom properties."
+description: "Used to define, manage, and output global and component-level themes powered by the tokens module."
 parent: core
 group: sass-modules
+order: 4
 ---
 
 import ReferenceCard from "../../components/ReferenceCard.astro";
 import ReferenceBar from "../../components/ReferenceBar.astro";
 
 <CodeExample lang="scss">
-  ```scss
-  @use "@vrembem/core/theme";
-  ```
+```scss
+@use "@vrembem/core/theme";
+```
 </CodeExample>
 
 ## Basic usage
@@ -35,24 +36,24 @@ Function for outputting a theme class. Returns the theme class with appropriate 
 #### Example
 
 <CodeExample lang="scss">
-  ```scss
-  // Output: .vb-theme-light { ... }
-  #{theme.class("light")} {
-    // ...
-  }
+```scss
+// Output: .vb-theme-light { ... }
+#{theme.class("light")} {
+  // ...
+}
 
-  // Output: .vb-theme-dark { ... }
-  #{theme.class("dark")} {
-    // ...
-  }
-  ```
+// Output: .vb-theme-dark { ... }
+#{theme.class("dark")} {
+  // ...
+}
+```
 </CodeExample>
 
 ### theme.set()
 
 <ReferenceBar type="mixin" />
 
-Set a new or modify existing theme custom properties. These are stored as CSS variables in the `core/css` module.
+Set a new or modify existing theme custom properties. These are stored as CSS variables in the `core/tokens` module.
 
 #### Arguments
 
@@ -75,19 +76,19 @@ Set a new or modify existing theme custom properties. These are stored as CSS va
 #### Example
 
 <CodeExample lang="scss">
-  ```scss
-  // Set the foreground custom property for the card dark theme.
-  @include theme.set("dark", "card", "foreground", blue);
+```scss
+// Set the foreground custom property for the card dark theme.
+@include theme.set("dark", "card", "foreground", blue);
 
-  // Set the background and foreground custom properties for the card light theme using a map of property/value pairs.
-  @include theme.set("light", "card", (
-    "background": blue,
-    "foreground": white,
-  ));
+// Set the background and foreground custom properties for the card light theme using a map of property/value pairs.
+@include theme.set("light", "card", (
+  "background": blue,
+  "foreground": white,
+));
 
-  // Create an empty theme by not passing a property or value. This will take the properties of the default theme once output.
-  @include theme.set("dark", "card");
-  ```
+// Create an empty theme by not passing a property or value. This will take the properties of the default theme once output.
+@include theme.set("dark", "card");
+```
 </CodeExample>
 
 ### theme.remove()
@@ -113,19 +114,19 @@ Remove a custom property from themes in a variety of ways.
 #### Example
 
 <CodeExample lang="scss">
-  ```scss
-  // Remove the dark theme from buttons component
-  @include theme.remove("dark", "button");
+```scss
+// Remove the dark theme from buttons component
+@include theme.remove("dark", "button");
 
-  // Remove the border-color property from all button themes
-  @include theme.remove("*", "button", "border-color");
+// Remove the border-color property from all button themes
+@include theme.remove("*", "button", "border-color");
 
-  // Remove the background property from the light button theme
-  @include theme.remove("light", "button", "border-color");
+// Remove the background property from the light button theme
+@include theme.remove("light", "button", "border-color");
 
-  // Remove all themes from all components
-  @include theme.remove("*", "*");
-  ```
+// Remove all themes from all components
+@include theme.remove("*", "*");
+```
 </CodeExample>
 
 ### theme.output-theme()
@@ -147,17 +148,17 @@ Output all the custom properties and values of a component theme or output a spe
 #### Example
 
 <CodeExample lang="scss">
-  ```scss
-  // Output the custom properties for the button light theme.
-  .vb-theme-light {
-    @include theme.output-theme("light", "button");
-  }
+```scss
+// Output the custom properties for the button light theme.
+.vb-theme-light {
+  @include theme.output-theme("light", "button");
+}
 
-  // Output the custom properties for the light theme from all components.
-  .vb-theme-light {
-    @include theme.output-theme("light", "*");
-  }
-  ```
+// Output the custom properties for the light theme from all components.
+.vb-theme-light {
+  @include theme.output-theme("light", "*");
+}
+```
 </CodeExample>
 
 ### theme.output()
@@ -175,11 +176,11 @@ Output all the themes for a specific component. Each theme will be wrapped in it
 #### Example
 
 <CodeExample lang="scss">
-  ```scss
-  // Output all themes of all components.
-  @include theme.output();
+```scss
+// Output all themes of all components.
+@include theme.output();
 
-  // Output all themes of the notice component.
-  @include theme.output("notice");
-  ```
+// Output all themes of the notice component.
+@include theme.output("notice");
+```
 </CodeExample>

--- a/docs/src/packages/core/tokens.mdx
+++ b/docs/src/packages/core/tokens.mdx
@@ -1,22 +1,23 @@
 ---
-title: core/css
-description: "Used to define, manage, and output global and component-level custom properties."
+title: core/tokens
+description: "Used to define, manage, and output global and component-level design tokens expressed as CSS variables."
 parent: core
 group: sass-modules
+order: 2
 ---
 
 import ReferenceCard from "../../components/ReferenceCard.astro";
 import ReferenceBar from "../../components/ReferenceBar.astro";
 
 <CodeExample lang="scss">
-  ```scss
-  @use "@vrembem/core/tokens";
-  ```
+```scss
+@use "@vrembem/core/tokens";
+```
 </CodeExample>
 
 ## Basic usage
 
-For most use-cases, `core/css` provides a straightforward API for managing custom properties. Define, reference and output custom properties both globally and on a per-component basis.
+For most use-cases, `core/tokens` provides a straightforward API for managing custom properties. Define, reference and output custom properties both globally and on a per-component basis.
 
 ### tokens.get()
 
@@ -83,16 +84,16 @@ Mixin to store custom properties for later definition and reference. Can also up
 #### Example
 
 <CodeExample lang="scss">
-  ```scss
-  // Set a single option
-  @include tokens.set("block", "accent", teal);
+```scss
+// Set a single option
+@include tokens.set("block", "accent", teal);
 
-  // Set multiple options at once
-  @include tokens.set("block", (
-    "background": darkGreen,
-    "foreground": lightPink
-  ));
-  ```
+// Set multiple options at once
+@include tokens.set("block", (
+  "background": darkGreen,
+  "foreground": lightPink
+));
+```
 </CodeExample>
 
 
@@ -175,8 +176,7 @@ Mixin to override previously defined custom properties. This is primarily used i
 
 ## Advanced usage
 
-For more advanced use-cases, `core/css` provides a more primitive API for fine grained custom property management.
-
+For more advanced use-cases, `core/tokens` provides a more primitive API for fine grained custom property management.
 
 ### tokens.register()
 
@@ -309,12 +309,12 @@ Function used to check if a custom property has been set.
 #### Example
 
 <CodeExample lang="scss">
-  ```scss
-  @include tokens.set("block", "background", darkGreen);
+```scss
+@include tokens.set("block", "background", darkGreen);
 
-  @debug tokens.has("block", "background"); // Returns true
-  @debug tokens.has("block", "border"); // Returns false
-  ```
+@debug tokens.has("block", "background"); // Returns true
+@debug tokens.has("block", "border"); // Returns false
+```
 </CodeExample>
 
 
@@ -333,10 +333,10 @@ Mixin used to remove a previously set custom property.
 #### Example
 
 <CodeExample lang="scss">
-  ```scss
-  // Remove the "background" property from the "block" component.
-  @include tokens.remove("block", "background");
-  ```
+```scss
+// Remove the "background" property from the "block" component.
+@include tokens.remove("block", "background");
+```
 </CodeExample>
 
 
@@ -359,13 +359,13 @@ Log to console all custom properties, a component map or component theme. Provid
 #### Example
 
 <CodeExample lang="scss">
-  ```scss
-  @include tokens.log("block");
+```scss
+@include tokens.log("block");
 
-  // Debug output:
-  // Custom properties of "block": (
-  //   "background": blue,
-  //   "foreground": green,
-  // )
-  ```
+// Debug output:
+// Custom properties of "block": (
+//   "background": blue,
+//   "foreground": green,
+// )
+```
 </CodeExample>

--- a/docs/src/packages/flex.mdx
+++ b/docs/src/packages/flex.mdx
@@ -34,13 +34,13 @@ Flex comes with the following Sass configuration options that can be set using e
     // @type map
     "flex-gap": (
       "breakpoints": true,
-      "default": css.get("spacing-md"),
+      "default": tokens.get("spacing-md"),
       "0": 0,
       "xs": 1px,
-      "sm": css.get("spacing-sm"),
-      "md": css.get("spacing-md"),
-      "lg": css.get("spacing-lg"),
-      "xl": css.get("spacing-xl")
+      "sm": tokens.get("spacing-sm"),
+      "md": tokens.get("spacing-md"),
+      "lg": tokens.get("spacing-lg"),
+      "xl": tokens.get("spacing-xl")
     ),
 
     // Map for outputting flex_wrap_[key] modifier variants

--- a/docs/src/packages/grid.mdx
+++ b/docs/src/packages/grid.mdx
@@ -50,13 +50,13 @@ Grid comes with the following Sass configuration options that can be set using e
     // @type map
     "grid-gap": (
       "breakpoints": true,
-      "default": calc(css.get("spacing") * 8),
+      "default": calc(tokens.get("spacing") * 8),
       "0": 0,
-      "xs": calc(css.get("spacing") * 2),
-      "sm": calc(css.get("spacing") * 4),
-      "md": calc(css.get("spacing") * 8),
-      "lg": calc(css.get("spacing") * 12),
-      "xl": calc(css.get("spacing") * 16)
+      "xs": calc(tokens.get("spacing") * 2),
+      "sm": calc(tokens.get("spacing") * 4),
+      "md": calc(tokens.get("spacing") * 8),
+      "lg": calc(tokens.get("spacing") * 12),
+      "xl": calc(tokens.get("spacing") * 16)
     ),
 
     // Map for outputting the grid_flow_[key] modifier variants

--- a/docs/src/packages/input.mdx
+++ b/docs/src/packages/input.mdx
@@ -35,9 +35,9 @@ Input comes with the following Sass configuration options that can be set using 
     // @type map
     "input-size": (
       "breakpoints": true,
-      "sm": css.get("form-control-size-sm"),
-      "md": css.get("form-control-size"),
-      "lg": css.get("form-control-size-lg"),
+      "sm": tokens.get("form-control-size-sm"),
+      "md": tokens.get("form-control-size"),
+      "lg": tokens.get("form-control-size-lg"),
     ),
 
     // Map for outputting input_state_[key] modifier variants

--- a/docs/src/packages/menu.mdx
+++ b/docs/src/packages/menu.mdx
@@ -43,9 +43,9 @@ Menu comes with the following Sass configuration options that can be set using e
     // @type map
     "menu-size": (
       "breakpoints": true,
-      "sm": css.get("form-control-size-sm"),
-      "md": css.get("form-control-size"),
-      "lg": css.get("form-control-size-lg")
+      "sm": tokens.get("form-control-size-sm"),
+      "md": tokens.get("form-control-size"),
+      "lg": tokens.get("form-control-size-lg")
     )
   )
 );

--- a/docs/src/packages/radio.mdx
+++ b/docs/src/packages/radio.mdx
@@ -33,10 +33,10 @@ Radio comes with the following Sass configuration options that can be set using 
     // @type map
     "radio-size": (
       "breakpoints": true,
-      "default": css.get("form-control-size"),
-      "sm": css.get("form-control-size-sm"),
-      "md": css.get("form-control-size"),
-      "lg": css.get("form-control-size-lg")
+      "default": tokens.get("form-control-size"),
+      "sm": tokens.get("form-control-size-sm"),
+      "md": tokens.get("form-control-size"),
+      "lg": tokens.get("form-control-size-lg")
     )
   )
 );

--- a/docs/src/packages/switch.mdx
+++ b/docs/src/packages/switch.mdx
@@ -33,10 +33,10 @@ Switch comes with the following Sass configuration options that can be set using
     // @type map
     "switch-size": (
       "breakpoints": true,
-      "default": css.get("form-control-size"),
-      "sm": css.get("form-control-size-sm"),
-      "md": css.get("form-control-size"),
-      "lg": css.get("form-control-size-lg")
+      "default": tokens.get("form-control-size"),
+      "sm": tokens.get("form-control-size-sm"),
+      "md": tokens.get("form-control-size"),
+      "lg": tokens.get("form-control-size-lg")
     )
   )
 );

--- a/docs/src/packages/utility.mdx
+++ b/docs/src/packages/utility.mdx
@@ -61,9 +61,9 @@ Utility comes with the following Sass configuration options that can be set usin
     // A map of border-radius utilities to output
     // @type map
     "utility-border-radius": (
-      "": css.get("border-radius"),
-      "lg": css.get("border-radius-lg"),
-      "circle": css.get("border-radius-circle"),
+      "": tokens.get("border-radius"),
+      "lg": tokens.get("border-radius-lg"),
+      "circle": tokens.get("border-radius-circle"),
       "square": 0
     ),
 
@@ -85,22 +85,22 @@ Utility comes with the following Sass configuration options that can be set usin
     // @type map
     "utility-spacing": (
       "0": 0,
-      "xs": css.get("spacing"),
-      "sm": calc(css.get("spacing") * 2),
-      "": calc(css.get("spacing") * 4),
-      "lg": calc(css.get("spacing") * 8),
-      "xl": calc(css.get("spacing") * 12)
+      "xs": tokens.get("spacing"),
+      "sm": calc(tokens.get("spacing") * 2),
+      "": calc(tokens.get("spacing") * 4),
+      "lg": calc(tokens.get("spacing") * 8),
+      "xl": calc(tokens.get("spacing") * 12)
     ),
 
     // A map of gap utilities to output
     // @type map
     "utility-gap": (
       "0": 0,
-      "xs": css.get("spacing"),
-      "sm": css.get("spacing-sm"),
-      "": css.get("spacing-md"),
-      "lg": css.get("spacing-lg"),
-      "xl": css.get("spacing-xl")
+      "xs": tokens.get("spacing"),
+      "sm": tokens.get("spacing-sm"),
+      "": tokens.get("spacing-md"),
+      "lg": tokens.get("spacing-lg"),
+      "xl": tokens.get("spacing-xl")
     ),
 
     // A map of max-width utilities to output

--- a/docs/src/styles/_badge.scss
+++ b/docs/src/styles/_badge.scss
@@ -1,4 +1,4 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 
 .badge {
@@ -6,10 +6,10 @@
   z-index: 1;
   display: inline-block;
   padding: 0 0.75em;
-  border-radius: css.get("border-radius-circle");
-  font-size: css.get("font-size-sm");
-  color: css.get("foreground-subtle");
-  background-color: css.get("background-shift");
+  border-radius: tokens.get("border-radius-circle");
+  font-size: tokens.get("font-size-sm");
+  color: tokens.get("foreground-subtle");
+  background-color: tokens.get("background-shift");
 }
 
 a.badge:hover {

--- a/docs/src/styles/_box.scss
+++ b/docs/src/styles/_box.scss
@@ -1,4 +1,4 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 @use "@vrembem/core/theme";
 
@@ -9,11 +9,11 @@
 }
 
 .box {
-  color: css.get("primary-foreground");
-  background: css.get("primary-background");
+  color: tokens.get("primary-foreground");
+  background: tokens.get("primary-background");
 }
 
 .box-alt {
-  color: css.get("secondary-foreground");
-  background: css.get("secondary-background");
+  color: tokens.get("secondary-foreground");
+  background: tokens.get("secondary-background");
 }

--- a/docs/src/styles/_brand.scss
+++ b/docs/src/styles/_brand.scss
@@ -1,4 +1,4 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 
 .brand {
@@ -12,16 +12,16 @@
 }
 
 .brand__name {
-  color: css.get("foreground-strong");
+  color: tokens.get("foreground-strong");
 }
 
 .brand__version {
-  color: css.get("foreground-subtle");
+  color: tokens.get("foreground-subtle");
 }
 
 .brand:hover,
 .brand:focus {
   .brand__version {
-    color: css.get("foreground-accent");
+    color: tokens.get("foreground-accent");
   }
 }

--- a/docs/src/styles/_card_reference.scss
+++ b/docs/src/styles/_card_reference.scss
@@ -1,21 +1,21 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 .card_reference {
   .card__header {
-    @include css.override("card", "padding", 0.75em 1em);
+    @include tokens.override("card", "padding", 0.75em 1em);
 
     display: flex;
     flex-wrap: wrap;
-    gap: css.get("spacing-md");
+    gap: tokens.get("spacing-md");
     align-items: center;
   }
 
   .card__title {
-    @include css.override("link", "decoration-thickness", 1.5px);
+    @include tokens.override("link", "decoration-thickness", 1.5px);
 
     padding: 0;
     font-size: 1rem;
-    color: css.get("foreground-strong");
+    color: tokens.get("foreground-strong");
     background: transparent;
   }
 }

--- a/docs/src/styles/_code-block.scss
+++ b/docs/src/styles/_code-block.scss
@@ -1,17 +1,17 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 
 .code-block {
   position: relative;
-  font-size: css.get("font-size");
-  line-height: css.get("line-height");
+  font-size: tokens.get("font-size");
+  line-height: tokens.get("line-height");
   text-align: left;
 
   .pre {
     padding-right: 4em;
-    border: css.get("border");
-    background-color: css.get("background-alt");
+    border: tokens.get("border");
+    background-color: tokens.get("background-alt");
   }
 
   &.has-icon .pre {
@@ -20,7 +20,7 @@
 
   @include core.media-max("xs") {
     .pre {
-      margin: auto calc(css.get("layout", "padding") * -1);
+      margin: auto calc(tokens.get("layout", "padding") * -1);
       border-right: none;
       border-left: none;
       border-radius: 0;
@@ -37,9 +37,9 @@
   display: flex;
   align-items: center;
   padding: 0.5rem;
-  border-radius: css.get("border-radius");
-  color: css.get("foreground-subtle");
-  background-color: css.get("background-alt");
+  border-radius: tokens.get("border-radius");
+  color: tokens.get("foreground-subtle");
+  background-color: tokens.get("background-alt");
 }
 
 .code-block__icon {
@@ -56,7 +56,7 @@
   left: auto;
 
   &:hover {
-    color: css.get("foreground-strong");
+    color: tokens.get("foreground-strong");
   }
 
   @include core.media-max("xs") {
@@ -95,8 +95,8 @@
   @include core.media-max("xs") {
     .pre {
       margin: 0;
-      border: css.get("border");
-      border-radius: css.get("border-radius");
+      border: tokens.get("border");
+      border-radius: tokens.get("border-radius");
     }
 
     .code-block__icon {

--- a/docs/src/styles/_code-example.scss
+++ b/docs/src/styles/_code-example.scss
@@ -1,24 +1,24 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 
 .code-example {
   overflow: hidden;
-  border: css.get("border");
-  border-radius: css.get("border-radius");
-  font-size: css.get("font-size");
-  line-height: css.get("line-height");
+  border: tokens.get("border");
+  border-radius: tokens.get("border-radius");
+  font-size: tokens.get("font-size");
+  line-height: tokens.get("line-height");
 
   * {
     scroll-margin-top: initial;
   }
 
   > * + * {
-    border-top: css.get("border");
+    border-top: tokens.get("border");
   }
 
   @include core.media-max("xs") {
-    margin: 2rem calc(css.get("layout", "padding") * -1) !important;
+    margin: 2rem calc(tokens.get("layout", "padding") * -1) !important;
     border-right: none;
     border-left: none;
     border-radius: 0;
@@ -76,7 +76,7 @@
   }
 
   > *:not(.popover) {
-    transition: all css.get("transition-duration") css.get("transition-timing-function");
+    transition: all tokens.get("transition-duration") tokens.get("transition-timing-function");
   }
 }
 
@@ -92,7 +92,7 @@
   display: flex;
   gap: 0.5rem;
   padding: 0.5rem 3.5rem 0.5rem 1rem;
-  color: css.get("foreground-subtle");
+  color: tokens.get("foreground-subtle");
 
   [data-reset] {
     margin: -2px 0;

--- a/docs/src/styles/_code-expander.scss
+++ b/docs/src/styles/_code-expander.scss
@@ -1,21 +1,21 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
-@include css.set("code-expander", "max-height", 20rem);
+@include tokens.set("code-expander", "max-height", 20rem);
 
 .code-expander {
   position: relative;
-  border: css.get("border");
-  border-radius: css.get("border-radius");
-  font-size: css.get("font-size");
-  line-height: css.get("line-height");
-  transition-timing-function: css.get("transition-timing-function");
-  transition-duration: css.get("transition-duration-short");
+  border: tokens.get("border");
+  border-radius: tokens.get("border-radius");
+  font-size: tokens.get("font-size");
+  line-height: tokens.get("line-height");
+  transition-timing-function: tokens.get("transition-timing-function");
+  transition-duration: tokens.get("transition-duration-short");
   transition-property: border-color, box-shadow;
 
   .pre {
-    max-height: css.get("code-expander", "max-height");
+    max-height: tokens.get("code-expander", "max-height");
     border: none;
-    transition: max-height css.get("transition-duration") css.get("transition-timing-function");
+    transition: max-height tokens.get("transition-duration") tokens.get("transition-timing-function");
   }
 
   &.has-header {
@@ -40,23 +40,23 @@
   display: flex;
   gap: 0.5rem;
   padding: 0.5rem 3.5rem 0.5rem 1rem;
-  border-bottom: css.get("border");
-  color: css.get("foreground-subtle");
+  border-bottom: tokens.get("border");
+  color: tokens.get("foreground-subtle");
 }
 
 .code-expander__tools {
   position: absolute;
   z-index: 2;
-  inset: auto css.get("spacing-md") css.get("spacing-md") auto;
+  inset: auto tokens.get("spacing-md") tokens.get("spacing-md") auto;
   display: flex;
-  gap: css.get("spacing-sm");
+  gap: tokens.get("spacing-sm");
 }
 
 .code-expander__unlock-scroll {
   display: none;
   opacity: 0;
-  transition-timing-function: css.get("transition-timing-function");
-  transition-duration: css.get("transition-duration-short");
+  transition-timing-function: tokens.get("transition-timing-function");
+  transition-duration: tokens.get("transition-duration-short");
   transition-property: opacity, border-color;
 }
 
@@ -80,13 +80,13 @@
   &:hover,
   &:focus-within {
     border-color: palette.get("primary");
-    box-shadow: 0 0 0 css.get("focus-ring-width") palette.get("primary", $a: css.get("focus-ring-opacity"));
+    box-shadow: 0 0 0 tokens.get("focus-ring-width") palette.get("primary", $a: tokens.get("focus-ring-opacity"));
 
     .code-expander__unlock-scroll {
       display: inline-flex;
       border-color: palette.get("primary");
       opacity: 1;
-      box-shadow: 0 0 0 css.get("focus-ring-width") palette.get("primary", $a: css.get("focus-ring-opacity"));
+      box-shadow: 0 0 0 tokens.get("focus-ring-width") palette.get("primary", $a: tokens.get("focus-ring-opacity"));
     }
   }
 }

--- a/docs/src/styles/_config.scss
+++ b/docs/src/styles/_config.scss
@@ -3,7 +3,7 @@
 
 // Import modules to configure
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 @use "@vrembem/core/theme";
 
@@ -26,16 +26,16 @@
 );
 
 // Set CSS variables
-@include css.set("core", "font-family", ("Barlow", system-ui, ui-sans-serif, sans-serif));
-@include css.set("core", "background-glass", oklch(from css.get("background") l c h / 90%));
-@include css.set(
+@include tokens.set("core", "font-family", ("Barlow", system-ui, ui-sans-serif, sans-serif));
+@include tokens.set("core", "background-glass", oklch(from tokens.get("background") l c h / 90%));
+@include tokens.set(
   "type",
   (
-    "font-size": css.get("font-size-lg"),
+    "font-size": tokens.get("font-size-lg"),
     "line-height": 1.7778
   )
 );
-@include css.set(
+@include tokens.set(
   "layout",
   (
     "width": 82rem,
@@ -57,14 +57,14 @@
   "astro",
   (
     "code": (
-      "background": css.get("background-alt"),
-      "foreground": css.get("foreground-strong"),
-      "color-text": css.get("foreground-strong"),
+      "background": tokens.get("background-alt"),
+      "foreground": tokens.get("foreground-strong"),
+      "color-text": tokens.get("foreground-strong"),
       "token": (
-        "comment": css.get("foreground-subtle"),
+        "comment": tokens.get("foreground-subtle"),
         "constant": #1b6bc6,
         "string": #1b6bc6,
-        "keyword": css.get("foreground-strong"),
+        "keyword": tokens.get("foreground-strong"),
         "parameter": #df7a32,
         "function": #794bcf,
         "string-expression": #309b4a,
@@ -79,14 +79,14 @@
   "astro",
   (
     "code": (
-      "background": css.get("background-alt"),
-      "foreground": css.get("foreground-strong"),
-      "color-text": css.get("foreground-strong"),
+      "background": tokens.get("background-alt"),
+      "foreground": tokens.get("foreground-strong"),
+      "color-text": tokens.get("foreground-strong"),
       "token": (
-        "comment": css.get("foreground-subtle"),
+        "comment": tokens.get("foreground-subtle"),
         "constant": #79b8ff,
         "string": #79b8ff,
-        "keyword": css.get("foreground-strong"),
+        "keyword": tokens.get("foreground-strong"),
         "parameter": #ffab70,
         "function": #b392f0,
         "string-expression": #85e89d,

--- a/docs/src/styles/_content.scss
+++ b/docs/src/styles/_content.scss
@@ -1,11 +1,11 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 .content {
-  scroll-margin-top: calc(css.get("layout", "toolbar-height") + 2rem);
+  scroll-margin-top: calc(tokens.get("layout", "toolbar-height") + 2rem);
 
   @include core.media-min("sidebar") {
-    scroll-margin-top: calc(css.get("layout", "navibar-height") + 2rem);
+    scroll-margin-top: calc(tokens.get("layout", "navibar-height") + 2rem);
   }
 
   * {

--- a/docs/src/styles/_doc-block.scss
+++ b/docs/src/styles/_doc-block.scss
@@ -1,15 +1,15 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 
 .doc-block {
   margin: 2rem 0 !important;
-  border: css.get("border");
-  border-radius: css.get("border-radius");
-  font-size: css.get("font-size");
-  line-height: css.get("line-height");
+  border: tokens.get("border");
+  border-radius: tokens.get("border-radius");
+  font-size: tokens.get("font-size");
+  line-height: tokens.get("line-height");
   box-shadow: 0 0 0 0 palette.get("primary", 90%);
-  transition: css.get("transition");
+  transition: tokens.get("transition");
   transition-property: border-color, box-shadow;
 
   & + & {
@@ -22,7 +22,7 @@
   }
 
   @include core.media-max("xs") {
-    margin: 2rem calc(css.get("layout", "padding") * -1) !important;
+    margin: 2rem calc(tokens.get("layout", "padding") * -1) !important;
     border-right: none;
     border-left: none;
     border-radius: 0;
@@ -33,8 +33,8 @@
   }
 
   .type {
-    font-size: css.get("font-size");
-    line-height: css.get("line-height");
+    font-size: tokens.get("font-size");
+    line-height: tokens.get("line-height");
   }
 }
 
@@ -49,7 +49,7 @@
 
 .doc-block__content {
   position: relative;
-  border-top: css.get("border");
+  border-top: tokens.get("border");
 }
 
 .doc-block__meta {

--- a/docs/src/styles/_drawer_aside.scss
+++ b/docs/src/styles/_drawer_aside.scss
@@ -1,5 +1,5 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 
 @layer components {
@@ -8,13 +8,13 @@
     visibility: hidden;
 
     .drawer__dialog {
-      background-color: css.get("background-shift");
+      background-color: tokens.get("background-shift");
       outline: none;
     }
 
     .drawer__container {
       overscroll-behavior: contain;
-      padding: css.get("layout", "padding");
+      padding: tokens.get("layout", "padding");
     }
   }
 
@@ -26,20 +26,20 @@
     .drawer_aside {
       z-index: 2;
       box-sizing: content-box;
-      width: calc(css.get("layout", "aside-width") + css.get("layout", "padding"));
-      padding-right: max(0px, calc((100% - (css.get("layout", "width") + (css.get("layout", "padding") * 2))) / 2));
+      width: calc(tokens.get("layout", "aside-width") + tokens.get("layout", "padding"));
+      padding-right: max(0px, calc((100% - (tokens.get("layout", "width") + (tokens.get("layout", "padding") * 2))) / 2));
       visibility: visible;
 
       .drawer__dialog {
         inset: 0 auto auto 0;
-        width: calc(css.get("layout", "aside-width") + css.get("layout", "padding"));
+        width: calc(tokens.get("layout", "aside-width") + tokens.get("layout", "padding"));
         max-height: 100vh;
         background-color: transparent;
       }
 
       .drawer__container {
         scroll-behavior: smooth;
-        padding: calc(css.get("layout", "navibar-height") + css.get("layout", "content-padding-y")) css.get("layout", "padding") calc(css.get("layout", "footer-height") + css.get("layout", "content-padding-y")) css.get("focus-ring-width");
+        padding: calc(tokens.get("layout", "navibar-height") + tokens.get("layout", "content-padding-y")) tokens.get("layout", "padding") calc(tokens.get("layout", "footer-height") + tokens.get("layout", "content-padding-y")) tokens.get("focus-ring-width");
       }
     }
   }

--- a/docs/src/styles/_drawer_aside.scss
+++ b/docs/src/styles/_drawer_aside.scss
@@ -2,45 +2,43 @@
 @use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 
-@layer components {
+.drawer_aside {
+  position: fixed;
+  visibility: hidden;
+
+  .drawer__dialog {
+    background-color: tokens.get("background-shift");
+    outline: none;
+  }
+
+  .drawer__container {
+    overscroll-behavior: contain;
+    padding: tokens.get("layout", "padding");
+  }
+}
+
+/**
+* Inline aside
+*/
+
+@include core.media-min("aside") {
   .drawer_aside {
-    position: fixed;
-    visibility: hidden;
+    z-index: 2;
+    box-sizing: content-box;
+    width: calc(tokens.get("layout", "aside-width") + tokens.get("layout", "padding"));
+    padding-right: max(0px, calc((100% - (tokens.get("layout", "width") + (tokens.get("layout", "padding") * 2))) / 2));
+    visibility: visible;
 
     .drawer__dialog {
-      background-color: tokens.get("background-shift");
-      outline: none;
+      inset: 0 auto auto 0;
+      width: calc(tokens.get("layout", "aside-width") + tokens.get("layout", "padding"));
+      max-height: 100vh;
+      background-color: transparent;
     }
 
     .drawer__container {
-      overscroll-behavior: contain;
-      padding: tokens.get("layout", "padding");
-    }
-  }
-
-  /**
-  * Inline aside
-  */
-
-  @include core.media-min("aside") {
-    .drawer_aside {
-      z-index: 2;
-      box-sizing: content-box;
-      width: calc(tokens.get("layout", "aside-width") + tokens.get("layout", "padding"));
-      padding-right: max(0px, calc((100% - (tokens.get("layout", "width") + (tokens.get("layout", "padding") * 2))) / 2));
-      visibility: visible;
-
-      .drawer__dialog {
-        inset: 0 auto auto 0;
-        width: calc(tokens.get("layout", "aside-width") + tokens.get("layout", "padding"));
-        max-height: 100vh;
-        background-color: transparent;
-      }
-
-      .drawer__container {
-        scroll-behavior: smooth;
-        padding: calc(tokens.get("layout", "navibar-height") + tokens.get("layout", "content-padding-y")) tokens.get("layout", "padding") calc(tokens.get("layout", "footer-height") + tokens.get("layout", "content-padding-y")) tokens.get("focus-ring-width");
-      }
+      scroll-behavior: smooth;
+      padding: calc(tokens.get("layout", "navibar-height") + tokens.get("layout", "content-padding-y")) tokens.get("layout", "padding") calc(tokens.get("layout", "footer-height") + tokens.get("layout", "content-padding-y")) tokens.get("focus-ring-width");
     }
   }
 }

--- a/docs/src/styles/_drawer_sidebar.scss
+++ b/docs/src/styles/_drawer_sidebar.scss
@@ -1,74 +1,72 @@
 @use "@vrembem/core";
 @use "@vrembem/core/tokens";
 
-@layer components {
+.drawer_sidebar {
+  position: fixed;
+  visibility: hidden;
+
+  .drawer__dialog {
+    background-color: tokens.get("background-shift");
+    outline: none;
+  }
+
+  .drawer__container {
+    overscroll-behavior: contain;
+    padding: tokens.get("layout", "padding");
+  }
+}
+
+/**
+* Inline sidebar
+*/
+
+@include core.media-min("sidebar") {
   .drawer_sidebar {
-    position: fixed;
-    visibility: hidden;
+    z-index: 2;
+    box-sizing: content-box;
+    width: calc(tokens.get("layout", "sidebar-width") + tokens.get("layout", "padding"));
+    padding-left: max(0px, calc((100% - (tokens.get("layout", "width") + (tokens.get("layout", "padding") * 2))) / 2));
+    visibility: visible;
+    background-color: tokens.get("background-shift");
+
+    // Fold shadow
+    &::after {
+      pointer-events: none;
+      content: "";
+      position: absolute;
+      z-index: 2;
+      inset: 0 0 auto auto;
+      width: 2rem;
+      height: 100%;
+      background: linear-gradient(268deg, rgb(0 0 0 / 8%) 0, rgb(0 0 0 / 0%) 2rem);
+    }
 
     .drawer__dialog {
-      background-color: tokens.get("background-shift");
-      outline: none;
+      inset: 0 0 0 auto;
+      width: calc(tokens.get("layout", "sidebar-width") + tokens.get("layout", "padding"));
+      background-color: transparent;
     }
 
     .drawer__container {
-      overscroll-behavior: contain;
-      padding: tokens.get("layout", "padding");
+      padding: tokens.get("layout", "navibar-height") tokens.get("layout", "padding") tokens.get("layout", "padding");
     }
-  }
 
-  /**
-  * Inline sidebar
-  */
-
-  @include core.media-min("sidebar") {
-    .drawer_sidebar {
+    // Scrolling mask
+    .drawer__mask {
+      position: sticky;
       z-index: 2;
-      box-sizing: content-box;
-      width: calc(tokens.get("layout", "sidebar-width") + tokens.get("layout", "padding"));
-      padding-left: max(0px, calc((100% - (tokens.get("layout", "width") + (tokens.get("layout", "padding") * 2))) / 2));
-      visibility: visible;
+      inset: calc((tokens.get("layout", "navibar-height") + tokens.get("layout", "padding")) * -1) 0 auto 0;
+      flex-shrink: 0;
+      height: calc(tokens.get("layout", "navibar-height") + tokens.get("layout", "padding"));
+      margin: calc((tokens.get("layout", "navibar-height") + tokens.get("layout", "padding")) * -1) calc(tokens.get("layout", "padding") * -1) tokens.get("layout", "padding") calc(tokens.get("layout", "padding") * -1);
       background-color: tokens.get("background-shift");
 
-      // Fold shadow
       &::after {
-        pointer-events: none;
         content: "";
         position: absolute;
-        z-index: 2;
-        inset: 0 0 auto auto;
-        width: 2rem;
-        height: 100%;
-        background: linear-gradient(268deg, rgb(0 0 0 / 8%) 0, rgb(0 0 0 / 0%) 2rem);
-      }
-
-      .drawer__dialog {
-        inset: 0 0 0 auto;
-        width: calc(tokens.get("layout", "sidebar-width") + tokens.get("layout", "padding"));
-        background-color: transparent;
-      }
-
-      .drawer__container {
-        padding: tokens.get("layout", "navibar-height") tokens.get("layout", "padding") tokens.get("layout", "padding");
-      }
-
-      // Scrolling mask
-      .drawer__mask {
-        position: sticky;
-        z-index: 2;
-        inset: calc((tokens.get("layout", "navibar-height") + tokens.get("layout", "padding")) * -1) 0 auto 0;
-        flex-shrink: 0;
-        height: calc(tokens.get("layout", "navibar-height") + tokens.get("layout", "padding"));
-        margin: calc((tokens.get("layout", "navibar-height") + tokens.get("layout", "padding")) * -1) calc(tokens.get("layout", "padding") * -1) tokens.get("layout", "padding") calc(tokens.get("layout", "padding") * -1);
-        background-color: tokens.get("background-shift");
-
-        &::after {
-          content: "";
-          position: absolute;
-          inset: 100% 0 auto;
-          margin: 0 tokens.get("layout", "padding");
-          border-bottom: 1px solid tokens.get("border-color");
-        }
+        inset: 100% 0 auto;
+        margin: 0 tokens.get("layout", "padding");
+        border-bottom: 1px solid tokens.get("border-color");
       }
     }
   }

--- a/docs/src/styles/_drawer_sidebar.scss
+++ b/docs/src/styles/_drawer_sidebar.scss
@@ -1,5 +1,5 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 @layer components {
   .drawer_sidebar {
@@ -7,13 +7,13 @@
     visibility: hidden;
 
     .drawer__dialog {
-      background-color: css.get("background-shift");
+      background-color: tokens.get("background-shift");
       outline: none;
     }
 
     .drawer__container {
       overscroll-behavior: contain;
-      padding: css.get("layout", "padding");
+      padding: tokens.get("layout", "padding");
     }
   }
 
@@ -25,10 +25,10 @@
     .drawer_sidebar {
       z-index: 2;
       box-sizing: content-box;
-      width: calc(css.get("layout", "sidebar-width") + css.get("layout", "padding"));
-      padding-left: max(0px, calc((100% - (css.get("layout", "width") + (css.get("layout", "padding") * 2))) / 2));
+      width: calc(tokens.get("layout", "sidebar-width") + tokens.get("layout", "padding"));
+      padding-left: max(0px, calc((100% - (tokens.get("layout", "width") + (tokens.get("layout", "padding") * 2))) / 2));
       visibility: visible;
-      background-color: css.get("background-shift");
+      background-color: tokens.get("background-shift");
 
       // Fold shadow
       &::after {
@@ -44,30 +44,30 @@
 
       .drawer__dialog {
         inset: 0 0 0 auto;
-        width: calc(css.get("layout", "sidebar-width") + css.get("layout", "padding"));
+        width: calc(tokens.get("layout", "sidebar-width") + tokens.get("layout", "padding"));
         background-color: transparent;
       }
 
       .drawer__container {
-        padding: css.get("layout", "navibar-height") css.get("layout", "padding") css.get("layout", "padding");
+        padding: tokens.get("layout", "navibar-height") tokens.get("layout", "padding") tokens.get("layout", "padding");
       }
 
       // Scrolling mask
       .drawer__mask {
         position: sticky;
         z-index: 2;
-        inset: calc((css.get("layout", "navibar-height") + css.get("layout", "padding")) * -1) 0 auto 0;
+        inset: calc((tokens.get("layout", "navibar-height") + tokens.get("layout", "padding")) * -1) 0 auto 0;
         flex-shrink: 0;
-        height: calc(css.get("layout", "navibar-height") + css.get("layout", "padding"));
-        margin: calc((css.get("layout", "navibar-height") + css.get("layout", "padding")) * -1) calc(css.get("layout", "padding") * -1) css.get("layout", "padding") calc(css.get("layout", "padding") * -1);
-        background-color: css.get("background-shift");
+        height: calc(tokens.get("layout", "navibar-height") + tokens.get("layout", "padding"));
+        margin: calc((tokens.get("layout", "navibar-height") + tokens.get("layout", "padding")) * -1) calc(tokens.get("layout", "padding") * -1) tokens.get("layout", "padding") calc(tokens.get("layout", "padding") * -1);
+        background-color: tokens.get("background-shift");
 
         &::after {
           content: "";
           position: absolute;
           inset: 100% 0 auto;
-          margin: 0 css.get("layout", "padding");
-          border-bottom: 1px solid css.get("border-color");
+          margin: 0 tokens.get("layout", "padding");
+          border-bottom: 1px solid tokens.get("border-color");
         }
       }
     }

--- a/docs/src/styles/_footer.scss
+++ b/docs/src/styles/_footer.scss
@@ -1,19 +1,19 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 
 .footer {
   display: flex;
-  color: css.get("foreground-subtle");
+  color: tokens.get("foreground-subtle");
 }
 
 .footer__content {
   flex-grow: 1;
   width: 100%;
-  max-width: css.get("layout", "content-width");
+  max-width: tokens.get("layout", "content-width");
   margin: auto;
   padding: 3rem 0;
-  border-top: css.get("border");
+  border-top: tokens.get("border");
 
   .is-home & {
     max-width: unset;
@@ -25,7 +25,7 @@
   flex-grow: 0;
   justify-content: center;
   padding: 3rem 0;
-  border-top: css.get("border");
+  border-top: tokens.get("border");
   color: palette.get("primary");
   text-align: center;
 
@@ -34,8 +34,8 @@
       position: absolute;
       z-index: 2;
       right: 0;
-      width: calc(css.get("layout", "aside-width") - css.get("focus-ring-width"));
-      background-color: css.get("background");
+      width: calc(tokens.get("layout", "aside-width") - tokens.get("focus-ring-width"));
+      background-color: tokens.get("background");
     }
 
     .is-home & {

--- a/docs/src/styles/_global.scss
+++ b/docs/src/styles/_global.scss
@@ -1,5 +1,5 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 @use "@vrembem/button";
 
@@ -29,7 +29,7 @@ html {
   position: relative;
   transform: translateY(1rem);
   opacity: 0;
-  transition: css.get("transition");
+  transition: tokens.get("transition");
   transition-property: transform, opacity;
 
   &.is-active {
@@ -86,7 +86,7 @@ html {
 
 // Source: sass-utilities.mdx ## focus-ring-color
 
-@include css.register("focus-ring-example");
+@include tokens.register("focus-ring-example");
 
 .focus-ring-example {
   @include core.focus-ring-base;

--- a/docs/src/styles/_heading-anchor.scss
+++ b/docs/src/styles/_heading-anchor.scss
@@ -1,25 +1,25 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 
 .heading-anchor {
-  @include css.override("core", "form-control-border-width", 0);
+  @include tokens.override("core", "form-control-border-width", 0);
 
   user-select: none;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   margin-left: 0.5rem;
-  padding: css.get("form-control-padding-y");
-  border-radius: css.get("border-radius-circle");
+  padding: tokens.get("form-control-padding-y");
+  border-radius: tokens.get("border-radius-circle");
   font-size: 1rem;
   font-weight: 500;
   text-decoration: none !important;
   vertical-align: middle;
   opacity: 0;
   background-color: palette.get("primary", $a: 0%);
-  transition-timing-function: css.get("transition-timing-function");
-  transition-duration: css.get("transition-duration");
+  transition-timing-function: tokens.get("transition-timing-function");
+  transition-duration: tokens.get("transition-duration");
   transition-property: color, opacity;
 
   &:hover,
@@ -40,7 +40,7 @@
 
   @include core.media-min("sm") {
     position: absolute;
-    top: calc(60% - calc(css.get("form-control-size-calc") / 2));
+    top: calc(60% - calc(tokens.get("form-control-size-calc") / 2));
     right: calc(100% + 0.5rem);
     margin-left: 0;
   }

--- a/docs/src/styles/_icon_external.scss
+++ b/docs/src/styles/_icon_external.scss
@@ -1,12 +1,12 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 .icon_external {
   position: relative;
   right: -0.25em;
   font-size: 0.75em;
-  color: css.get("foreground-subtle");
+  color: tokens.get("foreground-subtle");
   stroke-width: 2.5;
-  transition: transform css.get("transition-duration-short") css.get("transition-timing-function");
+  transition: transform tokens.get("transition-duration-short") tokens.get("transition-timing-function");
 }
 
 a:hover > .icon_external {

--- a/docs/src/styles/_layout-demo.scss
+++ b/docs/src/styles/_layout-demo.scss
@@ -1,4 +1,4 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/theme";
 @include theme.set(
   "light",
@@ -18,7 +18,7 @@
 );
 
 .layout-demo {
-  background-color: css.get("layout", "background-color");
-  background-image: linear-gradient(135deg, css.get("layout", "background-stripe") 10%, rgb(0 0 0 / 0%) 0, rgb(0 0 0 / 0%) 50%, css.get("layout", "background-stripe") 0, css.get("layout", "background-stripe") 60%, rgb(0 0 0 / 0%) 0, rgb(0 0 0 / 0%));
+  background-color: tokens.get("layout", "background-color");
+  background-image: linear-gradient(135deg, tokens.get("layout", "background-stripe") 10%, rgb(0 0 0 / 0%) 0, rgb(0 0 0 / 0%) 50%, tokens.get("layout", "background-stripe") 0, tokens.get("layout", "background-stripe") 60%, rgb(0 0 0 / 0%) 0, rgb(0 0 0 / 0%));
   background-size: 8px 8px;
 }

--- a/docs/src/styles/_layout.scss
+++ b/docs/src/styles/_layout.scss
@@ -1,5 +1,5 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 
 .layout {
@@ -7,35 +7,35 @@
   display: flex;
   justify-content: center;
   width: 100%;
-  padding: 0 css.get("layout", "padding");
+  padding: 0 tokens.get("layout", "padding");
 
   @include core.media-min("xs") {
-    @include css.override("layout", "content-padding-x", 1rem);
-    @include css.override("layout", "content-padding-y", 1rem);
+    @include tokens.override("layout", "content-padding-x", 1rem);
+    @include tokens.override("layout", "content-padding-y", 1rem);
   }
 
   @include core.media-min("sm") {
-    @include css.override("layout", "content-padding-x", 3rem);
-    @include css.override("layout", "content-padding-y", 2rem);
+    @include tokens.override("layout", "content-padding-x", 3rem);
+    @include tokens.override("layout", "content-padding-y", 2rem);
   }
 
   @include core.media-min("sidebar") {
-    @include css.override("layout", "content-padding-x", 4rem);
-    @include css.override("layout", "content-padding-y", 3rem);
-    @include css.override("layout", "padding", 1.5rem);
+    @include tokens.override("layout", "content-padding-x", 4rem);
+    @include tokens.override("layout", "content-padding-y", 3rem);
+    @include tokens.override("layout", "padding", 1.5rem);
 
     &.has-sidebar .layout__main {
-      padding-left: css.get("layout", "sidebar-width");
+      padding-left: tokens.get("layout", "sidebar-width");
     }
 
     &.has-aside .layout__main {
-      padding-right: css.get("form-control-size-calc");
+      padding-right: tokens.get("form-control-size-calc");
     }
   }
 
   @include core.media-min("aside") {
     &.has-aside .layout__main {
-      padding-right: css.get("layout", "aside-width");
+      padding-right: tokens.get("layout", "aside-width");
     }
   }
 }
@@ -43,12 +43,12 @@
 .layout__main {
   position: relative;
   width: 100%;
-  max-width: css.get("layout", "width");
+  max-width: tokens.get("layout", "width");
   margin: auto;
   outline: none;
 
   @include core.media-min("sidebar") {
-    padding-top: css.get("layout", "navibar-height");
+    padding-top: tokens.get("layout", "navibar-height");
 
     &::before {
       content: "";
@@ -56,8 +56,8 @@
       z-index: 4;
       top: 0;
       width: 100%;
-      height: css.get("layout", "navibar-height");
-      background-color: css.get("background-glass");
+      height: tokens.get("layout", "navibar-height");
+      background-color: tokens.get("background-glass");
       backdrop-filter: blur(8px);
     }
   }
@@ -65,11 +65,11 @@
 
 .layout__container {
   width: 100%;
-  max-width: calc(css.get("layout", "content-width"));
+  max-width: calc(tokens.get("layout", "content-width"));
   margin: auto;
-  padding: css.get("layout", "content-padding-y") css.get("layout", "content-padding-x") 0;
+  padding: tokens.get("layout", "content-padding-y") tokens.get("layout", "content-padding-x") 0;
 
   > * + * {
-    margin-top: calc(css.get("spacing") * 12) !important;
+    margin-top: calc(tokens.get("spacing") * 12) !important;
   }
 }

--- a/docs/src/styles/_menu_collection.scss
+++ b/docs/src/styles/_menu_collection.scss
@@ -1,14 +1,14 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 .menu_collection {
-  @include css.override("menu", "gap", 0);
+  @include tokens.override("menu", "gap", 0);
 
   margin-top: 0.5rem;
 
   .menu__action.is-active,
   .menu__action.is-parent {
-    color: css.get("foreground-accent");
-    background: css.get("background");
+    color: tokens.get("foreground-accent");
+    background: tokens.get("background");
   }
 
   .menu {

--- a/docs/src/styles/_menu_minimal.scss
+++ b/docs/src/styles/_menu_minimal.scss
@@ -1,12 +1,12 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 
 .menu_minimal {
-  @include css.override(
+  @include tokens.override(
     "menu",
     (
       "gap": 0,
-      "size": css.get("font-size-sm")
+      "size": tokens.get("font-size-sm")
     )
   );
 
@@ -32,7 +32,7 @@
     }
 
     &:hover::before {
-      background: css.get("foreground-strong");
+      background: tokens.get("foreground-strong");
     }
 
     &.is-active::before {

--- a/docs/src/styles/_menu_themes.scss
+++ b/docs/src/styles/_menu_themes.scss
@@ -1,7 +1,7 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 .menu_themes {
-  @include css.override("menu", "action-gap", 1rem);
+  @include tokens.override("menu", "action-gap", 1rem);
 
   .popover & {
     font-size: 0.875rem;

--- a/docs/src/styles/_navibar.scss
+++ b/docs/src/styles/_navibar.scss
@@ -1,20 +1,20 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 .navibar {
   position: relative;
   z-index: 5;
   width: 100%;
-  padding: 0 css.get("layout", "padding");
+  padding: 0 tokens.get("layout", "padding");
 
   @include core.media-min("sidebar") {
-    @include css.override("layout", "padding", 1.5rem);
+    @include tokens.override("layout", "padding", 1.5rem);
 
     position: fixed;
   }
 
   .is-home & {
-    background-color: css.get("background-glass");
+    background-color: tokens.get("background-glass");
     backdrop-filter: blur(8px);
   }
 }
@@ -22,7 +22,7 @@
 .navibar__container {
   display: flex;
   width: 100%;
-  max-width: css.get("layout", "width");
+  max-width: tokens.get("layout", "width");
   margin: auto;
 }
 
@@ -30,12 +30,12 @@
 .navibar__menu {
   display: flex;
   align-items: center;
-  height: css.get("layout", "navibar-height");
+  height: tokens.get("layout", "navibar-height");
 }
 
 .navibar__title {
   position: relative;
-  width: css.get("layout", "sidebar-width");
+  width: tokens.get("layout", "sidebar-width");
 }
 
 .navibar__skip {
@@ -45,12 +45,12 @@
   width: calc(100% - 1em);
   margin-right: 1em;
   opacity: 0;
-  transition-timing-function: css.get("transition-timing-function");
-  transition-duration: css.get("transition-duration");
+  transition-timing-function: tokens.get("transition-timing-function");
+  transition-duration: tokens.get("transition-duration");
   transition-property: top, opacity;
 
   &:focus {
-    top: calc(calc(css.get("layout", "navibar-height") - css.get("form-control-size-calc")) / 2);
+    top: calc(calc(tokens.get("layout", "navibar-height") - tokens.get("form-control-size-calc")) / 2);
     opacity: 1;
   }
 }
@@ -75,6 +75,6 @@
   height: 0;
 
   @include core.media-min("sidebar") {
-    height: css.get("layout", "navibar-height");
+    height: tokens.get("layout", "navibar-height");
   }
 }

--- a/docs/src/styles/_pagi.scss
+++ b/docs/src/styles/_pagi.scss
@@ -1,5 +1,5 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 
 .pagi {
@@ -29,11 +29,11 @@
 .pagi_link {
   display: block;
   padding: 1rem;
-  border: 1px solid css.get("border-color");
-  border-radius: css.get("border-radius");
+  border: 1px solid tokens.get("border-color");
+  border-radius: tokens.get("border-radius");
   transition: border-color;
-  transition-timing-function: css.get("transition-timing-function");
-  transition-duration: css.get("transition-duration");
+  transition-timing-function: tokens.get("transition-timing-function");
+  transition-duration: tokens.get("transition-duration");
 
   &:hover {
     border-color: palette.get("primary");
@@ -41,11 +41,11 @@
 }
 
 .pagi_label {
-  font-size: css.get("font-size-sm");
-  color: css.get("foreground-subtle");
+  font-size: tokens.get("font-size-sm");
+  color: tokens.get("foreground-subtle");
 }
 
 .pagi_title {
-  font-size: css.get("font-size-lg");
+  font-size: tokens.get("font-size-lg");
   color: palette.get("primary");
 }

--- a/docs/src/styles/_popover_copy.scss
+++ b/docs/src/styles/_popover_copy.scss
@@ -1,8 +1,8 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 
 .popover_copy {
-  @include css.override(
+  @include tokens.override(
     "popover",
     (
       "placement": top,

--- a/docs/src/styles/_reference-bar.scss
+++ b/docs/src/styles/_reference-bar.scss
@@ -1,16 +1,16 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 .reference-bar {
   display: flex;
   flex-wrap: wrap;
-  gap: css.get("spacing-sm") css.get("spacing-md");
+  gap: tokens.get("spacing-sm") tokens.get("spacing-md");
   align-items: center;
   justify-content: space-between;
-  color: css.get("foreground-strong");
+  color: tokens.get("foreground-strong");
 
   .link_hash {
     display: flex;
-    gap: css.get("spacing-sm");
+    gap: tokens.get("spacing-sm");
     align-items: center;
   }
 }
@@ -18,6 +18,6 @@
 .reference-bar__item {
   display: flex;
   flex-wrap: nowrap;
-  gap: css.get("spacing-sm");
+  gap: tokens.get("spacing-sm");
   align-items: center;
 }

--- a/docs/src/styles/_reference-table.scss
+++ b/docs/src/styles/_reference-table.scss
@@ -1,14 +1,14 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 @use "@vrembem/core/theme";
-@include css.set("reference-table", "max-height", 28rem);
+@include tokens.set("reference-table", "max-height", 28rem);
 
 .reference-table {
   scroll-margin-top: 84px; // Magic number found using JS: `this.el.getBoundingClientRect().top;`
   width: 100%;
-  font-size: css.get("font-size");
-  transition: max-height css.get("transition-duration") css.get("transition-timing-function");
+  font-size: tokens.get("font-size");
+  transition: max-height tokens.get("transition-duration") tokens.get("transition-timing-function");
 
   table {
     position: relative;
@@ -17,20 +17,20 @@
   }
 
   thead {
-    border-bottom: 1px solid css.get("border-color");
+    border-bottom: 1px solid tokens.get("border-color");
   }
 
   tr {
-    scroll-margin-top: calc(css.get("layout", "toolbar-height") + 81px);
+    scroll-margin-top: calc(tokens.get("layout", "toolbar-height") + 81px);
     position: relative;
-    border-top: 1px solid css.get("border-color");
-    border-radius: css.get("border-radius");
+    border-top: 1px solid tokens.get("border-color");
+    border-radius: tokens.get("border-radius");
     box-shadow:
       0 0 0 0 palette.get("primary"),
       0 0 0 0 palette.get("primary", $a: 20%);
 
     @include core.media-min("sidebar") {
-      scroll-margin-top: calc(css.get("layout", "navibar-height") + 82px);
+      scroll-margin-top: calc(tokens.get("layout", "navibar-height") + 82px);
     }
 
     &.is-active {
@@ -58,13 +58,13 @@
     padding: 0;
 
     &:first-child {
-      @include css.override("pre", "foreground", css.get("foreground-accent-alt"));
+      @include tokens.override("pre", "foreground", tokens.get("foreground-accent-alt"));
 
       text-wrap: nowrap;
     }
 
     &:last-child {
-      @include css.override("pre", "foreground", css.get("foreground-accent"));
+      @include tokens.override("pre", "foreground", tokens.get("foreground-accent"));
     }
   }
 
@@ -83,14 +83,14 @@
       background-color: transparent;
 
       .icon {
-        @include css.override("icon", "size", 1em);
+        @include tokens.override("icon", "size", 1em);
       }
     }
 
     .code-block__copy-button {
       right: 0;
       opacity: 0;
-      background-color: css.get("background");
+      background-color: tokens.get("background");
 
       &:hover,
       &:focus {
@@ -110,24 +110,24 @@
   }
 
   .notice {
-    margin-top: css.get("spacing-md");
-    border-radius: css.get("border-radius");
-    font-size: css.get("font-size");
+    margin-top: tokens.get("spacing-md");
+    border-radius: tokens.get("border-radius");
+    font-size: tokens.get("font-size");
   }
 
   &.is-expandable {
     overflow: hidden;
-    max-height: css.get("reference-table", "max-height");
+    max-height: tokens.get("reference-table", "max-height");
   }
 
   &.is-expanded {
     overflow: visible;
 
     thead {
-      top: calc(css.get("layout", "toolbar-height") - 1px);
+      top: calc(tokens.get("layout", "toolbar-height") - 1px);
 
       @include core.media-min("sidebar") {
-        top: calc(css.get("layout", "navibar-height") - 1px);
+        top: calc(tokens.get("layout", "navibar-height") - 1px);
       }
     }
   }
@@ -136,12 +136,12 @@
 .reference-table__header {
   position: sticky;
   z-index: 2;
-  top: calc(css.get("layout", "toolbar-height") - 1px);
-  padding: css.get("spacing-md") 0;
-  background: css.get("background");
+  top: calc(tokens.get("layout", "toolbar-height") - 1px);
+  padding: tokens.get("spacing-md") 0;
+  background: tokens.get("background");
 
   @include core.media-min("sidebar") {
-    top: css.get("layout", "navibar-height");
+    top: tokens.get("layout", "navibar-height");
   }
 
   .is-expandable:not(.is-expanded) & {
@@ -162,7 +162,7 @@
     align-items: center;
     justify-content: center;
     padding: 0 0.75em;
-    color: css.get("foreground-subtle");
+    color: tokens.get("foreground-subtle");
 
     &:hover {
       color: palette.get("primary");
@@ -177,16 +177,16 @@
   }
 
   .input {
-    @include css.override(
+    @include tokens.override(
       "input",
       (
         "padding": 0.75rem,
-        "size": css.get("font-size-sm")
+        "size": tokens.get("font-size-sm")
       )
     );
 
     padding-left: 3.5em;
-    font-family: css.get("font-family-mono");
+    font-family: tokens.get("font-family-mono");
 
     &:focus ~ .input-icon {
       color: palette.get("primary");
@@ -196,7 +196,7 @@
 
 .table-anchor,
 .table-anchor-clear {
-  @include css.override("core", "form-control-border-width", 0);
+  @include tokens.override("core", "form-control-border-width", 0);
 
   user-select: none;
   position: absolute;
@@ -206,8 +206,8 @@
   align-items: center;
   justify-content: center;
   margin-left: 0.5rem;
-  padding: css.get("form-control-padding-y");
-  border-radius: css.get("border-radius-circle");
+  padding: tokens.get("form-control-padding-y");
+  border-radius: tokens.get("border-radius-circle");
   font-size: 1rem;
   font-weight: 500;
   line-height: 1em;
@@ -253,5 +253,5 @@
   bottom: 0;
   padding: 1.5em 0;
   text-align: center;
-  background: linear-gradient(to bottom, transparent, css.reference("core", "background") 70%);
+  background: linear-gradient(to bottom, transparent, tokens.reference("core", "background") 70%);
 }

--- a/docs/src/styles/_swatch.scss
+++ b/docs/src/styles/_swatch.scss
@@ -1,10 +1,10 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 .swatch {
   @include core.size(4rem);
 
   display: inline-block;
-  border: css.get("border");
-  border-radius: css.get("border-radius");
+  border: tokens.get("border");
+  border-radius: tokens.get("border-radius");
 }

--- a/docs/src/styles/_tabs.scss
+++ b/docs/src/styles/_tabs.scss
@@ -1,11 +1,11 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 
 [role="tab"] {
   position: relative;
   margin: -0.5rem 0;
   padding: 0.5rem;
-  color: css.get("foreground-subtle");
+  color: tokens.get("foreground-subtle");
 
   &::after {
     content: "";
@@ -16,7 +16,7 @@
   }
 
   &:hover {
-    color: css.get("foreground-strong");
+    color: tokens.get("foreground-strong");
   }
 
   &[aria-selected="true"] {

--- a/docs/src/styles/_tictactoe.scss
+++ b/docs/src/styles/_tictactoe.scss
@@ -1,10 +1,10 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 @use "@vrembem/core/theme";
-@include css.set(
+@include tokens.set(
   "tictactoe",
   (
-    "border": 0.25em solid css.reference("tictactoe", "border-color")
+    "border": 0.25em solid tokens.reference("tictactoe", "border-color")
   )
 );
 @include theme.set(
@@ -44,26 +44,26 @@
   height: 3em;
   font-size: 1.6em;
   text-align: center;
-  box-shadow: inset 0 0 0 0.25em css.get("tictactoe", "box-shadow-color");
+  box-shadow: inset 0 0 0 0.25em tokens.get("tictactoe", "box-shadow-color");
 
   &.is-winner {
-    color: css.get("tictactoe", "foreground-winner");
-    background-color: css.get("tictactoe", "background-winner");
+    color: tokens.get("tictactoe", "foreground-winner");
+    background-color: tokens.get("tictactoe", "background-winner");
   }
 
   &:first-child {
-    border-right: css.get("tictactoe", "border");
+    border-right: tokens.get("tictactoe", "border");
   }
 
   &:last-child {
-    border-left: css.get("tictactoe", "border");
+    border-left: tokens.get("tictactoe", "border");
   }
 
   tr:first-child & {
-    border-bottom: css.get("tictactoe", "border");
+    border-bottom: tokens.get("tictactoe", "border");
   }
 
   tr:last-child & {
-    border-top: css.get("tictactoe", "border");
+    border-top: tokens.get("tictactoe", "border");
   }
 }

--- a/docs/src/styles/_toggle.scss
+++ b/docs/src/styles/_toggle.scss
@@ -1,10 +1,10 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 .toggle-trigger {
   .icon {
     transform: rotate(0);
-    transition: transform css.get("transition");
+    transition: transform tokens.get("transition");
   }
 
   &[aria-expanded="true"] .icon {

--- a/docs/src/styles/_toolbar.scss
+++ b/docs/src/styles/_toolbar.scss
@@ -1,15 +1,15 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 .toolbar {
   position: sticky;
   z-index: 4;
   top: -1px;
   display: block;
-  padding: css.get("layout", "padding");
-  border-top: 1px solid css.get("border-color");
-  border-bottom: 1px solid css.get("border-color");
-  background-color: css.get("background-glass");
+  padding: tokens.get("layout", "padding");
+  border-top: 1px solid tokens.get("border-color");
+  border-bottom: 1px solid tokens.get("border-color");
+  background-color: tokens.get("background-glass");
   background-clip: padding-box;
   backdrop-filter: blur(8px);
 
@@ -26,8 +26,8 @@
 .toolbar-mini {
   position: fixed;
   z-index: 6;
-  top: css.get("layout", "navibar-height");
-  right: css.get("layout", "padding");
+  top: tokens.get("layout", "navibar-height");
+  right: tokens.get("layout", "padding");
   transform: translate(100%);
   visibility: hidden;
   opacity: 0;

--- a/docs/src/styles/app.scss
+++ b/docs/src/styles/app.scss
@@ -1,3 +1,5 @@
+@use "sass:meta";
+
 // Import the Vrembem defined layers
 @forward "vrembem/layers";
 
@@ -10,43 +12,45 @@
 // Miscellaneous global styles
 @forward "./global";
 
-// Layout
-@forward "./brand";
-@forward "./navibar";
-@forward "./toolbar";
-@forward "./layout";
-@forward "./drawer_sidebar";
-@forward "./drawer_aside";
+@layer components {
+  // Layout
+  @include meta.load-css("./brand");
+  @include meta.load-css("./navibar");
+  @include meta.load-css("./toolbar");
+  @include meta.load-css("./layout");
+  @include meta.load-css("./drawer_sidebar");
+  @include meta.load-css("./drawer_aside");
 
-// Components
-@forward "./badge";
-@forward "./box";
-@forward "./card_reference";
-@forward "./code-block";
-@forward "./code-example";
-@forward "./code-expander";
-@forward "./content";
-@forward "./doc-block";
-@forward "./floats";
-@forward "./fold-shadow";
-@forward "./footer";
-@forward "./heading-anchor";
-@forward "./icon_external";
-@forward "./layout-demo";
-@forward "./menu_collection";
-@forward "./menu_minimal";
-@forward "./menu_themes";
-@forward "./pagi";
-@forward "./popover_copy";
-@forward "./reference-bar";
-@forward "./reference-table";
-@forward "./swatch";
-@forward "./tabs";
-@forward "./theme-icons";
-@forward "./tictactoe";
-@forward "./toggle";
+  // Components
+  @include meta.load-css("./badge");
+  @include meta.load-css("./box");
+  @include meta.load-css("./card_reference");
+  @include meta.load-css("./code-block");
+  @include meta.load-css("./code-example");
+  @include meta.load-css("./code-expander");
+  @include meta.load-css("./content");
+  @include meta.load-css("./doc-block");
+  @include meta.load-css("./floats");
+  @include meta.load-css("./fold-shadow");
+  @include meta.load-css("./footer");
+  @include meta.load-css("./heading-anchor");
+  @include meta.load-css("./icon_external");
+  @include meta.load-css("./layout-demo");
+  @include meta.load-css("./menu_collection");
+  @include meta.load-css("./menu_minimal");
+  @include meta.load-css("./menu_themes");
+  @include meta.load-css("./pagi");
+  @include meta.load-css("./popover_copy");
+  @include meta.load-css("./reference-bar");
+  @include meta.load-css("./reference-table");
+  @include meta.load-css("./swatch");
+  @include meta.load-css("./tabs");
+  @include meta.load-css("./theme-icons");
+  @include meta.load-css("./tictactoe");
+  @include meta.load-css("./toggle");
+}
 
 // Important!
 // Include this last to catch all defined custom properties
 // Output all CSS custom properties
-@forward "vrembem/tokens";
+@include meta.load-css("vrembem/tokens");

--- a/packages/base/src/modules/_blockquote.scss
+++ b/packages/base/src/modules/_blockquote.scss
@@ -1,19 +1,19 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "../functions" as fun;
 
 @if fun.maybe-output("blockquote") {
-  @include css.register("blockquote");
+  @include tokens.register("blockquote");
 
   #{fun.selector("blockquote")} {
     position: relative;
-    padding: css.get("blockquote", "padding", css.get("spacing-md"));
-    border: css.get("blockquote", "border", css.get("border"));
-    border-radius: css.get("blockquote", "border-radius", css.get("border-radius"));
-    color: css.get("blockquote", "foreground", currentcolor);
-    background: css.get("blockquote", "background", transparent);
+    padding: tokens.get("blockquote", "padding", tokens.get("spacing-md"));
+    border: tokens.get("blockquote", "border", tokens.get("border"));
+    border-radius: tokens.get("blockquote", "border-radius", tokens.get("border-radius"));
+    color: tokens.get("blockquote", "foreground", currentcolor);
+    background: tokens.get("blockquote", "background", transparent);
 
     > * + * {
-      margin-top: css.get("blockquote", "spacing", css.get("spacing-md"));
+      margin-top: tokens.get("blockquote", "spacing", tokens.get("spacing-md"));
     }
   }
 }

--- a/packages/base/src/modules/_code.scss
+++ b/packages/base/src/modules/_code.scss
@@ -1,17 +1,17 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "../functions" as fun;
 
 @if fun.maybe-output("code") {
-  @include css.register("code");
+  @include tokens.register("code");
 
   #{fun.selector("code")} {
-    padding: css.get("code", "padding", 0.125rem 0.375rem);
-    border: css.get("code", "border", null);
-    border-radius: css.get("code", "border-radius", css.get("border-radius"));
-    font-family: css.get("font-family-mono");
-    font-size: css.get("code", "font-size", css.get("font-size-sm"));
-    color: css.get("code", "foreground", css.get("foreground-accent-alt"));
+    padding: tokens.get("code", "padding", 0.125rem 0.375rem);
+    border: tokens.get("code", "border", null);
+    border-radius: tokens.get("code", "border-radius", tokens.get("border-radius"));
+    font-family: tokens.get("font-family-mono");
+    font-size: tokens.get("code", "font-size", tokens.get("font-size-sm"));
+    color: tokens.get("code", "foreground", tokens.get("foreground-accent-alt"));
     overflow-wrap: break-word;
-    background: css.get("code", "background", css.get("background-alt"));
+    background: tokens.get("code", "background", tokens.get("background-alt"));
   }
 }

--- a/packages/base/src/modules/_global.scss
+++ b/packages/base/src/modules/_global.scss
@@ -1,13 +1,13 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "../functions" as fun;
 
 @if fun.maybe-output("global") {
-  @include css.register("base");
+  @include tokens.register("base");
   @include core.reset;
 
   body {
-    color: css.get("base", "foreground", css.get("foreground"));
-    background: css.get("base", "background", css.get("background"));
+    color: tokens.get("base", "foreground", tokens.get("foreground"));
+    background: tokens.get("base", "background", tokens.get("background"));
   }
 }

--- a/packages/base/src/modules/_headings.scss
+++ b/packages/base/src/modules/_headings.scss
@@ -1,18 +1,18 @@
 @use "sass:list";
 @use "sass:meta";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/config";
 @use "../functions" as fun;
 
 @if fun.maybe-output("headings") {
-  @include css.register("headings");
+  @include tokens.register("headings");
 
   #{fun.selector(config.get("base-headings"))} {
-    font-family: css.get("headings", "font-family", inherit);
-    font-size: css.get("headings", "font-size", 1em);
-    font-weight: css.get("headings", "font-weight", css.get("font-weight-semi-bold"));
-    line-height: css.get("headings", "line-height", inherit);
-    color: css.get("headings", "foreground", css.get("foreground-strong"));
+    font-family: tokens.get("headings", "font-family", inherit);
+    font-size: tokens.get("headings", "font-size", 1em);
+    font-weight: tokens.get("headings", "font-weight", tokens.get("font-weight-semi-bold"));
+    line-height: tokens.get("headings", "line-height", inherit);
+    color: tokens.get("headings", "foreground", tokens.get("foreground-strong"));
   }
 
   @each $key, $value in config.get("base-headings") {
@@ -25,8 +25,8 @@
     }
 
     #{fun.selector($key)} {
-      @include css.override("headings", "font-size", $font-size);
-      @include css.override("headings", "line-height", $line-height);
+      @include tokens.override("headings", "font-size", $font-size);
+      @include tokens.override("headings", "line-height", $line-height);
     }
   }
 }

--- a/packages/base/src/modules/_link.scss
+++ b/packages/base/src/modules/_link.scss
@@ -1,41 +1,41 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 @use "../functions" as fun;
 
 @if fun.maybe-output("link") {
-  @include css.register("link");
+  @include tokens.register("link");
 
   #{fun.selector("link")} {
-    color: css.get("link", "foreground", css.get("foreground-accent"));
-    text-decoration: css.get("link", "decoration", underline);
-    text-decoration-thickness: css.get("link", "decoration-thickness", 1px);
-    text-underline-offset: css.get("link", "underline-offset", 2px);
+    color: tokens.get("link", "foreground", tokens.get("foreground-accent"));
+    text-decoration: tokens.get("link", "decoration", underline);
+    text-decoration-thickness: tokens.get("link", "decoration-thickness", 1px);
+    text-underline-offset: tokens.get("link", "underline-offset", 2px);
 
     code {
-      color: css.get("link", "foreground", css.get("foreground-accent"));
-      background-color: css.get("background-alt");
+      color: tokens.get("link", "foreground", tokens.get("foreground-accent"));
+      background-color: tokens.get("background-alt");
     }
 
     // prettier-ignore
     &:hover,
     &:focus {
-      color: css.get("link", "foreground-hover", light-dark(
-        oklch(from css.get("foreground-accent") calc(l - 0.1) c h),
-        oklch(from css.get("foreground-accent") calc(l + 0.1) c h),
+      color: tokens.get("link", "foreground-hover", light-dark(
+        oklch(from tokens.get("foreground-accent") calc(l - 0.1) c h),
+        oklch(from tokens.get("foreground-accent") calc(l + 0.1) c h),
       ));
-      text-decoration: css.get("link", "decoration-hover", none);
+      text-decoration: tokens.get("link", "decoration-hover", none);
 
       code {
-        color: css.get("link", "foreground-hover", light-dark(
-          oklch(from css.get("foreground-accent") calc(l - 0.1) c h),
-          oklch(from css.get("foreground-accent") calc(l + 0.1) c h)
+        color: tokens.get("link", "foreground-hover", light-dark(
+          oklch(from tokens.get("foreground-accent") calc(l - 0.1) c h),
+          oklch(from tokens.get("foreground-accent") calc(l + 0.1) c h)
         ));
       }
     }
 
     &:focus {
-      outline: css.get("link", "focus-ring", currentcolor dotted 1px);
-      outline-offset: css.get("link", "focus-ring-offset", 0.125rem);
+      outline: tokens.get("link", "focus-ring", currentcolor dotted 1px);
+      outline-offset: tokens.get("link", "focus-ring-offset", 0.125rem);
     }
   }
 }

--- a/packages/base/src/modules/_list.scss
+++ b/packages/base/src/modules/_list.scss
@@ -1,20 +1,20 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "../functions" as fun;
 
 @if fun.maybe-output("list") {
-  @include css.register("list");
+  @include tokens.register("list");
 
   #{fun.selector("list")} {
-    margin-left: css.get("list", "indent", css.get("spacing-lg"));
+    margin-left: tokens.get("list", "indent", tokens.get("spacing-lg"));
 
     ul,
     ol {
-      margin-left: css.get("list", "indent", css.get("spacing-lg"));
+      margin-left: tokens.get("list", "indent", tokens.get("spacing-lg"));
     }
 
     li li,
     li + li {
-      margin-top: css.get("list", "spacing", css.get("spacing-sm"));
+      margin-top: tokens.get("list", "spacing", tokens.get("spacing-sm"));
     }
   }
 

--- a/packages/base/src/modules/_pre.scss
+++ b/packages/base/src/modules/_pre.scss
@@ -1,22 +1,22 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "../functions" as fun;
 
 @if fun.maybe-output("pre") {
-  @include css.register("pre");
+  @include tokens.register("pre");
 
   #{fun.selector("pre")} {
     overflow: auto;
-    padding: css.get("pre", "padding", css.get("spacing-md"));
-    border: css.get("pre", "border", none);
-    border-radius: css.get("pre", "border-radius", css.get("border-radius"));
-    font-family: css.get("font-family-mono");
-    color: css.get("pre", "foreground", css.get("foreground-strong"));
-    background: css.get("pre", "background", css.get("background-alt"));
+    padding: tokens.get("pre", "padding", tokens.get("spacing-md"));
+    border: tokens.get("pre", "border", none);
+    border-radius: tokens.get("pre", "border-radius", tokens.get("border-radius"));
+    font-family: tokens.get("font-family-mono");
+    color: tokens.get("pre", "foreground", tokens.get("foreground-strong"));
+    background: tokens.get("pre", "background", tokens.get("background-alt"));
 
     code {
       padding: 0;
       border: none;
-      font-size: css.get("pre", "font-size", css.get("font-size-sm"));
+      font-size: tokens.get("pre", "font-size", tokens.get("font-size-sm"));
       color: inherit;
       background: none;
     }

--- a/packages/base/src/modules/_separator.scss
+++ b/packages/base/src/modules/_separator.scss
@@ -1,13 +1,13 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "../functions" as fun;
 
 @if fun.maybe-output("separator") {
-  @include css.register("separator");
+  @include tokens.register("separator");
 
   #{fun.selector("separator")} {
     display: block;
     height: 0;
     border: none;
-    border-top: css.get("separator", "border-width", css.get("border-width")) css.get("separator", "border-style", css.get("border-style")) css.get("separator", "border-color", css.get("border-color"));
+    border-top: tokens.get("separator", "border-width", tokens.get("border-width")) tokens.get("separator", "border-style", tokens.get("border-style")) tokens.get("separator", "border-color", tokens.get("border-color"));
   }
 }

--- a/packages/base/src/modules/_type.scss
+++ b/packages/base/src/modules/_type.scss
@@ -1,18 +1,18 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "../functions" as fun;
 
 @if fun.maybe-output("type") {
-  @include css.register("type");
-  @include css.register("heading");
+  @include tokens.register("type");
+  @include tokens.register("heading");
 
   #{fun.selector("type")} {
-    font-family: css.get("type", "font-family", inherit);
-    font-size: css.get("type", "font-size", inherit);
-    line-height: css.get("type", "line-height", inherit);
-    color: css.get("type", "foreground", css.get("foreground"));
+    font-family: tokens.get("type", "font-family", inherit);
+    font-size: tokens.get("type", "font-size", inherit);
+    line-height: tokens.get("type", "line-height", inherit);
+    color: tokens.get("type", "foreground", tokens.get("foreground"));
 
     > * + * {
-      margin-top: css.get("type", "spacing", null);
+      margin-top: tokens.get("type", "spacing", null);
     }
   }
 }

--- a/packages/button/src/_button.scss
+++ b/packages/button/src/_button.scss
@@ -1,48 +1,48 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "./mixins" as mix;
 
 #{core.bem("button")} {
   @include mix.base;
 
-  border-color: css.get("button", "border-color", css.get("border-color-strong"));
-  color: css.get("button", "foreground", css.get("foreground-strong"));
-  background-color: css.get("button", "background", css.get("background"));
-  box-shadow: css.get("button", "box-shadow", none);
+  border-color: tokens.get("button", "border-color", tokens.get("border-color-strong"));
+  color: tokens.get("button", "foreground", tokens.get("foreground-strong"));
+  background-color: tokens.get("button", "background", tokens.get("background"));
+  box-shadow: tokens.get("button", "box-shadow", none);
 
   &:hover {
-    border-color: css.get("button", "border-color-hover", "border-color", css.get("border-color-stronger"));
-    color: css.get("button", "foreground-hover", "foreground", css.get("foreground-strong"));
-    background-color: css.get("button", "background-hover", "background", css.get("background"));
-    box-shadow: css.get("button", "box-shadow-hover", "box-shadow", css.get("box-shadow-1"));
+    border-color: tokens.get("button", "border-color-hover", "border-color", tokens.get("border-color-stronger"));
+    color: tokens.get("button", "foreground-hover", "foreground", tokens.get("foreground-strong"));
+    background-color: tokens.get("button", "background-hover", "background", tokens.get("background"));
+    box-shadow: tokens.get("button", "box-shadow-hover", "box-shadow", tokens.get("box-shadow-1"));
   }
 
   &:focus {
-    border-color: css.get("button", "border-color-focus", "border-color-hover", "border-color", css.get("border-color-stronger"));
-    color: css.get("button", "foreground-focus", "foreground-hover", "foreground", css.get("foreground-strong"));
-    background-color: css.get("button", "background-focus", "background-hover", "background", css.get("background"));
-    box-shadow: css.get("button", "box-shadow-focus", "box-shadow-hover", "box-shadow", css.get("box-shadow-1"));
+    border-color: tokens.get("button", "border-color-focus", "border-color-hover", "border-color", tokens.get("border-color-stronger"));
+    color: tokens.get("button", "foreground-focus", "foreground-hover", "foreground", tokens.get("foreground-strong"));
+    background-color: tokens.get("button", "background-focus", "background-hover", "background", tokens.get("background"));
+    box-shadow: tokens.get("button", "box-shadow-focus", "box-shadow-hover", "box-shadow", tokens.get("box-shadow-1"));
   }
 
   &:focus-visible {
-    @include core.focus-ring-color(css.get("button", "accent", css.get("form-control-accent")));
+    @include core.focus-ring-color(tokens.get("button", "accent", tokens.get("form-control-accent")));
 
-    border-color: css.get("button", "border-color-focus-visible", "border-color-focus", "border-color-hover", "border-color", css.get("button", "accent", css.get("form-control-accent")));
-    color: css.get("button", "foreground-focus-visible", "foreground-focus", "foreground-hover", "foreground", css.get("foreground-strong"));
-    background-color: css.get("button", "background-focus-visible", "background-focus", "background-hover", "background", css.get("background"));
-    box-shadow: css.get("button", "box-shadow-focus-visible", "box-shadow-focus", "box-shadow-hover", "box-shadow", none);
+    border-color: tokens.get("button", "border-color-focus-visible", "border-color-focus", "border-color-hover", "border-color", tokens.get("button", "accent", tokens.get("form-control-accent")));
+    color: tokens.get("button", "foreground-focus-visible", "foreground-focus", "foreground-hover", "foreground", tokens.get("foreground-strong"));
+    background-color: tokens.get("button", "background-focus-visible", "background-focus", "background-hover", "background", tokens.get("background"));
+    box-shadow: tokens.get("button", "box-shadow-focus-visible", "box-shadow-focus", "box-shadow-hover", "box-shadow", none);
   }
 
   &:active {
-    border-color: css.get("button", "border-color-active", "border-color", css.get("foreground-strong"));
-    color: css.get("button", "foreground-active", "foreground", css.get("foreground-strong"));
-    background-color: css.get("button", "background-active", "background", css.get("background"));
-    box-shadow: css.get("button", "box-shadow-active", "box-shadow", none);
+    border-color: tokens.get("button", "border-color-active", "border-color", tokens.get("foreground-strong"));
+    color: tokens.get("button", "foreground-active", "foreground", tokens.get("foreground-strong"));
+    background-color: tokens.get("button", "background-active", "background", tokens.get("background"));
+    box-shadow: tokens.get("button", "box-shadow-active", "box-shadow", none);
   }
 
   &:disabled:not(.is-loading) {
     pointer-events: none;
-    opacity: css.get("button", "opacity-disabled", css.get("form-control-opacity-disabled"));
+    opacity: tokens.get("button", "opacity-disabled", tokens.get("form-control-opacity-disabled"));
   }
 
   &.is-loading {
@@ -52,7 +52,7 @@
     &::after {
       content: "";
 
-      @include css.override("loading", "color", css.get("button", "foreground", css.get("foreground-strong")));
+      @include tokens.override("loading", "color", tokens.get("button", "foreground", tokens.get("foreground-strong")));
       @include core.loading-spinner;
     }
   }

--- a/packages/button/src/_button_icon.scss
+++ b/packages/button/src/_button_icon.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 #{core.bem("button", null, "icon")} {
-  @include css.override("button", "padding", css.get("form-control-padding-y"));
+  @include tokens.override("button", "padding", tokens.get("form-control-padding-y"));
 }

--- a/packages/button/src/_button_size.scss
+++ b/packages/button/src/_button_size.scss
@@ -1,12 +1,12 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $-button-size: config.get("button-size", "variants");
 
 @each $key, $value in $-button-size {
   #{core.bem("button", null, "size", $key)} {
-    @include css.override("button", "size", $value);
+    @include tokens.override("button", "size", $value);
   }
 }
 
@@ -14,7 +14,7 @@ $-button-size: config.get("button-size", "variants");
   @include core.media-min($value) {
     @each $key, $value in $-button-size {
       #{core.bem("button", null, "size", $key, $bp)} {
-        @include css.override("button", "size", $value);
+        @include tokens.override("button", "size", $value);
       }
     }
   }

--- a/packages/button/src/_config.scss
+++ b/packages/button/src/_config.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 
 $config: () !default;
@@ -24,11 +24,11 @@ $default: (
   // @type map
   "button-size": (
     "breakpoints": true,
-    "sm": css.get("form-control-size-sm"),
-    "md": css.get("form-control-size"),
-    "lg": css.get("form-control-size-lg")
+    "sm": tokens.get("form-control-size-sm"),
+    "md": tokens.get("form-control-size"),
+    "lg": tokens.get("form-control-size-lg")
   )
 );
 
 @include config.apply($config, $default);
-@include css.register("button");
+@include tokens.register("button");

--- a/packages/button/src/_mixins.scss
+++ b/packages/button/src/_mixins.scss
@@ -1,7 +1,7 @@
 @use "sass:map";
 @use "sass:meta";
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 /// Output the base styles for a button component. This includes:
 /// - Setup of button specific CSS variables with shared form-control fallbacks.
@@ -14,7 +14,7 @@
   cursor: pointer;
   position: relative;
   display: inline-flex;
-  gap: css.get("button", "gap", css.get("spacing-sm"));
+  gap: tokens.get("button", "gap", tokens.get("spacing-sm"));
   align-items: center;
   justify-content: center;
   border-style: solid;
@@ -78,5 +78,5 @@
   }
 
   // Define the overrides CSS variables
-  @include css.override("button", $overrides);
+  @include tokens.override("button", $overrides);
 }

--- a/packages/card/src/_card.scss
+++ b/packages/card/src/_card.scss
@@ -1,5 +1,5 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $-transition-property: background-color, border-color, box-shadow, transform;
 
@@ -8,26 +8,26 @@ $-transition-property: background-color, border-color, box-shadow, transform;
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  border: css.get("card", "border", 1px solid css.get("border-color"));
-  border-radius: css.get("card", "border-radius", css.get("border-radius"));
-  color: css.get("card", "foreground", css.get("foreground"));
-  background: css.get("card", "background", css.get("background"));
+  border: tokens.get("card", "border", 1px solid tokens.get("border-color"));
+  border-radius: tokens.get("card", "border-radius", tokens.get("border-radius"));
+  color: tokens.get("card", "foreground", tokens.get("foreground"));
+  background: tokens.get("card", "background", tokens.get("background"));
   background-clip: padding-box;
-  box-shadow: css.get("card", "box-shadow", none);
-  transition-timing-function: css.get("card", "transition-timing-function", css.get("transition-timing-function"));
-  transition-duration: css.get("card", "transition-duration", css.get("transition-duration"));
-  transition-property: css.get("card", "transition-property", $-transition-property);
+  box-shadow: tokens.get("card", "box-shadow", none);
+  transition-timing-function: tokens.get("card", "transition-timing-function", tokens.get("transition-timing-function"));
+  transition-duration: tokens.get("card", "transition-duration", tokens.get("transition-duration"));
+  transition-property: tokens.get("card", "transition-property", $-transition-property);
 }
 
 a#{core.bem("card")} {
   transform: translate(0, 0);
-  box-shadow: css.get("card", "link-box-shadow", css.get("box-shadow-2"));
+  box-shadow: tokens.get("card", "link-box-shadow", tokens.get("box-shadow-2"));
 
   &:hover,
   &:focus,
   &:focus-within {
-    transform: translate(0, css.get("card", "link-offset", -0.25em));
-    box-shadow: css.get("card", "link-box-shadow-hover", css.get("box-shadow-3"));
+    transform: translate(0, tokens.get("card", "link-offset", -0.25em));
+    box-shadow: tokens.get("card", "link-box-shadow-hover", tokens.get("box-shadow-3"));
   }
 }
 
@@ -39,36 +39,36 @@ a#{core.bem("card")} {
   z-index: 3;
 
   &:first-child {
-    border-top-left-radius: css.get("card", "border-radius", css.get("border-radius"));
-    border-top-right-radius: css.get("card", "border-radius", css.get("border-radius"));
+    border-top-left-radius: tokens.get("card", "border-radius", tokens.get("border-radius"));
+    border-top-right-radius: tokens.get("card", "border-radius", tokens.get("border-radius"));
   }
 
   &:last-child {
-    border-bottom-right-radius: css.get("card", "border-radius", css.get("border-radius"));
-    border-bottom-left-radius: css.get("card", "border-radius", css.get("border-radius"));
+    border-bottom-right-radius: tokens.get("card", "border-radius", tokens.get("border-radius"));
+    border-bottom-left-radius: tokens.get("card", "border-radius", tokens.get("border-radius"));
   }
 }
 
 #{core.bem("card", "header")},
 #{core.bem("card", "body")},
 #{core.bem("card", "footer")} {
-  padding: css.get("card", "padding", 1.25em);
+  padding: tokens.get("card", "padding", 1.25em);
 }
 
 #{core.bem("card", "body")} {
   flex: 1 1 auto;
 
   & + & {
-    border-top: css.get("card", "sep-border", 1px solid css.get("border-color"));
+    border-top: tokens.get("card", "sep-border", 1px solid tokens.get("border-color"));
   }
 }
 
 #{core.bem("card", "header")} {
-  border-bottom: css.get("card", "sep-border", 1px solid css.get("border-color"));
+  border-bottom: tokens.get("card", "sep-border", 1px solid tokens.get("border-color"));
 }
 
 #{core.bem("card", "footer")} {
-  border-top: css.get("card", "sep-border", 1px solid css.get("border-color"));
+  border-top: tokens.get("card", "sep-border", 1px solid tokens.get("border-color"));
 }
 
 #{core.bem("card", "image")} {
@@ -79,10 +79,10 @@ a#{core.bem("card")} {
 
 #{core.bem("card", "title")} {
   flex-grow: 1;
-  font-size: css.get("card", "title-font-size", css.get("font-size-lg"));
-  font-weight: css.get("card", "title-font-weight", css.get("font-weight-semi-bold"));
-  line-height: css.get("card", "title-line-height", inherit);
-  color: css.get("card", "title-color", css.get("foreground-strong"));
+  font-size: tokens.get("card", "title-font-size", tokens.get("font-size-lg"));
+  font-weight: tokens.get("card", "title-font-weight", tokens.get("font-weight-semi-bold"));
+  line-height: tokens.get("card", "title-line-height", inherit);
+  color: tokens.get("card", "title-color", tokens.get("foreground-strong"));
 }
 
 #{core.bem("card", "background")},
@@ -91,10 +91,10 @@ a#{core.bem("card")} {
 
   position: absolute;
   inset: 0;
-  border-radius: css.get("card", "border-radius", css.get("border-radius"));
-  transition-timing-function: css.get("card", "transition-timing-function", css.get("transition-timing-function"));
-  transition-duration: css.get("card", "transition-duration", css.get("transition-duration"));
-  transition-property: css.get("card", "transition-property", $-transition-property);
+  border-radius: tokens.get("card", "border-radius", tokens.get("border-radius"));
+  transition-timing-function: tokens.get("card", "transition-timing-function", tokens.get("transition-timing-function"));
+  transition-duration: tokens.get("card", "transition-duration", tokens.get("transition-duration"));
+  transition-property: tokens.get("card", "transition-property", $-transition-property);
 }
 
 #{core.bem("card", "background")} {
@@ -104,6 +104,6 @@ a#{core.bem("card")} {
 
 #{core.bem("card", "screen")} {
   z-index: 2;
-  opacity: css.get("card", "screen-opacity", 0.8);
-  background: css.get("card", "screen-background", css.get("background"));
+  opacity: tokens.get("card", "screen-opacity", 0.8);
+  background: tokens.get("card", "screen-background", tokens.get("background"));
 }

--- a/packages/card/src/_config.scss
+++ b/packages/card/src/_config.scss
@@ -1,3 +1,3 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
-@include css.register("card");
+@use "@vrembem/core/tokens";
+@include tokens.register("card");

--- a/packages/checkbox/src/_checkbox.scss
+++ b/packages/checkbox/src/_checkbox.scss
@@ -1,10 +1,10 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
-$-color: css.get("checkbox", "color", css.get("form-control-choice-color"));
-$-color-checked: css.get("checkbox", "color-checked", css.get("form-control-choice-color-checked"));
-$-fill: css.get("checkbox", "fill", css.get("form-control-choice-fill"));
+$-color: tokens.get("checkbox", "color", tokens.get("form-control-choice-color"));
+$-color-checked: tokens.get("checkbox", "color-checked", tokens.get("form-control-choice-color-checked"));
+$-fill: tokens.get("checkbox", "fill", tokens.get("form-control-choice-fill"));
 
 #{core.ce("checkbox")},
 #{core.bem("checkbox")} {
@@ -15,12 +15,12 @@ $-fill: css.get("checkbox", "fill", css.get("form-control-choice-fill"));
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;
-  font-size: css.get("checkbox", "size", config.get("checkbox-size", "default"));
+  font-size: tokens.get("checkbox", "size", config.get("checkbox-size", "default"));
   vertical-align: middle;
 
   &:has(:disabled) {
     pointer-events: none;
-    opacity: css.get("checkbox", "opacity-disabled", css.get("form-control-opacity-disabled"));
+    opacity: tokens.get("checkbox", "opacity-disabled", tokens.get("form-control-opacity-disabled"));
   }
 }
 
@@ -32,30 +32,30 @@ $-fill: css.get("checkbox", "fill", css.get("form-control-choice-fill"));
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: css.get("checkbox", "background-border-radius", css.get("form-control-choice-background-border-radius"));
-  background-color: oklch(from $-color-checked l c h / css.get("checkbox", "background-opacity", css.get("form-control-choice-background-opacity")));
+  border-radius: tokens.get("checkbox", "background-border-radius", tokens.get("form-control-choice-background-border-radius"));
+  background-color: oklch(from $-color-checked l c h / tokens.get("checkbox", "background-opacity", tokens.get("form-control-choice-background-opacity")));
 }
 
 #{core.bem("checkbox", "box")} {
-  @include core.size(css.get("checkbox", "box-size", 1.2em));
+  @include core.size(tokens.get("checkbox", "box-size", 1.2em));
 
   display: flex;
   align-items: center;
   justify-content: center;
-  border: css.get("checkbox", "border-width", 2px) solid $-color;
-  border-radius: css.get("checkbox", "border-radius", css.get("border-radius"));
+  border: tokens.get("checkbox", "border-width", 2px) solid $-color;
+  border-radius: tokens.get("checkbox", "border-radius", tokens.get("border-radius"));
   color: transparent;
   background-color: $-fill;
 }
 
 #{core.bem("checkbox", "icon")} {
-  @include core.size(css.get("checkbox", "icon-size", 0.8em));
+  @include core.size(tokens.get("checkbox", "icon-size", 0.8em));
 
   opacity: 0;
   background-color: $-fill;
   mask-image: url(core.svg("check"));
   mask-repeat: no-repeat;
-  mask-position: center calc(css.get("checkbox", "icon-size", 0.8em) * -1);
+  mask-position: center calc(tokens.get("checkbox", "icon-size", 0.8em) * -1);
   mask-size: 100%;
 }
 
@@ -70,7 +70,7 @@ $-fill: css.get("checkbox", "fill", css.get("form-control-choice-fill"));
   opacity: 0;
 
   &:hover + #{core.bem("checkbox", "background")} {
-    background-color: oklch(from $-color-checked l c h / css.get("checkbox", "background-opacity-hover", css.get("form-control-choice-background-opacity-hover")));
+    background-color: oklch(from $-color-checked l c h / tokens.get("checkbox", "background-opacity-hover", tokens.get("form-control-choice-background-opacity-hover")));
 
     #{core.bem("checkbox", "box")} {
       border-color: $-color-checked;
@@ -79,7 +79,7 @@ $-fill: css.get("checkbox", "fill", css.get("form-control-choice-fill"));
   }
 
   &:focus + #{core.bem("checkbox", "background")} {
-    background-color: oklch(from $-color-checked l c h / css.get("checkbox", "background-opacity-focus", css.get("form-control-choice-background-opacity-focus")));
+    background-color: oklch(from $-color-checked l c h / tokens.get("checkbox", "background-opacity-focus", tokens.get("form-control-choice-background-opacity-focus")));
 
     #{core.bem("checkbox", "box")} {
       border-color: $-color-checked;
@@ -89,7 +89,7 @@ $-fill: css.get("checkbox", "fill", css.get("form-control-choice-fill"));
 
   &:focus-visible + #{core.bem("checkbox", "background")},
   &:active + #{core.bem("checkbox", "background")} {
-    background-color: oklch(from $-color-checked l c h / css.get("checkbox", "background-opacity-active", css.get("form-control-choice-background-opacity-active")));
+    background-color: oklch(from $-color-checked l c h / tokens.get("checkbox", "background-opacity-active", tokens.get("form-control-choice-background-opacity-active")));
 
     #{core.bem("checkbox", "box")} {
       border-color: $-color-checked;
@@ -107,8 +107,8 @@ $-fill: css.get("checkbox", "fill", css.get("form-control-choice-fill"));
     #{core.bem("checkbox", "icon")} {
       opacity: 1;
       mask-position: center center;
-      transition-timing-function: css.get("checkbox", "transition-timing-function", css.get("form-control-transition-timing-function"));
-      transition-duration: css.get("checkbox", "transition-duration", css.get("form-control-transition-duration"));
+      transition-timing-function: tokens.get("checkbox", "transition-timing-function", tokens.get("form-control-transition-timing-function"));
+      transition-duration: tokens.get("checkbox", "transition-duration", tokens.get("form-control-transition-duration"));
       transition-property: opacity, mask-position;
     }
   }

--- a/packages/checkbox/src/_checkbox_size.scss
+++ b/packages/checkbox/src/_checkbox_size.scss
@@ -1,12 +1,12 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $-checkbox-size: config.get("checkbox-size", "variants");
 
 @each $key, $value in $-checkbox-size {
   #{core.bem("checkbox", null, "size", $key)} {
-    @include css.override("checkbox", "size", $value);
+    @include tokens.override("checkbox", "size", $value);
   }
 }
 
@@ -14,7 +14,7 @@ $-checkbox-size: config.get("checkbox-size", "variants");
   @include core.media-min($value) {
     @each $key, $value in $-checkbox-size {
       #{core.bem("checkbox", null, "size", $key, $bp)} {
-        @include css.override("checkbox", "size", $value);
+        @include tokens.override("checkbox", "size", $value);
       }
     }
   }

--- a/packages/checkbox/src/_config.scss
+++ b/packages/checkbox/src/_config.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $config: () !default;
 
@@ -10,12 +10,12 @@ $default: (
   // @type map
   "checkbox-size": (
     "breakpoints": true,
-    "default": css.get("form-control-size"),
-    "sm": css.get("form-control-size-sm"),
-    "md": css.get("form-control-size"),
-    "lg": css.get("form-control-size-lg")
+    "default": tokens.get("form-control-size"),
+    "sm": tokens.get("form-control-size-sm"),
+    "md": tokens.get("form-control-size"),
+    "lg": tokens.get("form-control-size-lg")
   )
 );
 
 @include config.apply($config, $default);
-@include css.register("checkbox");
+@include tokens.register("checkbox");

--- a/packages/core/build/layers.scss
+++ b/packages/core/build/layers.scss
@@ -1,1 +1,0 @@
-@forward "../layers";

--- a/packages/core/build/reset.scss
+++ b/packages/core/build/reset.scss
@@ -1,1 +1,0 @@
-@forward "../reset";

--- a/packages/core/build/tokens.scss
+++ b/packages/core/build/tokens.scss
@@ -1,1 +1,0 @@
-@forward "../tokens";

--- a/packages/core/css.scss
+++ b/packages/core/css.scss
@@ -1,1 +1,0 @@
-@forward "./src/scss/modules/css";

--- a/packages/core/index.scss
+++ b/packages/core/index.scss
@@ -1,6 +1,6 @@
 @forward "./src/scss/config";
 @forward "./src/scss/modules/config" as config-*;
-@forward "./src/scss/modules/css" as css-*;
+@forward "./src/scss/modules/tokens" as tokens-*;
 @forward "./src/scss/modules/palette" as palette-*;
 @forward "./src/scss/modules/theme" as theme-*;
 @forward "./src/scss/tokens/themes";

--- a/packages/core/layers.scss
+++ b/packages/core/layers.scss
@@ -1,1 +1,0 @@
-@layer tokens, base, components, utilities;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,33 +10,15 @@
     "component",
     "core"
   ],
-  "style": "./dist/index.css",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "sass": "./index.scss",
-      "style": "./dist/index.css",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.umd.cjs"
     },
-    "./layers": {
-      "sass": "./layers.scss",
-      "import": "./dist/layers.css",
-      "default": "./dist/layers.css"
-    },
-    "./tokens": {
-      "sass": "./tokens.scss",
-      "import": "./dist/tokens.css",
-      "default": "./dist/tokens.css"
-    },
-    "./reset": {
-      "sass": "./reset.scss",
-      "import": "./dist/reset.css",
-      "default": "./dist/reset.css"
-    },
     "./config": "./src/scss/modules/_config.scss",
-    "./css": "./src/scss/modules/_css.scss",
+    "./tokens": "./src/scss/modules/_tokens.scss",
     "./palette": "./src/scss/modules/_palette.scss",
     "./theme": "./src/scss/modules/_theme.scss",
     "./dev/*": "./dev/*",
@@ -49,28 +31,20 @@
     "src",
     "index.ts",
     "index.scss",
-    "layers.scss",
-    "tokens.scss",
-    "reset.scss",
     "config.scss",
-    "css.scss",
+    "tokens.scss",
     "palette.scss",
     "theme.scss"
   ],
   "scripts": {
     "serve": "vite",
-    "build": "npm-run-all clean styles scripts",
+    "build": "npm-run-all clean scripts",
     "clean": "del dev && del dist",
     "scripts": "npm-run-all scripts:dev scripts:dist scripts:types",
     "scripts:dev": "vite build --outDir dev --minify false",
     "scripts:dist": "vite build --outDir dist",
     "scripts:types": "tsc --project tsconfig.build.json",
-    "styles": "npm-run-all styles:dev styles:dist",
-    "styles:dev": "sass build:dev --load-path=../../node_modules",
-    "styles:dist": "sass build:dist --load-path=../../node_modules --style=compressed",
-    "watch": "concurrently --kill-others 'npm run watch:scripts' 'npm run watch:styles'",
-    "watch:scripts": "concurrently 'npm run scripts:dev -- --watch' 'npm run scripts:dist -- --watch'",
-    "watch:styles": "concurrently 'npm run styles:dev -- --watch' 'npm run styles:dist -- --watch'"
+    "watch": "concurrently 'npm run scripts:dev -- --watch' 'npm run scripts:dist -- --watch'"
   },
   "repository": {
     "type": "git",

--- a/packages/core/reset.scss
+++ b/packages/core/reset.scss
@@ -1,5 +1,0 @@
-@use "@vrembem/core";
-
-@layer base {
-  @include core.reset;
-}

--- a/packages/core/src/scss/library/_arrow.scss
+++ b/packages/core/src/scss/library/_arrow.scss
@@ -1,5 +1,5 @@
-@use "../modules/css";
-@include css.register("arrow");
+@use "../modules/tokens";
+@include tokens.register("arrow");
 
 /// Outputs the styles for an arrow or caret.
 ///
@@ -15,11 +15,11 @@
   flex-shrink: 0;
   width: 0;
   height: 0;
-  border-color: css.get("arrow", "color", currentcolor) transparent transparent;
+  border-color: tokens.get("arrow", "color", currentcolor) transparent transparent;
   border-style: solid;
-  border-width: css.get("arrow", "size", 6px 4px);
+  border-width: tokens.get("arrow", "size", 6px 4px);
   border-bottom-width: 0;
-  border-radius: css.get("arrow", "radius", 2px);
+  border-radius: tokens.get("arrow", "radius", 2px);
 
   @if $direction == "up" {
     transform: rotate(180deg);

--- a/packages/core/src/scss/library/_backdrop.scss
+++ b/packages/core/src/scss/library/_backdrop.scss
@@ -1,4 +1,4 @@
-@use "../modules/css";
+@use "../modules/tokens";
 
 /// Output the styles for a backdrop pseudo element.
 ///
@@ -10,5 +10,5 @@
   position: fixed;
   inset: 0;
   opacity: 0;
-  background-color: css.get($component, "backdrop-color", css.get("backdrop-color"));
+  background-color: tokens.get($component, "backdrop-color", tokens.get("backdrop-color"));
 }

--- a/packages/core/src/scss/library/_focus-ring.scss
+++ b/packages/core/src/scss/library/_focus-ring.scss
@@ -1,19 +1,19 @@
-@use "../modules/css";
+@use "../modules/tokens";
 
 /// Apply the base styles for focus-ring using the outline properties.
 @mixin focus-ring-base() {
-  outline: css.get("focus-ring-width") css.get("focus-ring-style") transparent;
-  outline-offset: css.get("focus-ring-offset");
+  outline: tokens.get("focus-ring-width") tokens.get("focus-ring-style") transparent;
+  outline-offset: tokens.get("focus-ring-offset");
 }
 
 /// Builds the focus ring styles by applying a number of custom property values
 /// and optional component overrides using the outline property.
 ///
-/// @param {string} $color (css.get("focus-ring-color"))
+/// @param {string} $color (tokens.get("focus-ring-color"))
 ///   The color to use as the fallback value.
-/// @param {number} $opacity (css.get("focus-ring-opacity"))
+/// @param {number} $opacity (tokens.get("focus-ring-opacity"))
 ///   The value to set for the opacity of the color.
 ///
-@mixin focus-ring-color($color: css.get("focus-ring-color"), $opacity: css.get("focus-ring-opacity")) {
+@mixin focus-ring-color($color: tokens.get("focus-ring-color"), $opacity: tokens.get("focus-ring-opacity")) {
   outline-color: oklch(from $color l c h / $opacity);
 }

--- a/packages/core/src/scss/library/_form-control.scss
+++ b/packages/core/src/scss/library/_form-control.scss
@@ -1,4 +1,4 @@
-@use "../modules/css";
+@use "../modules/tokens";
 @use "./size" as mix;
 
 /// Output the shared form-control properties with the component specific CSS
@@ -11,21 +11,21 @@
   // These styles are not needed by menu actions (button) elements because
   // they're set on the root menu component directly and are inherited.
   @if $component != "menu" {
-    font-size: css.get($component, "size", css.get("form-control-size"));
-    line-height: css.get($component, "line-height", css.get("form-control-line-height"));
+    font-size: tokens.get($component, "size", tokens.get("form-control-size"));
+    line-height: tokens.get($component, "line-height", tokens.get("form-control-line-height"));
   }
 
   @if $component == "input" {
-    padding: css.get($component, "padding", css.get("form-control-padding-y"));
+    padding: tokens.get($component, "padding", tokens.get("form-control-padding-y"));
   } @else {
-    padding: css.get($component, "padding", css.get("form-control-padding"));
+    padding: tokens.get($component, "padding", tokens.get("form-control-padding"));
   }
 
-  border-width: css.get($component, "border-width", css.get("form-control-border-width"));
-  border-radius: css.get($component, "border-radius", css.get("form-control-border-radius"));
-  transition-timing-function: css.get($component, "transition-timing-function", css.get("form-control-transition-timing-function"));
-  transition-duration: css.get($component, "transition-duration", css.get("form-control-transition-duration"));
-  transition-property: css.get($component, "transition-property", css.get("form-control-transition-property"));
+  border-width: tokens.get($component, "border-width", tokens.get("form-control-border-width"));
+  border-radius: tokens.get($component, "border-radius", tokens.get("form-control-border-radius"));
+  transition-timing-function: tokens.get($component, "transition-timing-function", tokens.get("form-control-transition-timing-function"));
+  transition-duration: tokens.get($component, "transition-duration", tokens.get("form-control-transition-duration"));
+  transition-property: tokens.get($component, "transition-property", tokens.get("form-control-transition-property"));
 }
 
 /// Output the width and height with the form-control-size CSS variable value.
@@ -35,5 +35,5 @@
 ///   include `"min"` and `"max"`.
 ///
 @mixin form-control-size($prefix: null) {
-  @include mix.size(css.get("form-control-size-calc"), css.get("form-control-size-calc"), $prefix);
+  @include mix.size(tokens.get("form-control-size-calc"), tokens.get("form-control-size-calc"), $prefix);
 }

--- a/packages/core/src/scss/library/_loading-spinner.scss
+++ b/packages/core/src/scss/library/_loading-spinner.scss
@@ -1,9 +1,9 @@
-@use "../modules/css";
+@use "../modules/tokens";
 @use "./size" as *;
 
 $-output-spin-animation: true;
 
-@include css.register("loading");
+@include tokens.register("loading");
 
 /// Output the styles for a loading spinner. If a position argument is provided
 /// with a value of "absolute" or "fixed" the spinner will be centered to its
@@ -13,19 +13,19 @@ $-output-spin-animation: true;
 ///   The value of the position property to use.
 ///
 @mixin loading-spinner($position: absolute) {
-  @include size(css.get("loading", "size", 1em));
+  @include size(tokens.get("loading", "size", 1em));
 
   @if $position == absolute or $position == fixed {
-    top: calc(50% - calc(css.get("loading", "size", 1em) * 0.5));
-    left: calc(50% - calc(css.get("loading", "size", 1em) * 0.5));
+    top: calc(50% - calc(tokens.get("loading", "size", 1em) * 0.5));
+    left: calc(50% - calc(tokens.get("loading", "size", 1em) * 0.5));
   }
 
   position: $position;
   display: inline-block;
-  border: css.get("loading", "border", 2px solid);
-  border-color: css.get("loading", "color", currentcolor) css.get("loading", "color", currentcolor) transparent transparent;
-  border-radius: css.get("border-radius-circle");
-  animation: spin css.get("loading", "duration", 0.6s) infinite linear;
+  border: tokens.get("loading", "border", 2px solid);
+  border-color: tokens.get("loading", "color", currentcolor) tokens.get("loading", "color", currentcolor) transparent transparent;
+  border-radius: tokens.get("border-radius-circle");
+  animation: spin tokens.get("loading", "duration", 0.6s) infinite linear;
 
   // Only output the spin animation once
   @if $-output-spin-animation {

--- a/packages/core/src/scss/library/_reset.scss
+++ b/packages/core/src/scss/library/_reset.scss
@@ -1,4 +1,4 @@
-@use "../modules/css";
+@use "../modules/tokens";
 
 /// Output an opinionated reset that removes user agent defaults in favor of
 /// minimalistic base styles. This creates a clean starting point for the UI and
@@ -26,8 +26,8 @@
   //    - https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/text-size-adjust
   html,
   :host {
-    font-family: css.get("core", "font-family", (system-ui, sans-serif)); // 1
-    line-height: css.get("core", "line-height", 1.5); // 2
+    font-family: tokens.get("core", "font-family", (system-ui, sans-serif)); // 1
+    line-height: tokens.get("core", "line-height", 1.5); // 2
     text-size-adjust: none; // 3
   }
 
@@ -103,7 +103,7 @@
   h5,
   h6 {
     font-size: inherit;
-    color: css.get("foreground-strong");
+    color: tokens.get("foreground-strong");
   }
 
   // Global font weight for Chrome, Edge, and Safari
@@ -114,13 +114,13 @@
 
   // Set small element font-size
   small {
-    font-size: css.get("core", "font-size-sm", 0.875rem);
+    font-size: tokens.get("core", "font-size-sm", 0.875rem);
   }
 
   // Default font family and font size for code and pre elements
   code,
   pre {
-    font-family: css.get("core", "font-family-mono", (ui-monospace, monospace));
+    font-family: tokens.get("core", "font-family-mono", (ui-monospace, monospace));
     font-size: 1em;
   }
 

--- a/packages/core/src/scss/modules/_palette.scss
+++ b/packages/core/src/scss/modules/_palette.scss
@@ -3,7 +3,7 @@
 @use "sass:color";
 @use "../utilities/round-to" as *;
 @use "./config";
-@use "./css";
+@use "./tokens";
 
 /// Builds a palette map using values set in `config.get("palette")`.
 ///
@@ -15,25 +15,25 @@
 ///
 @mixin -rebuild-palette($action: "") {
   // Remove the palette component before building
-  @include css.remove("palette");
+  @include tokens.remove("palette");
 
   // Set the black and white tokens
-  @include css.set("palette", "black", oklch(0% 0 0));
-  @include css.set("palette", "white", oklch(100% 0 0));
+  @include tokens.set("palette", "black", oklch(0% 0 0));
+  @include tokens.set("palette", "white", oklch(100% 0 0));
 
   // Loop through the seeds and set the variables for each item in $seeds
   @each $name, $value in config.get("palette") {
     // Set the raw value
-    @include css.set("palette", "#{$name}", $value);
+    @include tokens.set("palette", "#{$name}", $value);
 
     // Set the lightness, chroma and hue parts
-    @include css.set("palette", "#{$name}-l", round-to(color.channel($value, "lightness", $space: oklch), config.get("palette-round-decimal")));
-    @include css.set("palette", "#{$name}-c", round-to(color.channel($value, "chroma", $space: oklch), config.get("palette-round-decimal")));
-    @include css.set("palette", "#{$name}-h", round-to(color.channel($value, "hue", $space: oklch), config.get("palette-round-decimal")));
+    @include tokens.set("palette", "#{$name}-l", round-to(color.channel($value, "lightness", $space: oklch), config.get("palette-round-decimal")));
+    @include tokens.set("palette", "#{$name}-c", round-to(color.channel($value, "chroma", $space: oklch), config.get("palette-round-decimal")));
+    @include tokens.set("palette", "#{$name}-h", round-to(color.channel($value, "hue", $space: oklch), config.get("palette-round-decimal")));
 
     // Palette variants
     @each $key, $args in config.get("palette-variants") {
-      @include css.set("palette", "#{$name}-#{$key}", #{get($name, $args...)});
+      @include tokens.set("palette", "#{$name}-#{$key}", #{get($name, $args...)});
     }
   }
 }
@@ -82,7 +82,7 @@
 ///
 @function get($name, $l: null, $c: null, $a: null) {
   // Check if the color name exists in the palette map
-  @if not css.has("palette", $name) {
+  @if not tokens.has("palette", $name) {
     @error 'Palette value could not be found: "#{$name}"';
   }
 
@@ -91,13 +91,13 @@
 
   // Set color as the seed value if lightness or chroma are not provided
   @if not $l and not $c {
-    $color: css.get("palette", $name);
+    $color: tokens.get("palette", $name);
   }
 
   // If the lightness is a string, try and return the stored token.
-  // E.g.: palette.get("primary", "400") => css.get("palette", "primary-400")
+  // E.g.: palette.get("primary", "400") => tokens.get("palette", "primary-400")
   @if meta.type-of($l) == "string" {
-    $color: css.get("palette", "#{$name}-#{$l}");
+    $color: tokens.get("palette", "#{$name}-#{$l}");
   }
 
   // If the color value was set, return it along with alpha channel if provided
@@ -116,21 +116,21 @@
   }
 
   @if not $l {
-    $l: css.get("palette", "#{$name}-l");
+    $l: tokens.get("palette", "#{$name}-l");
   }
 
   @if not $c {
-    $c: css.get("palette", "#{$name}-c");
+    $c: tokens.get("palette", "#{$name}-c");
   } @else if $c != 0 {
     // Adjust the chroma based on the seeded value
-    $c: calc(#{css.get("palette", "#{$name}-c")} * ($c / 100%));
+    $c: calc(#{tokens.get("palette", "#{$name}-c")} * ($c / 100%));
   }
 
   // If an alpha channel is provided, return oklch with the alpha
   @if $a {
-    @return oklch($l $c css.get("palette", "#{$name}-h") / $a);
+    @return oklch($l $c tokens.get("palette", "#{$name}-h") / $a);
   } @else {
-    @return oklch($l $c css.get("palette", "#{$name}-h"));
+    @return oklch($l $c tokens.get("palette", "#{$name}-h"));
   }
 }
 

--- a/packages/core/src/scss/modules/_theme.scss
+++ b/packages/core/src/scss/modules/_theme.scss
@@ -5,11 +5,11 @@
 @use "../utilities/empty-map" as *;
 @use "../utilities/remove-nth" as *;
 @use "./config";
-@use "./css";
+@use "./tokens";
 @use "./palette";
 
 // Add to custom properties map for output as a config output
-@include css.set(
+@include tokens.set(
   "core",
   "theme-prefix",
   (
@@ -17,7 +17,7 @@
   )
 );
 
-/// Used to track theme keys that get added to the `css.$-css-vars` map.
+/// Used to track theme keys that get added to the `tokens.$-css-vars` map.
 /// @type list
 /// @access private
 $-theme-keys: "light", "dark";
@@ -128,7 +128,7 @@ $-theme-keys: "light", "dark";
   }
 
   // Initialize the results map with a copy of the CSS variables map
-  $result: css.get("*");
+  $result: tokens.get("*");
 
   // If no property or value are provided, create a theme with an empty map
   @if not $prop and not $value {
@@ -152,7 +152,7 @@ $-theme-keys: "light", "dark";
   }
 
   // Replace the CSS variables map with the modified result
-  @include css.set("*", $result);
+  @include tokens.set("*", $result);
 }
 
 /// Remove a custom property from themes in a variety of ways.
@@ -186,8 +186,8 @@ $-theme-keys: "light", "dark";
 ///
 @mixin remove($theme, $component, $prop: "*") {
   @if $component == "*" {
-    // Call remove() for every component in `css.$-css-vars`
-    @each $component in map.keys(css.get("*")) {
+    // Call remove() for every component in `tokens.$-css-vars`
+    @each $component in map.keys(tokens.get("*")) {
       @include remove($component, $theme, $prop);
     }
 
@@ -195,7 +195,7 @@ $-theme-keys: "light", "dark";
     @include -remove-theme-key($theme);
   } @else {
     // Initialize the result with the component map
-    $result: css.get($component, "*");
+    $result: tokens.get($component, "*");
 
     // Remove all themes from component
     // Example: theme.remove("component", "*")
@@ -225,8 +225,8 @@ $-theme-keys: "light", "dark";
       $result: map.deep-remove($result, $theme, $prop);
     }
 
-    // Save the results to `css.$-css-vars`
-    @include css.set($component, "*", $result, $deep: false);
+    // Save the results to `tokens.$-css-vars`
+    @include tokens.set($component, "*", $result, $deep: false);
   }
 }
 
@@ -254,13 +254,13 @@ $-theme-keys: "light", "dark";
 ///
 @mixin output-theme($theme, $component: "*") {
   @if $component == "*" {
-    // Call output-theme() for every component in `css.$-css-vars`
-    @each $component in map.keys(css.get("*")) {
+    // Call output-theme() for every component in `tokens.$-css-vars`
+    @each $component in map.keys(tokens.get("*")) {
       @include output-theme($theme, $component);
     }
   } @else {
     // Initialize the component map
-    $component-map: css.get($component, "*");
+    $component-map: tokens.get($component, "*");
 
     // Check if the theme exists for the component map
     @if map.has-key($component-map, $theme) {
@@ -284,7 +284,7 @@ $-theme-keys: "light", "dark";
       @each $prop, $value in $component-theme-map {
         // Don't output the color-scheme property
         @if $prop != "color-scheme" {
-          @include css.define($component, $prop, $value);
+          @include tokens.define($component, $prop, $value);
         }
       }
     }

--- a/packages/core/src/scss/modules/_theme.scss
+++ b/packages/core/src/scss/modules/_theme.scss
@@ -69,7 +69,7 @@ $-theme-keys: "light", "dark";
 }
 
 /// Set a new or modify existing theme custom properties. These are stored as
-/// CSS variables in the `core/css` module.
+/// CSS variables in the `core/tokens` module.
 ///
 /// @param {string} $theme
 ///   The theme to set a property value for.

--- a/packages/core/src/scss/modules/_tokens.scss
+++ b/packages/core/src/scss/modules/_tokens.scss
@@ -136,12 +136,12 @@ $-tokens: (
 ///   Custom property variable reference using var().
 ///
 /// @example scss
-///   css.reference("core", "background");
+///   tokens.reference("core", "background");
 ///   // CSS Output
 ///   var(--vb-background);
 ///
 /// @example scss
-///   css.reference("button", "background-hover", "background");
+///   tokens.reference("button", "background-hover", "background");
 ///   // CSS Output
 ///   var(--vb-button-background-hover, var(--vb-button-background));
 ///
@@ -165,12 +165,12 @@ $-tokens: (
 ///   The value of the custom property.
 ///
 /// @example scss
-///   css.define("core", "background", #000);
+///   tokens.define("core", "background", #000);
 ///   // CSS Output
 ///   --vb-background: #000;
 ///
 /// @example scss
-///   css.define("button", "background", #fff);
+///   tokens.define("button", "background", #fff);
 ///   // CSS Output
 ///   --vb-button-background: #fff;
 ///
@@ -219,22 +219,22 @@ $-tokens: (
 ///   Custom property variable reference using var().
 ///
 /// @example scss
-///   css.get("background");
+///   tokens.get("background");
 ///   // CSS Output
 ///   var(--vb-background);
 ///
 /// @example scss
-///   css.get("button", "background");
+///   tokens.get("button", "background");
 ///   // CSS Output
 ///   var(--vb-button-background);
 ///
 /// @example scss
-///   css.get("button", "background-hover", "background");
+///   tokens.get("button", "background-hover", "background");
 ///   // CSS Output
 ///   var(--vb-button-background-hover, var(--vb-button-background));
 ///
 /// @example scss
-///   css.get("button", "background-hover", "background", pink);
+///   tokens.get("button", "background-hover", "background", pink);
 ///   // CSS Output
 ///   var(--vb-button-background-hover, var(--vb-button-background, pink));
 ///
@@ -317,7 +317,7 @@ $-tokens: (
 ///   Whether or not to use `merge` or `deep-merge` when combining maps.
 ///
 /// @example scss
-///   @include css.set("button", "background", #000);
+///   @include tokens.set("button", "background", #000);
 ///
 ///   // Result in custom properties map:
 ///   $-tokens: (
@@ -327,7 +327,7 @@ $-tokens: (
 ///   );
 ///
 /// @example scss
-///   @include css.set("button", (
+///   @include tokens.set("button", (
 ///     "background": #000,
 ///     "foreground": #fff,
 ///   ));
@@ -341,7 +341,7 @@ $-tokens: (
 ///   );
 ///
 /// @example scss
-///   @include css.set("button", (
+///   @include tokens.set("button", (
 ///     "background": (
 ///       "hover": #000,
 ///       "focus": #555,
@@ -363,7 +363,7 @@ $-tokens: (
   // This primarily allows other modules to more easily modify the CSS var map
   // by circumventing the limitations of what `set` allows.
   // Example in core/theme:
-  // @include css.set("*", $result);
+  // @include tokens.set("*", $result);
   @if $component == "*" {
     $-tokens: $prop !global;
   }
@@ -372,7 +372,7 @@ $-tokens: (
   // This primarily allows other modules to more easily modifier a component's
   // CSS var map by circumventing the limitations of what `set` allows.
   // Example in core/theme:
-  // @include css.set($component, "*", $result, $deep: false);
+  // @include tokens.set($component, "*", $result, $deep: false);
   @else if $prop == "*" {
     $component-map: (
       $component: $value
@@ -385,7 +385,7 @@ $-tokens: (
     }
   }
 
-  // Handle this as a normal css.set call
+  // Handle this as a normal tokens.set call
   @else {
     // Build the component map using the prop and value arguments
     $component-map: (
@@ -417,19 +417,19 @@ $-tokens: (
 ///   The property value to override with.
 ///
 /// @example scss
-///   @include css.override("core", "background", #000);
+///   @include tokens.override("core", "background", #000);
 ///
 ///   // CSS Output
 ///   --vb-background: #000;
 ///
 /// @example scss
-///   @include css.override("button", "background", #fff);
+///   @include tokens.override("button", "background", #fff);
 ///
 ///   // CSS Output
 ///   --vb-button-background: #fff;
 ///
 /// @example scss
-///   @include css.override("button", (
+///   @include tokens.override("button", (
 ///     "background": #000,
 ///     "foreground": #fff
 ///   ));
@@ -495,7 +495,7 @@ $-tokens: (
 ///
 ///   // SCSS input
 ///   :root {
-///     @include css.output("button");
+///     @include tokens.output("button");
 ///   }
 ///
 ///   // CSS output

--- a/packages/core/src/scss/tokens/_backdrop.scss
+++ b/packages/core/src/scss/tokens/_backdrop.scss
@@ -1,6 +1,6 @@
-@use "../modules/css";
+@use "../modules/tokens";
 @use "../modules/palette";
-@include css.set(
+@include tokens.set(
   "core",
   "backdrop",
   (

--- a/packages/core/src/scss/tokens/_border.scss
+++ b/packages/core/src/scss/tokens/_border.scss
@@ -1,17 +1,17 @@
-@use "../modules/css";
-@include css.set(
+@use "../modules/tokens";
+@include tokens.set(
   "core",
   (
     "border-width": 1px,
     "border-style": solid
   )
 );
-@include css.set(
+@include tokens.set(
   "core",
   (
-    "border": css.get("border-width") css.get("border-style") css.get("border-color"),
-    "border-strong": css.get("border-width") css.get("border-style") css.get("border-color-strong"),
-    "border-stronger": css.get("border-width") css.get("border-style") css.get("border-color-stronger"),
+    "border": tokens.get("border-width") tokens.get("border-style") tokens.get("border-color"),
+    "border-strong": tokens.get("border-width") tokens.get("border-style") tokens.get("border-color-strong"),
+    "border-stronger": tokens.get("border-width") tokens.get("border-style") tokens.get("border-color-stronger"),
     "border-radius": 0.25rem,
     "border-radius-lg": 0.5rem,
     "border-radius-circle": 9999px

--- a/packages/core/src/scss/tokens/_box-shadow.scss
+++ b/packages/core/src/scss/tokens/_box-shadow.scss
@@ -1,14 +1,14 @@
-@use "../modules/css";
+@use "../modules/tokens";
 @use "../modules/palette";
-@include css.set("core", "box-shadow-color", palette.get("neutral", 20%, $a: 20%));
-@include css.set(
+@include tokens.set("core", "box-shadow-color", palette.get("neutral", 20%, $a: 20%));
+@include tokens.set(
   "core",
   (
-    "box-shadow": 0 2px 6px css.get("box-shadow-color"),
-    "box-shadow-1": 0 1px 3px css.get("box-shadow-color"),
-    "box-shadow-2": 0 2px 6px css.get("box-shadow-color"),
-    "box-shadow-3": 0 4px 12px css.get("box-shadow-color"),
-    "box-shadow-4": 0 8px 18px css.get("box-shadow-color"),
-    "box-shadow-5": 0 12px 24px css.get("box-shadow-color")
+    "box-shadow": 0 2px 6px tokens.get("box-shadow-color"),
+    "box-shadow-1": 0 1px 3px tokens.get("box-shadow-color"),
+    "box-shadow-2": 0 2px 6px tokens.get("box-shadow-color"),
+    "box-shadow-3": 0 4px 12px tokens.get("box-shadow-color"),
+    "box-shadow-4": 0 8px 18px tokens.get("box-shadow-color"),
+    "box-shadow-5": 0 12px 24px tokens.get("box-shadow-color")
   )
 );

--- a/packages/core/src/scss/tokens/_focus-ring.scss
+++ b/packages/core/src/scss/tokens/_focus-ring.scss
@@ -1,6 +1,6 @@
-@use "../modules/css";
+@use "../modules/tokens";
 @use "../modules/palette";
-@include css.set(
+@include tokens.set(
   "core",
   "focus-ring",
   (

--- a/packages/core/src/scss/tokens/_form-control.scss
+++ b/packages/core/src/scss/tokens/_form-control.scss
@@ -1,45 +1,45 @@
-@use "../modules/css";
+@use "../modules/tokens";
 @use "../modules/palette";
 @use "../modules/theme";
 
 // Base form-control variables shared by all controls
-@include css.set(
+@include tokens.set(
   "core",
   "form-control",
   (
-    "size": css.get("font-size"),
-    "size-sm": css.get("font-size-sm"),
-    "size-lg": css.get("font-size-lg"),
-    "line-height": css.get("line-height"),
-    "border-width": css.get("border-width"),
-    "border-radius": css.get("border-radius"),
+    "size": tokens.get("font-size"),
+    "size-sm": tokens.get("font-size-sm"),
+    "size-lg": tokens.get("font-size-lg"),
+    "line-height": tokens.get("line-height"),
+    "border-width": tokens.get("border-width"),
+    "border-radius": tokens.get("border-radius"),
     "padding-x": 1em,
     "padding-y": 0.5em,
     "accent": palette.get("primary"),
-    "foreground": css.get("foreground-strong"),
-    "background": css.get("background"),
-    "background-disabled": css.get("background-shift"),
-    "background-readonly": css.get("background-shift"),
+    "foreground": tokens.get("foreground-strong"),
+    "background": tokens.get("background"),
+    "background-disabled": tokens.get("background-shift"),
+    "background-readonly": tokens.get("background-shift"),
     "opacity-disabled": 0.6,
     "transition-property": (
       box-shadow,
       outline
     ),
-    "transition-duration": css.get("transition-duration-short"),
-    "transition-timing-function": css.get("transition-timing-function")
+    "transition-duration": tokens.get("transition-duration-short"),
+    "transition-timing-function": tokens.get("transition-timing-function")
   )
 );
 
 // Form-control choice (checkbox, radio and switch) variables
-@include css.set(
+@include tokens.set(
   "core",
   "form-control-choice",
   (
-    "color": css.get("foreground-subtle"),
-    "color-checked": css.get("form-control-accent"),
-    "fill": css.get("form-control-background"),
+    "color": tokens.get("foreground-subtle"),
+    "color-checked": tokens.get("form-control-accent"),
+    "fill": tokens.get("form-control-background"),
     "background": (
-      "border-radius": css.get("border-radius-circle"),
+      "border-radius": tokens.get("border-radius-circle"),
       "opacity": 0%,
       "opacity-hover": 20%,
       "opacity-focus": 20%,
@@ -49,11 +49,11 @@
 );
 
 // Form-control composition variables
-@include css.set(
+@include tokens.set(
   "core",
   "form-control",
   (
-    "padding": css.get("form-control-padding-y") css.get("form-control-padding-x"),
-    "size-calc": calc(calc(1em * css.get("form-control-line-height")) + calc(calc(css.get("form-control-padding-y") + css.get("form-control-border-width")) * 2))
+    "padding": tokens.get("form-control-padding-y") tokens.get("form-control-padding-x"),
+    "size-calc": calc(calc(1em * tokens.get("form-control-line-height")) + calc(calc(tokens.get("form-control-padding-y") + tokens.get("form-control-border-width")) * 2))
   )
 );

--- a/packages/core/src/scss/tokens/_spacing.scss
+++ b/packages/core/src/scss/tokens/_spacing.scss
@@ -1,13 +1,13 @@
-@use "../modules/css";
-@include css.set("core", "spacing", 0.25em);
-@include css.set(
+@use "../modules/tokens";
+@include tokens.set("core", "spacing", 0.25em);
+@include tokens.set(
   "core",
   "spacing",
   (
-    "xs": css.get("spacing"),
-    "sm": calc(css.get("spacing") * 2),
-    "md": calc(css.get("spacing") * 4),
-    "lg": calc(css.get("spacing") * 6),
-    "xl": calc(css.get("spacing") * 8)
+    "xs": tokens.get("spacing"),
+    "sm": calc(tokens.get("spacing") * 2),
+    "md": calc(tokens.get("spacing") * 4),
+    "lg": calc(tokens.get("spacing") * 6),
+    "xl": calc(tokens.get("spacing") * 8)
   )
 );

--- a/packages/core/src/scss/tokens/_transition.scss
+++ b/packages/core/src/scss/tokens/_transition.scss
@@ -1,5 +1,5 @@
-@use "../modules/css";
-@include css.set(
+@use "../modules/tokens";
+@include tokens.set(
   "core",
   "transition",
   (
@@ -9,12 +9,12 @@
     "timing-function": cubic-bezier(0.4, 0, 0.2, 1)
   )
 );
-@include css.set(
+@include tokens.set(
   "core",
   "transition",
   (
-    "": css.get("transition-duration") css.get("transition-timing-function"),
-    "short": css.get("transition-duration-short") css.get("transition-timing-function"),
-    "long": css.get("transition-duration-long") css.get("transition-timing-function")
+    "": tokens.get("transition-duration") tokens.get("transition-timing-function"),
+    "short": tokens.get("transition-duration-short") tokens.get("transition-timing-function"),
+    "long": tokens.get("transition-duration-long") tokens.get("transition-timing-function")
   )
 );

--- a/packages/core/src/scss/tokens/_typography.scss
+++ b/packages/core/src/scss/tokens/_typography.scss
@@ -1,5 +1,5 @@
-@use "../modules/css";
-@include css.set(
+@use "../modules/tokens";
+@include tokens.set(
   "core",
   (
     "font-family-sans": (
@@ -32,4 +32,4 @@
     )
   )
 );
-@include css.set("core", "font-family", css.get("font-family-sans"));
+@include tokens.set("core", "font-family", tokens.get("font-family-sans"));

--- a/packages/core/tokens.scss
+++ b/packages/core/tokens.scss
@@ -1,9 +1,1 @@
-@use "@vrembem/core";
-
-@layer tokens {
-  :root {
-    @include core.css-output;
-  }
-
-  @include core.theme-output;
-}
+@forward "./src/scss/modules/tokens";

--- a/packages/dialog/src/_config.scss
+++ b/packages/dialog/src/_config.scss
@@ -1,3 +1,3 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
-@include css.register("dialog");
+@use "@vrembem/core/tokens";
+@include tokens.register("dialog");

--- a/packages/dialog/src/_dialog.scss
+++ b/packages/dialog/src/_dialog.scss
@@ -1,5 +1,5 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 
 #{core.bem("dialog")} {
@@ -9,25 +9,25 @@
   overflow: auto;
   display: flex;
   flex-direction: column;
-  border: css.get("dialog", "border", css.get("border"));
-  border-radius: css.get("dialog", "border-radius", css.get("border-radius"));
-  color: css.get("dialog", "foreground", css.get("foreground"));
-  background: css.get("dialog", "background", css.get("background"));
+  border: tokens.get("dialog", "border", tokens.get("border"));
+  border-radius: tokens.get("dialog", "border-radius", tokens.get("border-radius"));
+  color: tokens.get("dialog", "foreground", tokens.get("foreground"));
+  background: tokens.get("dialog", "background", tokens.get("background"));
   background-clip: padding-box;
-  box-shadow: css.get("dialog", "box-shadow", css.get("box-shadow-4"));
-  transition-timing-function: css.get("dialog", "transition-timing-function", css.get("transition-timing-function"));
-  transition-duration: css.get("dialog", "transition-duration", css.get("transition-duration"));
-  transition-property: css.get("dialog", "transition-duration", (outline, border-color));
+  box-shadow: tokens.get("dialog", "box-shadow", tokens.get("box-shadow-4"));
+  transition-timing-function: tokens.get("dialog", "transition-timing-function", tokens.get("transition-timing-function"));
+  transition-duration: tokens.get("dialog", "transition-duration", tokens.get("transition-duration"));
+  transition-property: tokens.get("dialog", "transition-duration", (outline, border-color));
 
   &:focus-visible,
   &[role="alertdialog"] {
-    @include core.focus-ring-color(css.get("dialog", "focus-ring-color", css.get("focus-ring-color")), css.get("dialog", "focus-ring-opacity", 80%));
+    @include core.focus-ring-color(tokens.get("dialog", "focus-ring-color", tokens.get("focus-ring-color")), tokens.get("dialog", "focus-ring-opacity", 80%));
 
-    border-color: css.get("dialog", "focus-ring-color", css.get("focus-ring-color"));
+    border-color: tokens.get("dialog", "focus-ring-color", tokens.get("focus-ring-color"));
   }
 
   &[role="alertdialog"] {
-    @include css.override("dialog", "focus-ring-color", palette.get("important"));
+    @include tokens.override("dialog", "focus-ring-color", palette.get("important"));
   }
 }
 
@@ -39,7 +39,7 @@
 #{core.bem("dialog", "body")},
 #{core.bem("dialog", "footer")} {
   flex: 0 0 auto;
-  padding: css.get("dialog", "padding", 1em);
+  padding: tokens.get("dialog", "padding", 1em);
 }
 
 #{core.bem("dialog", "header")},
@@ -47,34 +47,34 @@
   position: sticky;
   z-index: 1;
   display: flex;
-  gap: css.get("dialog", "gap", 0.5em);
+  gap: tokens.get("dialog", "gap", 0.5em);
   align-items: center;
   vertical-align: middle;
-  background: css.get("dialog", "background", css.get("background"));
+  background: tokens.get("dialog", "background", tokens.get("background"));
 }
 
 #{core.bem("dialog", "header")} {
   top: 0;
-  border-bottom: css.get("dialog", "sep-border", css.get("border"));
+  border-bottom: tokens.get("dialog", "sep-border", tokens.get("border"));
 }
 
 #{core.bem("dialog", "body")} {
   flex-grow: 1;
 
   & + & {
-    border-top: css.get("dialog", "sep-border", css.get("border"));
+    border-top: tokens.get("dialog", "sep-border", tokens.get("border"));
   }
 }
 
 #{core.bem("dialog", "footer")} {
   bottom: 0;
-  border-top: css.get("dialog", "sep-border", css.get("border"));
+  border-top: tokens.get("dialog", "sep-border", tokens.get("border"));
 }
 
 #{core.bem("dialog", "title")} {
   flex-grow: 1;
-  font-size: css.get("dialog", "title-font-size", css.get("font-size-lg"));
-  font-weight: css.get("dialog", "title-font-weight", css.get("font-weight-semi-bold"));
-  line-height: css.get("dialog", "title-line-height", inherit);
-  color: css.get("dialog", "title-color", css.get("foreground-strong"));
+  font-size: tokens.get("dialog", "title-font-size", tokens.get("font-size-lg"));
+  font-weight: tokens.get("dialog", "title-font-weight", tokens.get("font-weight-semi-bold"));
+  line-height: tokens.get("dialog", "title-line-height", inherit);
+  color: tokens.get("dialog", "title-color", tokens.get("foreground-strong"));
 }

--- a/packages/drawer/src/scss/_config.scss
+++ b/packages/drawer/src/scss/_config.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $config: () !default;
 
@@ -33,5 +33,5 @@ $default: (
 );
 
 @include config.apply($config, $default);
-@include css.register("drawer");
-@include css.register("dialog");
+@include tokens.register("drawer");
+@include tokens.register("dialog");

--- a/packages/drawer/src/scss/_drawer.scss
+++ b/packages/drawer/src/scss/_drawer.scss
@@ -1,12 +1,12 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 #{core.bem(config.get("drawer-classes", "frame"))} {
   position: relative;
   overflow: hidden auto;
   display: flex;
-  height: css.get("drawer", "frame-height", 100vh);
+  height: tokens.get("drawer", "frame-height", 100vh);
 }
 
 #{core.bem(config.get("drawer-classes", "main"))} {
@@ -18,14 +18,14 @@
 
 #{core.bem("drawer")} {
   position: absolute;
-  z-index: css.get("drawer", "z-index", 900);
+  z-index: tokens.get("drawer", "z-index", 900);
   inset: 0 auto 0 0;
-  width: css.get("drawer", "width", 18em);
-  max-width: css.get("drawer", "max-width", 80%);
+  width: tokens.get("drawer", "width", 18em);
+  max-width: tokens.get("drawer", "max-width", 80%);
 }
 
 #{core.bem("drawer", "dialog")} {
-  @include css.override("dialog", config.get("drawer-dialog-override"));
+  @include tokens.override("dialog", config.get("drawer-dialog-override"));
 
   position: absolute;
   inset: 0;
@@ -42,7 +42,7 @@
 }
 
 #{core.bem("drawer")}:not(#{core.bem("drawer", null, "modal")}) #{core.bem("drawer", "dialog")} {
-  @include css.override("dialog", config.get("drawer-inline-dialog-override"));
+  @include tokens.override("dialog", config.get("drawer-inline-dialog-override"));
 }
 
 #{core.bem("drawer")}.is-closed {
@@ -57,10 +57,10 @@
 
 #{core.bem("drawer")}.is-opening,
 #{core.bem("drawer")}.is-closing {
-  transition: opacity css.get("drawer", "transition-duration", css.get("transition-duration")) css.get("drawer", "transition-timing-function", css.get("transition-timing-function"));
+  transition: opacity tokens.get("drawer", "transition-duration", tokens.get("transition-duration")) tokens.get("drawer", "transition-timing-function", tokens.get("transition-timing-function"));
 
   #{core.bem("drawer", "dialog")} {
-    transition: transform css.get("drawer", "transition-duration", css.get("transition-duration")) css.get("drawer", "transition-timing-function", css.get("transition-timing-function"));
+    transition: transform tokens.get("drawer", "transition-duration", tokens.get("transition-duration")) tokens.get("drawer", "transition-timing-function", tokens.get("transition-timing-function"));
   }
 }
 

--- a/packages/drawer/src/scss/_drawer_modal.scss
+++ b/packages/drawer/src/scss/_drawer_modal.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 #{core.bem("drawer", null, "modal")} {
   position: fixed;
@@ -14,30 +14,30 @@
   }
 
   #{core.bem("drawer", "dialog")} {
-    @include css.override("dialog", config.get("drawer-modal-dialog-override"));
+    @include tokens.override("dialog", config.get("drawer-modal-dialog-override"));
 
     inset: 0 auto 0 0;
-    width: css.get("drawer", "width", 18em);
-    max-width: css.get("drawer", "max-width", 80%);
+    width: tokens.get("drawer", "width", 18em);
+    max-width: tokens.get("drawer", "max-width", 80%);
   }
 
   &#{core.bem("drawer", null, "switch")} #{core.bem("drawer", "dialog")} {
     inset: 0 0 0 auto;
   }
 
-  @include css.override("drawer", "z-index", 950);
+  @include tokens.override("drawer", "z-index", 950);
 }
 
 #{core.bem("drawer", null, "modal")}.is-opening,
 #{core.bem("drawer", null, "modal")}.is-closing {
   &::before {
-    transition: opacity css.get("drawer", "transition-duration", css.get("transition-duration")) css.get("drawer", "transition-timing-function", css.get("transition-timing-function"));
+    transition: opacity tokens.get("drawer", "transition-duration", tokens.get("transition-duration")) tokens.get("drawer", "transition-timing-function", tokens.get("transition-timing-function"));
   }
 }
 
 #{core.bem("drawer", null, "modal")}.is-opening,
 #{core.bem("drawer", null, "modal")}.is-opened {
   &::before {
-    opacity: css.get("drawer", "backdrop-opacity", css.get("backdrop-opacity"));
+    opacity: tokens.get("drawer", "backdrop-opacity", tokens.get("backdrop-opacity"));
   }
 }

--- a/packages/drawer/src/scss/_drawer_switch.scss
+++ b/packages/drawer/src/scss/_drawer_switch.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 #{core.bem("drawer", null, "switch")} {
   inset: 0 0 0 auto;
@@ -23,7 +23,7 @@
 #{core.bem("drawer")}:not(#{core.bem("drawer", null, "switch")}, #{core.bem("drawer", null, "modal")}) {
   &.is-opening ~ #{core.bem(config.get("drawer-classes", "main"))},
   &.is-opened ~ #{core.bem(config.get("drawer-classes", "main"))} {
-    margin-left: css.get("drawer", "width", 18em);
+    margin-left: tokens.get("drawer", "width", 18em);
   }
 }
 
@@ -31,6 +31,6 @@
 #{core.bem("drawer")}#{core.bem("drawer", null, "switch")}:not(#{core.bem("drawer", null, "modal")}) {
   &.is-opening ~ #{core.bem(config.get("drawer-classes", "main"))},
   &.is-opened ~ #{core.bem(config.get("drawer-classes", "main"))} {
-    margin-right: css.get("drawer", "width", 18em);
+    margin-right: tokens.get("drawer", "width", 18em);
   }
 }

--- a/packages/flex/src/_config.scss
+++ b/packages/flex/src/_config.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $config: () !default;
 
@@ -10,13 +10,13 @@ $default: (
   // @type map
   "flex-gap": (
     "breakpoints": true,
-    "default": css.get("spacing-md"),
+    "default": tokens.get("spacing-md"),
     "0": 0,
     "xs": 1px,
-    "sm": css.get("spacing-sm"),
-    "md": css.get("spacing-md"),
-    "lg": css.get("spacing-lg"),
-    "xl": css.get("spacing-xl")
+    "sm": tokens.get("spacing-sm"),
+    "md": tokens.get("spacing-md"),
+    "lg": tokens.get("spacing-lg"),
+    "xl": tokens.get("spacing-xl")
   ),
 
   // Map for outputting flex_wrap_[key] modifier variants
@@ -55,4 +55,4 @@ $default: (
 );
 
 @include config.apply($config, $default);
-@include css.register("flex");
+@include tokens.register("flex");

--- a/packages/flex/src/_flex-item.scss
+++ b/packages/flex/src/_flex-item.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $-flex-items: config.get("flex-items", "variants");
 

--- a/packages/flex/src/_flex.scss
+++ b/packages/flex/src/_flex.scss
@@ -1,11 +1,11 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 #{core.bem("flex")} {
   display: flex;
-  flex-flow: css.get("flex", "direction", config.get("flex-direction", "default")) css.get("flex", "wrap", config.get("flex-wrap", "default"));
-  gap: css.get("flex", "gap-y", "gap", config.get("flex-gap", "default")) css.get("flex", "gap-x", "gap", config.get("flex-gap", "default"));
+  flex-flow: tokens.get("flex", "direction", config.get("flex-direction", "default")) tokens.get("flex", "wrap", config.get("flex-wrap", "default"));
+  gap: tokens.get("flex", "gap-y", "gap", config.get("flex-gap", "default")) tokens.get("flex", "gap-x", "gap", config.get("flex-gap", "default"));
 }
 
 #{core.bem("flex", null, "inline")} {

--- a/packages/flex/src/_flex_direction.scss
+++ b/packages/flex/src/_flex_direction.scss
@@ -1,12 +1,12 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $-flex-direction-map: config.get("flex-direction", "variants");
 
 @each $key, $value in $-flex-direction-map {
   #{core.bem("flex", null, "direction", $key)} {
-    @include css.override("flex", "direction", $value);
+    @include tokens.override("flex", "direction", $value);
   }
 }
 
@@ -14,7 +14,7 @@ $-flex-direction-map: config.get("flex-direction", "variants");
   @include core.media-min($value) {
     @each $key, $value in $-flex-direction-map {
       #{core.bem("flex", null, "direction", $key, $bp)} {
-        @include css.override("flex", "direction", $value);
+        @include tokens.override("flex", "direction", $value);
       }
     }
   }

--- a/packages/flex/src/_flex_gap.scss
+++ b/packages/flex/src/_flex_gap.scss
@@ -1,22 +1,22 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $-flex-gap: config.get("flex-gap", "variants");
 
 @each $key, $value in $-flex-gap {
   #{core.bem("flex", null, "gap", $key)} {
-    @include css.override("flex", "gap", $value);
+    @include tokens.override("flex", "gap", $value);
   }
 }
 
 @each $key, $value in $-flex-gap {
   #{core.bem("flex", null, "gap-x", $key)} {
-    @include css.override("flex", "gap-x", $value);
+    @include tokens.override("flex", "gap-x", $value);
   }
 
   #{core.bem("flex", null, "gap-y", $key)} {
-    @include css.override("flex", "gap-y", $value);
+    @include tokens.override("flex", "gap-y", $value);
   }
 }
 
@@ -24,17 +24,17 @@ $-flex-gap: config.get("flex-gap", "variants");
   @include core.media-min($value) {
     @each $key, $value in $-flex-gap {
       #{core.bem("flex", null, "gap", $key, $bp)} {
-        @include css.override("flex", "gap", $value);
+        @include tokens.override("flex", "gap", $value);
       }
     }
 
     @each $key, $value in $-flex-gap {
       #{core.bem("flex", null, "gap-x", $key, $bp)} {
-        @include css.override("flex", "gap-x", $value);
+        @include tokens.override("flex", "gap-x", $value);
       }
 
       #{core.bem("flex", null, "gap-y", $key, $bp)} {
-        @include css.override("flex", "gap-y", $value);
+        @include tokens.override("flex", "gap-y", $value);
       }
     }
   }

--- a/packages/flex/src/_flex_items.scss
+++ b/packages/flex/src/_flex_items.scss
@@ -1,13 +1,13 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $-flex-items: config.get("flex-items", "variants");
 
 @each $key, $value in $-flex-items {
   #{core.bem("flex", null, "items", $key)} {
     @if $key == "full" {
-      @include css.override("flex", "wrap", wrap);
+      @include tokens.override("flex", "wrap", wrap);
     }
 
     > * {
@@ -21,7 +21,7 @@ $-flex-items: config.get("flex-items", "variants");
     @each $key, $value in $-flex-items {
       #{core.bem("flex", null, "items", $key, $bp)} {
         @if $key == "full" {
-          @include css.override("flex", "wrap", wrap);
+          @include tokens.override("flex", "wrap", wrap);
         }
 
         > * {

--- a/packages/flex/src/_flex_wrap.scss
+++ b/packages/flex/src/_flex_wrap.scss
@@ -1,12 +1,12 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $-flex-wrap: config.get("flex-wrap", "variants");
 
 @each $key, $value in $-flex-wrap {
   #{core.bem("flex", null, "wrap", $key)} {
-    @include css.override("flex", "wrap", $value);
+    @include tokens.override("flex", "wrap", $value);
   }
 }
 
@@ -14,7 +14,7 @@ $-flex-wrap: config.get("flex-wrap", "variants");
   @include core.media-min($value) {
     @each $key, $value in $-flex-wrap {
       #{core.bem("flex", null, "wrap", $key, $bp)} {
-        @include css.override("flex", "wrap", $value);
+        @include tokens.override("flex", "wrap", $value);
       }
     }
   }

--- a/packages/grid/src/_config.scss
+++ b/packages/grid/src/_config.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $config: () !default;
 
@@ -26,13 +26,13 @@ $default: (
   // @type map
   "grid-gap": (
     "breakpoints": true,
-    "default": calc(css.get("spacing") * 8),
+    "default": calc(tokens.get("spacing") * 8),
     "0": 0,
-    "xs": calc(css.get("spacing") * 2),
-    "sm": calc(css.get("spacing") * 4),
-    "md": calc(css.get("spacing") * 8),
-    "lg": calc(css.get("spacing") * 12),
-    "xl": calc(css.get("spacing") * 16)
+    "xs": calc(tokens.get("spacing") * 2),
+    "sm": calc(tokens.get("spacing") * 4),
+    "md": calc(tokens.get("spacing") * 8),
+    "lg": calc(tokens.get("spacing") * 12),
+    "xl": calc(tokens.get("spacing") * 16)
   ),
 
   // Map for outputting the grid_flow_[key] modifier variants
@@ -47,4 +47,4 @@ $default: (
 );
 
 @include config.apply($config, $default);
-@include css.register("grid");
+@include tokens.register("grid");

--- a/packages/grid/src/_grid-col.scss
+++ b/packages/grid/src/_grid-col.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $-grid-cols: config.get("grid-cols", "total");
 
@@ -9,7 +9,7 @@ $-grid-cols: config.get("grid-cols", "total");
 }
 
 #{core.bem("grid-col-full")} {
-  grid-column: span css.get("grid", "cols", 1) / span css.get("grid", "cols", 1);
+  grid-column: span tokens.get("grid", "cols", 1) / span tokens.get("grid", "cols", 1);
 }
 
 @for $i from 1 through $-grid-cols {
@@ -35,7 +35,7 @@ $-grid-cols: config.get("grid-cols", "total");
     }
 
     #{core.bem("grid-col-full", $bp: $bp)} {
-      grid-column: span css.get("grid", "cols", 1) / span css.get("grid", "cols", 1);
+      grid-column: span tokens.get("grid", "cols", 1) / span tokens.get("grid", "cols", 1);
     }
 
     @for $i from 1 through $-grid-cols {

--- a/packages/grid/src/_grid-row.scss
+++ b/packages/grid/src/_grid-row.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $-grid-rows: config.get("grid-rows", "total");
 
@@ -9,7 +9,7 @@ $-grid-rows: config.get("grid-rows", "total");
 }
 
 #{core.bem("grid-row-full")} {
-  grid-row: span css.get("grid", "rows", 1) / span css.get("grid", "rows", 1);
+  grid-row: span tokens.get("grid", "rows", 1) / span tokens.get("grid", "rows", 1);
 }
 
 @for $i from 1 through $-grid-rows {
@@ -35,7 +35,7 @@ $-grid-rows: config.get("grid-rows", "total");
     }
 
     #{core.bem("grid-row-full", $bp: $bp)} {
-      grid-row: span css.get("grid", "rows", 1) / span css.get("grid", "rows", 1);
+      grid-row: span tokens.get("grid", "rows", 1) / span tokens.get("grid", "rows", 1);
     }
 
     @for $i from 1 through $-grid-rows {

--- a/packages/grid/src/_grid.scss
+++ b/packages/grid/src/_grid.scss
@@ -1,13 +1,13 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 #{core.bem("grid")} {
   display: grid;
-  grid-auto-flow: css.get("grid", "flow", config.get("grid-flow", "default"));
-  grid-template-columns: repeat(css.get("grid", "cols", config.get("grid-cols", "default")), minmax(0, 1fr));
-  grid-template-rows: repeat(css.get("grid", "rows", config.get("grid-rows", "default")), minmax(0, 1fr));
-  gap: css.get("grid", "gap-y", "gap", config.get("grid-gap", "default")) css.get("grid", "gap-x", "gap", config.get("grid-gap", "default"));
+  grid-auto-flow: tokens.get("grid", "flow", config.get("grid-flow", "default"));
+  grid-template-columns: repeat(tokens.get("grid", "cols", config.get("grid-cols", "default")), minmax(0, 1fr));
+  grid-template-rows: repeat(tokens.get("grid", "rows", config.get("grid-rows", "default")), minmax(0, 1fr));
+  gap: tokens.get("grid", "gap-y", "gap", config.get("grid-gap", "default")) tokens.get("grid", "gap-x", "gap", config.get("grid-gap", "default"));
 }
 
 #{core.bem("grid", null, "inline")} {

--- a/packages/grid/src/_grid_cols.scss
+++ b/packages/grid/src/_grid_cols.scss
@@ -1,12 +1,12 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $-grid-cols: config.get("grid-cols", "total");
 
 @for $i from 1 through $-grid-cols {
   #{core.bem("grid", null, "cols", $i)} {
-    @include css.override("grid", "cols", $i);
+    @include tokens.override("grid", "cols", $i);
   }
 }
 
@@ -14,7 +14,7 @@ $-grid-cols: config.get("grid-cols", "total");
   @include core.media-min($value) {
     @for $i from 1 through $-grid-cols {
       #{core.bem("grid", null, "cols", $i, $bp)} {
-        @include css.override("grid", "cols", $i);
+        @include tokens.override("grid", "cols", $i);
       }
     }
   }

--- a/packages/grid/src/_grid_flow.scss
+++ b/packages/grid/src/_grid_flow.scss
@@ -1,9 +1,9 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 @each $key, $value in config.get("grid-flow", "variants") {
   #{core.bem("grid", null, "flow", $key)} {
-    @include css.override("grid", "flow", $value);
+    @include tokens.override("grid", "flow", $value);
   }
 }

--- a/packages/grid/src/_grid_gap.scss
+++ b/packages/grid/src/_grid_gap.scss
@@ -1,22 +1,22 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $-grid-gap: config.get("grid-gap", "variants");
 
 @each $key, $value in $-grid-gap {
   #{core.bem("grid", null, "gap", $key)} {
-    @include css.override("grid", "gap", $value);
+    @include tokens.override("grid", "gap", $value);
   }
 }
 
 @each $key, $value in $-grid-gap {
   #{core.bem("grid", null, "gap-x", $key)} {
-    @include css.override("grid", "gap-x", $value);
+    @include tokens.override("grid", "gap-x", $value);
   }
 
   #{core.bem("grid", null, "gap-y", $key)} {
-    @include css.override("grid", "gap-y", $value);
+    @include tokens.override("grid", "gap-y", $value);
   }
 }
 
@@ -24,17 +24,17 @@ $-grid-gap: config.get("grid-gap", "variants");
   @include core.media-min($value) {
     @each $key, $value in $-grid-gap {
       #{core.bem("grid", null, "gap", $key, $bp)} {
-        @include css.override("grid", "gap", $value);
+        @include tokens.override("grid", "gap", $value);
       }
     }
 
     @each $key, $value in $-grid-gap {
       #{core.bem("grid", null, "gap-x", $key, $bp)} {
-        @include css.override("grid", "gap-x", $value);
+        @include tokens.override("grid", "gap-x", $value);
       }
 
       #{core.bem("grid", null, "gap-y", $key, $bp)} {
-        @include css.override("grid", "gap-y", $value);
+        @include tokens.override("grid", "gap-y", $value);
       }
     }
   }

--- a/packages/grid/src/_grid_rows.scss
+++ b/packages/grid/src/_grid_rows.scss
@@ -1,12 +1,12 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $-grid-rows: config.get("grid-rows", "total");
 
 @for $i from 1 through $-grid-rows {
   #{core.bem("grid", null, "rows", $i)} {
-    @include css.override("grid", "rows", $i);
+    @include tokens.override("grid", "rows", $i);
   }
 }
 
@@ -14,7 +14,7 @@ $-grid-rows: config.get("grid-rows", "total");
   @include core.media-min($value) {
     @for $i from 1 through $-grid-rows {
       #{core.bem("grid", null, "rows", $i, $bp)} {
-        @include css.override("grid", "rows", $i);
+        @include tokens.override("grid", "rows", $i);
       }
     }
   }

--- a/packages/icon/src/_config.scss
+++ b/packages/icon/src/_config.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $config: () !default;
 
@@ -28,4 +28,4 @@ $default: (
 );
 
 @include config.apply($config, $default);
-@include css.register("icon");
+@include tokens.register("icon");

--- a/packages/icon/src/_icon.scss
+++ b/packages/icon/src/_icon.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "./mixins" as mix;
 
 #{core.bem("icon")} {
@@ -11,6 +11,6 @@
   box-sizing: content-box;
   width: 1em;
   height: 1em;
-  font-size: css.get("icon", "size", core.resolve-nth(config.get("icon-size", "default"), 1));
+  font-size: tokens.get("icon", "size", core.resolve-nth(config.get("icon-size", "default"), 1));
   vertical-align: top;
 }

--- a/packages/icon/src/_icon_size.scss
+++ b/packages/icon/src/_icon_size.scss
@@ -1,10 +1,10 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 @each $key, $value in config.get("icon-size", "variants") {
   #{core.bem("icon", null, "size", $key)} {
-    @include css.override("icon", "size", core.resolve-nth($value, 1));
-    @include css.override("icon", "stroke-width", core.resolve-nth($value, 2));
+    @include tokens.override("icon", "size", core.resolve-nth($value, 1));
+    @include tokens.override("icon", "stroke-width", core.resolve-nth($value, 2));
   }
 }

--- a/packages/icon/src/_mixins.scss
+++ b/packages/icon/src/_mixins.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 /// Outputs the required properties for a specific icon style.
 ///
@@ -10,16 +10,16 @@
 @mixin style($style) {
   @if $style == "stroke" {
     fill: none;
-    stroke: css.get("icon", "color", currentcolor);
-    stroke-width: css.get("icon", "stroke-width", core.resolve-nth(config.get("icon-size", "default"), 2));
+    stroke: tokens.get("icon", "color", currentcolor);
+    stroke-width: tokens.get("icon", "stroke-width", core.resolve-nth(config.get("icon-size", "default"), 2));
   } @else if $style == "fill" {
-    fill: css.get("icon", "color", currentcolor);
+    fill: tokens.get("icon", "color", currentcolor);
     stroke: none;
     stroke-width: 0;
   } @else if $style == "both" {
-    fill: css.get("icon", "color", currentcolor);
-    stroke: css.get("icon", "color", currentcolor);
-    stroke-width: css.get("icon", "stroke-width", core.resolve-nth(config.get("icon-size", "default"), 2));
+    fill: tokens.get("icon", "color", currentcolor);
+    stroke: tokens.get("icon", "color", currentcolor);
+    stroke-width: tokens.get("icon", "stroke-width", core.resolve-nth(config.get("icon-size", "default"), 2));
   } @else {
     @error 'Not a valid icon style: "#{$style}"';
   }

--- a/packages/input/build.scss
+++ b/packages/input/build.scss
@@ -1,10 +1,10 @@
 @use "./index";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/theme";
 
 @layer tokens {
   :root {
-    @include css.output("input");
+    @include tokens.output("input");
   }
 
   @include theme.output("input");

--- a/packages/input/src/_config.scss
+++ b/packages/input/src/_config.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 @use "@vrembem/core/theme";
 
@@ -12,9 +12,9 @@ $default: (
   // @type map
   "input-size": (
     "breakpoints": true,
-    "sm": css.get("form-control-size-sm"),
-    "md": css.get("form-control-size"),
-    "lg": css.get("form-control-size-lg")
+    "sm": tokens.get("form-control-size-sm"),
+    "md": tokens.get("form-control-size"),
+    "lg": tokens.get("form-control-size-lg")
   ),
 
   // Map for outputting input_state_[key] modifier variants
@@ -26,7 +26,7 @@ $default: (
 );
 
 @include config.apply($config, $default);
-@include css.register("input");
+@include tokens.register("input");
 
 // Themes
 // prettier-ignore

--- a/packages/input/src/_input.scss
+++ b/packages/input/src/_input.scss
@@ -1,44 +1,44 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "./mixins" as mix;
 
 #{core.bem("input")} {
   @include mix.base;
 
-  border-color: css.get("input", "border-color", css.get("border-color-strong"));
-  color: css.get("input", "foreground", css.get("form-control-foreground"));
-  background-color: css.get("input", "background", css.get("form-control-background"));
-  box-shadow: css.get("input", "box-shadow", inset 0 0.1rem 0.2rem rgb(0 0 0 / 10%));
+  border-color: tokens.get("input", "border-color", tokens.get("border-color-strong"));
+  color: tokens.get("input", "foreground", tokens.get("form-control-foreground"));
+  background-color: tokens.get("input", "background", tokens.get("form-control-background"));
+  box-shadow: tokens.get("input", "box-shadow", inset 0 0.1rem 0.2rem rgb(0 0 0 / 10%));
 
   &::placeholder {
-    color: css.get("input", "foreground-placeholder", css.get("foreground-subtle"));
+    color: tokens.get("input", "foreground-placeholder", tokens.get("foreground-subtle"));
   }
 
   &:hover {
-    border-color: css.get("input", "border-color-hover", "border-color", css.get("border-color-stronger"));
-    color: css.get("input", "foreground-hover", "foreground", css.get("form-control-foreground"));
-    background-color: css.get("input", "background-hover", "background", css.get("form-control-background"));
-    box-shadow: css.get("input", "box-shadow-hover", inset 0 0.1rem 0.2rem rgb(0 0 0 / 10%));
+    border-color: tokens.get("input", "border-color-hover", "border-color", tokens.get("border-color-stronger"));
+    color: tokens.get("input", "foreground-hover", "foreground", tokens.get("form-control-foreground"));
+    background-color: tokens.get("input", "background-hover", "background", tokens.get("form-control-background"));
+    box-shadow: tokens.get("input", "box-shadow-hover", inset 0 0.1rem 0.2rem rgb(0 0 0 / 10%));
   }
 
   &:focus {
-    border-color: css.get("input", "border-color-focus", "border-color", css.get("input", "accent", css.get("form-control-accent")));
-    color: css.get("input", "foreground-focus", "foreground", css.get("form-control-foreground"));
-    background-color: css.get("input", "background-focus", "background", css.get("form-control-background"));
-    box-shadow: css.get("input", "box-shadow-focus", none);
+    border-color: tokens.get("input", "border-color-focus", "border-color", tokens.get("input", "accent", tokens.get("form-control-accent")));
+    color: tokens.get("input", "foreground-focus", "foreground", tokens.get("form-control-foreground"));
+    background-color: tokens.get("input", "background-focus", "background", tokens.get("form-control-background"));
+    box-shadow: tokens.get("input", "box-shadow-focus", none);
   }
 
   &:focus-visible {
-    @include core.focus-ring-color(css.get("input", "accent", css.get("form-control-accent")));
+    @include core.focus-ring-color(tokens.get("input", "accent", tokens.get("form-control-accent")));
   }
 
   &:read-only {
-    background-color: css.get("input", "background-readonly", css.get("form-control-background-readonly"));
+    background-color: tokens.get("input", "background-readonly", tokens.get("form-control-background-readonly"));
   }
 
   &:disabled {
     pointer-events: none;
-    opacity: css.get("input", "opacity-disabled", css.get("form-control-opacity-disabled"));
-    background-color: css.get("input", "background-disabled", css.get("form-control-background-disabled"));
+    opacity: tokens.get("input", "opacity-disabled", tokens.get("form-control-opacity-disabled"));
+    background-color: tokens.get("input", "background-disabled", tokens.get("form-control-background-disabled"));
   }
 }

--- a/packages/input/src/_input_size.scss
+++ b/packages/input/src/_input_size.scss
@@ -1,12 +1,12 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $-input-size: config.get("input-size", "variants");
 
 @each $key, $value in $-input-size {
   #{core.bem("input", null, "size", $key)} {
-    @include css.override("input", "size", $value);
+    @include tokens.override("input", "size", $value);
   }
 }
 
@@ -14,7 +14,7 @@ $-input-size: config.get("input-size", "variants");
   @include core.media-min($value) {
     @each $key, $value in $-input-size {
       #{core.bem("input", null, "size", $key, $bp)} {
-        @include css.override("input", "size", $value);
+        @include tokens.override("input", "size", $value);
       }
     }
   }

--- a/packages/input/src/_input_state.scss
+++ b/packages/input/src/_input_state.scss
@@ -1,11 +1,11 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 
 @each $key, $value in config.get("input-state", "variants") {
   #{core.bem("input", null, "state", $key)} {
-    @include css.override(
+    @include tokens.override(
       "input",
       (
         "accent": $value,

--- a/packages/input/src/_input_type.scss
+++ b/packages/input/src/_input_type.scss
@@ -1,20 +1,20 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 #{core.bem("input", null, "type", "select")} {
   cursor: pointer;
   position: relative;
   padding-right: 2em;
-  background-image: css.get("input", "select-icon");
+  background-image: tokens.get("input", "select-icon");
   background-repeat: no-repeat;
   background-position: calc(100% - 0.75em) center;
 
   &:read-only {
-    background-color: css.get("input", "background", css.get("background"));
+    background-color: tokens.get("input", "background", tokens.get("background"));
   }
 
   &:disabled {
-    background-color: css.get("input", "background-disabled", css.get("background-shift"));
+    background-color: tokens.get("input", "background-disabled", tokens.get("background-shift"));
   }
 }
 

--- a/packages/menu/src/_config.scss
+++ b/packages/menu/src/_config.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $config: () !default;
 
@@ -18,11 +18,11 @@ $default: (
   // @type map
   "menu-size": (
     "breakpoints": true,
-    "sm": css.get("form-control-size-sm"),
-    "md": css.get("form-control-size"),
-    "lg": css.get("form-control-size-lg")
+    "sm": tokens.get("form-control-size-sm"),
+    "md": tokens.get("form-control-size"),
+    "lg": tokens.get("form-control-size-lg")
   )
 );
 
 @include config.apply($config, $default);
-@include css.register("menu");
+@include tokens.register("menu");

--- a/packages/menu/src/_menu.scss
+++ b/packages/menu/src/_menu.scss
@@ -1,14 +1,14 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "./mixins" as mix;
 
 #{core.bem("menu")} {
   display: flex;
   flex-direction: column;
-  gap: css.get("menu", "gap", 1px);
+  gap: tokens.get("menu", "gap", 1px);
   align-items: stretch;
-  font-size: css.get("menu", "size", css.get("form-control-size"));
-  line-height: css.get("menu", "line-height", css.get("form-control-line-height"));
+  font-size: tokens.get("menu", "size", tokens.get("form-control-size"));
+  line-height: tokens.get("menu", "line-height", tokens.get("form-control-line-height"));
   list-style: none;
 }
 
@@ -16,61 +16,61 @@
   flex: 0 0 auto;
   align-self: stretch;
   width: auto;
-  height: css.get("menu", "sep-size", 1px);
-  margin: css.get("menu", "sep-gap", 0.5em) 0;
-  background: css.get("menu", "sep-background", css.get("border-color"));
+  height: tokens.get("menu", "sep-size", 1px);
+  margin: tokens.get("menu", "sep-gap", 0.5em) 0;
+  background: tokens.get("menu", "sep-background", tokens.get("border-color"));
 }
 
 #{core.bem("menu", "action")} {
   @include mix.action-base;
 
-  border-color: css.get("menu", "border-color", transparent);
-  color: css.get("menu", "foreground", css.get("foreground-strong"));
-  background-color: css.get("menu", "background", transparent);
-  box-shadow: css.get("menu", "box-shadow", none);
+  border-color: tokens.get("menu", "border-color", transparent);
+  color: tokens.get("menu", "foreground", tokens.get("foreground-strong"));
+  background-color: tokens.get("menu", "background", transparent);
+  box-shadow: tokens.get("menu", "box-shadow", none);
 
   &:hover {
-    border-color: css.get("menu", "border-color-hover", "border-color", transparent);
-    color: css.get("menu", "foreground-hover", "foreground", css.get("foreground-strong"));
-    background-color: css.get("menu", "background-hover", "background", oklch(from currentcolor l c h / 5%));
-    box-shadow: css.get("menu", "box-shadow-hover", "box-shadow", none);
+    border-color: tokens.get("menu", "border-color-hover", "border-color", transparent);
+    color: tokens.get("menu", "foreground-hover", "foreground", tokens.get("foreground-strong"));
+    background-color: tokens.get("menu", "background-hover", "background", oklch(from currentcolor l c h / 5%));
+    box-shadow: tokens.get("menu", "box-shadow-hover", "box-shadow", none);
   }
 
   &:focus {
-    border-color: css.get("menu", "border-color-focus", "border-color-hover", "border-color", transparent);
-    color: css.get("menu", "foreground-focus", "foreground-hover", "foreground", css.get("foreground-strong"));
-    background-color: css.get("menu", "background-focus", "background-hover", "background", oklch(from currentcolor l c h / 5%));
-    box-shadow: css.get("menu", "box-shadow-focus", "box-shadow-hover", "box-shadow", none);
+    border-color: tokens.get("menu", "border-color-focus", "border-color-hover", "border-color", transparent);
+    color: tokens.get("menu", "foreground-focus", "foreground-hover", "foreground", tokens.get("foreground-strong"));
+    background-color: tokens.get("menu", "background-focus", "background-hover", "background", oklch(from currentcolor l c h / 5%));
+    box-shadow: tokens.get("menu", "box-shadow-focus", "box-shadow-hover", "box-shadow", none);
   }
 
   &:focus-visible {
-    @include core.focus-ring-color(css.get("menu", "accent", css.get("form-control-accent")));
+    @include core.focus-ring-color(tokens.get("menu", "accent", tokens.get("form-control-accent")));
 
-    border-color: css.get("menu", "border-color-focus-visible", "border-color-focus", "border-color-hover", "border-color", css.get("menu", "accent", css.get("form-control-accent")));
-    color: css.get("menu", "foreground-focus-visible", "foreground-focus", "foreground-hover", "foreground", css.get("foreground-strong"));
-    background-color: css.get("menu", "background-focus-visible", "background-focus", "background-hover", "background", oklch(from currentcolor l c h / 5%));
-    box-shadow: css.get("menu", "box-shadow-focus-visible", "box-shadow-focus", "box-shadow-hover", "box-shadow", none);
+    border-color: tokens.get("menu", "border-color-focus-visible", "border-color-focus", "border-color-hover", "border-color", tokens.get("menu", "accent", tokens.get("form-control-accent")));
+    color: tokens.get("menu", "foreground-focus-visible", "foreground-focus", "foreground-hover", "foreground", tokens.get("foreground-strong"));
+    background-color: tokens.get("menu", "background-focus-visible", "background-focus", "background-hover", "background", oklch(from currentcolor l c h / 5%));
+    box-shadow: tokens.get("menu", "box-shadow-focus-visible", "box-shadow-focus", "box-shadow-hover", "box-shadow", none);
   }
 
   &:active {
-    border-color: css.get("menu", "border-color-active", "border-color", transparent);
-    color: css.get("menu", "foreground-active", "foreground", css.get("foreground-strong"));
-    background-color: css.get("menu", "background-active", "background", oklch(from currentcolor l c h / 10%));
-    box-shadow: css.get("menu", "box-shadow-active", "box-shadow", none);
+    border-color: tokens.get("menu", "border-color-active", "border-color", transparent);
+    color: tokens.get("menu", "foreground-active", "foreground", tokens.get("foreground-strong"));
+    background-color: tokens.get("menu", "background-active", "background", oklch(from currentcolor l c h / 10%));
+    box-shadow: tokens.get("menu", "box-shadow-active", "box-shadow", none);
   }
 
   &:disabled:not(.is-active) {
     pointer-events: none;
-    color: css.get("menu", "disabled-foreground", css.get("foreground-subtle"));
-    background-color: css.get("menu", "disabled-background", none);
+    color: tokens.get("menu", "disabled-foreground", tokens.get("foreground-subtle"));
+    background-color: tokens.get("menu", "disabled-background", none);
   }
 
   &.is-active {
-    color: css.get("menu", "active-foreground", css.get("foreground-accent"));
-    background-color: css.get("menu", "active-background", none);
+    color: tokens.get("menu", "active-foreground", tokens.get("foreground-accent"));
+    background-color: tokens.get("menu", "active-background", none);
   }
 }
 
 #{core.bem("menu", "action", "icon")} {
-  @include css.override("menu", "padding", css.get("form-control-padding-y"));
+  @include tokens.override("menu", "padding", tokens.get("form-control-padding-y"));
 }

--- a/packages/menu/src/_menu_inline.scss
+++ b/packages/menu/src/_menu_inline.scss
@@ -1,15 +1,15 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 #{core.bem("menu", null, "inline")} {
   flex-direction: row;
   align-items: center;
 
   #{core.bem("menu", "sep")} {
-    width: css.get("menu", "sep-size", 1px);
+    width: tokens.get("menu", "sep-size", 1px);
     height: auto;
-    margin: 0 css.get("menu", "sep-gap", 0.5em);
+    margin: 0 tokens.get("menu", "sep-gap", 0.5em);
   }
 
   #{core.bem("menu", "action")} {
@@ -25,9 +25,9 @@
       align-items: center;
 
       #{core.bem("menu", "sep")} {
-        width: css.get("menu", "sep-size", 1px);
+        width: tokens.get("menu", "sep-size", 1px);
         height: auto;
-        margin: 0 css.get("menu", "sep-gap", 0.5em);
+        margin: 0 tokens.get("menu", "sep-gap", 0.5em);
       }
 
       #{core.bem("menu", "action")} {

--- a/packages/menu/src/_menu_size.scss
+++ b/packages/menu/src/_menu_size.scss
@@ -1,12 +1,12 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $-menu-size: config.get("menu-size", "variants");
 
 @each $key, $value in $-menu-size {
   #{core.bem("menu", null, "size", $key)} {
-    @include css.override("menu", "size", $value);
+    @include tokens.override("menu", "size", $value);
   }
 }
 
@@ -14,7 +14,7 @@ $-menu-size: config.get("menu-size", "variants");
   @include core.media-min($value) {
     @each $key, $value in $-menu-size {
       #{core.bem("menu", null, "size", $key, $bp)} {
-        @include css.override("menu", "size", $value);
+        @include tokens.override("menu", "size", $value);
       }
     }
   }

--- a/packages/menu/src/_mixins.scss
+++ b/packages/menu/src/_mixins.scss
@@ -1,5 +1,5 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 /// Output the base styles for a menu action component element.
 /// - Setup of menu specific CSS variables with shared form-control fallbacks.
@@ -12,7 +12,7 @@
   cursor: pointer;
   position: relative;
   display: flex;
-  gap: css.get("menu", "action-gap", 0.5em);
+  gap: tokens.get("menu", "action-gap", 0.5em);
   align-items: center;
   justify-content: flex-start;
   width: 100%;

--- a/packages/modal/src/scss/_config.scss
+++ b/packages/modal/src/scss/_config.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $config: () !default;
 
@@ -22,5 +22,5 @@ $default: (
 );
 
 @include config.apply($config, $default);
-@include css.register("modal");
-@include css.register("dialog");
+@include tokens.register("modal");
+@include tokens.register("dialog");

--- a/packages/modal/src/scss/_modal.scss
+++ b/packages/modal/src/scss/_modal.scss
@@ -1,10 +1,10 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 #{core.bem("modal")} {
   position: fixed;
-  z-index: css.get("modal", "z-index", 1000);
+  z-index: tokens.get("modal", "z-index", 1000);
   inset: 0;
   display: flex;
   flex-direction: column;
@@ -20,15 +20,15 @@
 }
 
 #{core.bem("modal", "dialog")} {
-  @include css.override("dialog", config.get("modal-dialog-override"));
+  @include tokens.override("dialog", config.get("modal-dialog-override"));
 
   position: relative;
-  transform: translateY(calc(css.get("modal", "travel", 5em) * -1));
+  transform: translateY(calc(tokens.get("modal", "travel", 5em) * -1));
   overflow: auto;
   display: flex;
   flex-direction: column;
-  width: css.get("modal", "width", config.get("modal-size", "default"));
-  max-width: css.get("modal", "max-width", 100%);
+  width: tokens.get("modal", "width", config.get("modal-size", "default"));
+  max-width: tokens.get("modal", "max-width", 100%);
   opacity: 0;
 }
 
@@ -41,19 +41,19 @@
 #{core.bem("modal")}.is-closing {
   width: 100%;
   height: 100%;
-  padding: css.get("modal", "margin", 1em);
+  padding: tokens.get("modal", "margin", 1em);
   visibility: visible;
 }
 
 #{core.bem("modal")}.is-opening,
 #{core.bem("modal")}.is-closing {
   &::before {
-    transition: opacity css.get("modal", "transition-duration", css.get("transition-duration")) css.get("modal", "transition-timing-function", css.get("transition-timing-function"));
+    transition: opacity tokens.get("modal", "transition-duration", tokens.get("transition-duration")) tokens.get("modal", "transition-timing-function", tokens.get("transition-timing-function"));
   }
 
   #{core.bem("modal", "dialog")} {
-    transition-timing-function: css.get("modal", "transition-timing-function", css.get("transition-timing-function"));
-    transition-duration: css.get("modal", "transition-duration", css.get("transition-duration"));
+    transition-timing-function: tokens.get("modal", "transition-timing-function", tokens.get("transition-timing-function"));
+    transition-duration: tokens.get("modal", "transition-duration", tokens.get("transition-duration"));
     transition-property: opacity, transform;
   }
 }
@@ -61,7 +61,7 @@
 #{core.bem("modal")}.is-opening,
 #{core.bem("modal")}.is-opened {
   &::before {
-    opacity: css.get("modal", "backdrop-opacity", css.get("backdrop-opacity"));
+    opacity: tokens.get("modal", "backdrop-opacity", tokens.get("backdrop-opacity"));
   }
 
   #{core.bem("modal", "dialog")} {

--- a/packages/modal/src/scss/_modal_full.scss
+++ b/packages/modal/src/scss/_modal_full.scss
@@ -1,9 +1,9 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 #{core.bem("modal", null, "full")} {
   #{core.bem("modal", "dialog")} {
-    transform: scale(css.get("modal", "full-scale", 0.75));
+    transform: scale(tokens.get("modal", "full-scale", 0.75));
     width: 100%;
     max-width: none;
     height: 100%;

--- a/packages/modal/src/scss/_modal_pos.scss
+++ b/packages/modal/src/scss/_modal_pos.scss
@@ -1,5 +1,5 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 #{core.bem("modal", null, "pos", "top")} {
   justify-content: flex-start;
@@ -9,15 +9,15 @@
   justify-content: flex-end;
 
   #{core.bem("modal", "dialog")} {
-    transform: translateY(css.get("modal", "travel", 5em));
+    transform: translateY(tokens.get("modal", "travel", 5em));
   }
 }
 
 #{core.bem("modal", null, "pos", "left")},
 #{core.bem("modal", null, "pos", "right")} {
   #{core.bem("modal", "dialog")} {
-    @include css.override("modal", "width", 16em);
-    @include css.override("modal", "max-width", 90%);
+    @include tokens.override("modal", "width", 16em);
+    @include tokens.override("modal", "max-width", 90%);
 
     height: 100%;
   }

--- a/packages/modal/src/scss/_modal_size.scss
+++ b/packages/modal/src/scss/_modal_size.scss
@@ -1,9 +1,9 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 @each $key, $value in config.get("modal-size", "variants") {
   #{core.bem("modal", null, "size", $key)} #{core.bem("modal", "dialog")} {
-    @include css.override("modal", "width", $value);
+    @include tokens.override("modal", "width", $value);
   }
 }

--- a/packages/notice/src/_config.scss
+++ b/packages/notice/src/_config.scss
@@ -1,3 +1,3 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
-@include css.register("notice");
+@use "@vrembem/core/tokens";
+@include tokens.register("notice");

--- a/packages/notice/src/_notice.scss
+++ b/packages/notice/src/_notice.scss
@@ -1,22 +1,22 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 #{core.bem("notice")} {
-  padding: css.get("notice", "padding", 1em 1.25em);
-  border: css.get("notice", "border", none);
-  border-radius: css.get("notice", "border-radius", css.get("border-radius"));
-  color: css.get("notice", "foreground", css.get("foreground-strong"));
-  background: css.get("notice", "background", css.get("background-shift"));
-  box-shadow: css.get("notice", "box-shadow", none);
+  padding: tokens.get("notice", "padding", 1em 1.25em);
+  border: tokens.get("notice", "border", none);
+  border-radius: tokens.get("notice", "border-radius", tokens.get("border-radius"));
+  color: tokens.get("notice", "foreground", tokens.get("foreground-strong"));
+  background: tokens.get("notice", "background", tokens.get("background-shift"));
+  box-shadow: tokens.get("notice", "box-shadow", none);
 
   > * + * {
-    margin-top: css.get("notice", "spacing", 0.5em);
+    margin-top: tokens.get("notice", "spacing", 0.5em);
   }
 }
 
 #{core.bem("notice", "title")} {
-  font-size: css.get("notice", "title-font-size", css.get("font-size-lg"));
-  font-weight: css.get("notice", "title-font-weight", css.get("font-weight-semi-bold"));
-  line-height: css.get("notice", "title-line-height", inherit);
+  font-size: tokens.get("notice", "title-font-size", tokens.get("font-size-lg"));
+  font-weight: tokens.get("notice", "title-font-weight", tokens.get("font-weight-semi-bold"));
+  line-height: tokens.get("notice", "title-line-height", inherit);
 }

--- a/packages/notice/src/_notice_color.scss
+++ b/packages/notice/src/_notice_color.scss
@@ -1,11 +1,11 @@
 @use "sass:map";
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 @each $key in map.keys(config.get("palette")) {
   #{core.bem("notice", null, "color", $key)} {
-    @include css.override("notice", "foreground", css.get("#{$key}-foreground"));
-    @include css.override("notice", "background", css.get("#{$key}-background"));
+    @include tokens.override("notice", "foreground", tokens.get("#{$key}-foreground"));
+    @include tokens.override("notice", "background", tokens.get("#{$key}-background"));
   }
 }

--- a/packages/popover/src/scss/_config.scss
+++ b/packages/popover/src/scss/_config.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $config: () !default;
 
@@ -16,4 +16,4 @@ $default: (
 );
 
 @include config.apply($config, $default);
-@include css.register("popover");
+@include tokens.register("popover");

--- a/packages/popover/src/scss/_popover.scss
+++ b/packages/popover/src/scss/_popover.scss
@@ -1,31 +1,31 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
-$-offset: calc((css.get("popover", "offset", 8) + 1) * 1px);
+$-offset: calc((tokens.get("popover", "offset", 8) + 1) * 1px);
 
 #{core.bem("popover")} {
   pointer-events: none;
   position: absolute;
-  z-index: css.get("popover", "z-index", 10);
+  z-index: tokens.get("popover", "z-index", 10);
   top: 0;
   left: 0;
   display: block;
-  width: css.get("popover", "width", 16em);
-  max-width: css.get("popover", "max-width", calc(100vw - 2rem));
+  width: tokens.get("popover", "width", 16em);
+  max-width: tokens.get("popover", "max-width", calc(100vw - 2rem));
   margin: 0;
-  padding: css.get("popover", "padding", 0.5em);
-  border: css.get("popover", "border", none);
-  border-radius: css.get("popover", "border-radius", css.get("border-radius"));
-  font-size: css.get("popover", "font-size", css.get("font-size-sm"));
-  line-height: css.get("popover", "line-height", inherit);
-  color: css.get("popover", "foreground", css.get("foreground"));
+  padding: tokens.get("popover", "padding", 0.5em);
+  border: tokens.get("popover", "border", none);
+  border-radius: tokens.get("popover", "border-radius", tokens.get("border-radius"));
+  font-size: tokens.get("popover", "font-size", tokens.get("font-size-sm"));
+  line-height: tokens.get("popover", "line-height", inherit);
+  color: tokens.get("popover", "foreground", tokens.get("foreground"));
   opacity: 0;
-  background: css.get("popover", "background", css.get("background"));
+  background: tokens.get("popover", "background", tokens.get("background"));
   background-clip: padding-box;
-  box-shadow: css.get("popover", "box-shadow", css.get("box-shadow-2"));
-  transition-timing-function: css.get("popover", "transition-timing-function", css.get("transition-timing-function"));
-  transition-duration: css.get("popover", "transition-duration", css.get("transition-duration-short"));
-  transition-property: css.get("popover", "transition-property", opacity);
+  box-shadow: tokens.get("popover", "box-shadow", tokens.get("box-shadow-2"));
+  transition-timing-function: tokens.get("popover", "transition-timing-function", tokens.get("transition-timing-function"));
+  transition-duration: tokens.get("popover", "transition-duration", tokens.get("transition-duration-short"));
+  transition-property: tokens.get("popover", "transition-property", opacity);
 
   &::before {
     content: "";
@@ -41,14 +41,14 @@ $-offset: calc((css.get("popover", "offset", 8) + 1) * 1px);
 
   &.is-active {
     pointer-events: auto;
-    z-index: calc(css.get("popover", "z-index", 10) + 1);
+    z-index: calc(tokens.get("popover", "z-index", 10) + 1);
     opacity: 1;
   }
 
   &:hover,
   &:focus,
   &:focus-within {
-    z-index: calc(css.get("popover", "z-index", 10) + 2);
+    z-index: calc(tokens.get("popover", "z-index", 10) + 2);
   }
 }
 

--- a/packages/popover/src/scss/_popover__arrow.scss
+++ b/packages/popover/src/scss/_popover__arrow.scss
@@ -1,9 +1,9 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 #{core.bem("popover", "arrow")},
 #{core.bem("popover", "arrow")}::after {
-  @include core.size(css.get("popover", "arrow-size", 8px));
+  @include core.size(tokens.get("popover", "arrow-size", 8px));
 
   position: absolute;
   z-index: -1;
@@ -19,7 +19,7 @@
 }
 
 [data-floating-placement^="top"] > #{core.bem("popover", "arrow")} {
-  bottom: calc(css.get("popover", "arrow-size", 8px) * -0.5);
+  bottom: calc(tokens.get("popover", "arrow-size", 8px) * -0.5);
 
   &::after {
     transform: rotate(-135deg);
@@ -27,7 +27,7 @@
 }
 
 [data-floating-placement^="bottom"] > #{core.bem("popover", "arrow")} {
-  top: calc(css.get("popover", "arrow-size", 8px) * -0.5);
+  top: calc(tokens.get("popover", "arrow-size", 8px) * -0.5);
 
   &::after {
     transform: rotate(45deg);
@@ -35,7 +35,7 @@
 }
 
 [data-floating-placement^="left"] > #{core.bem("popover", "arrow")} {
-  right: calc(css.get("popover", "arrow-size", 8px) * -0.5);
+  right: calc(tokens.get("popover", "arrow-size", 8px) * -0.5);
 
   &::after {
     transform: rotate(135deg);
@@ -43,7 +43,7 @@
 }
 
 [data-floating-placement^="right"] > #{core.bem("popover", "arrow")} {
-  left: calc(css.get("popover", "arrow-size", 8px) * -0.5);
+  left: calc(tokens.get("popover", "arrow-size", 8px) * -0.5);
 
   &::after {
     transform: rotate(-45deg);

--- a/packages/popover/src/scss/_popover_size.scss
+++ b/packages/popover/src/scss/_popover_size.scss
@@ -1,9 +1,9 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 @each $key, $value in config.get("popover-size", "variants") {
   #{core.bem("popover", null, "size", $key)} {
-    @include css.override("popover", "width", $value);
+    @include tokens.override("popover", "width", $value);
   }
 }

--- a/packages/popover/src/scss/_popover_tooltip.scss
+++ b/packages/popover/src/scss/_popover_tooltip.scss
@@ -1,8 +1,8 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 #{core.bem("popover", null, "tooltip")} {
-  @include css.override(
+  @include tokens.override(
     "popover",
     (
       "event": "hover",
@@ -11,8 +11,8 @@
       "width": auto,
       "max-width": 16rem,
       "padding": 0.5rem 0.75rem,
-      "background": css.get("foreground-strong"),
-      "foreground": css.get("background")
+      "background": tokens.get("foreground-strong"),
+      "foreground": tokens.get("background")
     )
   );
 

--- a/packages/radio/src/_config.scss
+++ b/packages/radio/src/_config.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $config: () !default;
 
@@ -10,12 +10,12 @@ $default: (
   // @type map
   "radio-size": (
     "breakpoints": true,
-    "default": css.get("form-control-size"),
-    "sm": css.get("form-control-size-sm"),
-    "md": css.get("form-control-size"),
-    "lg": css.get("form-control-size-lg")
+    "default": tokens.get("form-control-size"),
+    "sm": tokens.get("form-control-size-sm"),
+    "md": tokens.get("form-control-size"),
+    "lg": tokens.get("form-control-size-lg")
   )
 );
 
 @include config.apply($config, $default);
-@include css.register("radio");
+@include tokens.register("radio");

--- a/packages/radio/src/_radio.scss
+++ b/packages/radio/src/_radio.scss
@@ -1,10 +1,10 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
-$-color: css.get("radio", "color", css.get("form-control-choice-color")) !default;
-$-color-checked: css.get("radio", "color-checked", css.get("form-control-choice-color-checked"));
-$-fill: css.get("radio", "fill", css.get("form-control-choice-fill")) !default;
+$-color: tokens.get("radio", "color", tokens.get("form-control-choice-color")) !default;
+$-color-checked: tokens.get("radio", "color-checked", tokens.get("form-control-choice-color-checked"));
+$-fill: tokens.get("radio", "fill", tokens.get("form-control-choice-fill")) !default;
 
 #{core.ce("radio")},
 #{core.bem("radio")} {
@@ -15,12 +15,12 @@ $-fill: css.get("radio", "fill", css.get("form-control-choice-fill")) !default;
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;
-  font-size: css.get("radio", "size", config.get("radio-size", "default"));
+  font-size: tokens.get("radio", "size", config.get("radio-size", "default"));
   vertical-align: middle;
 
   &:has(:disabled) {
     pointer-events: none;
-    opacity: css.get("radio", "opacity-disabled", css.get("form-control-opacity-disabled"));
+    opacity: tokens.get("radio", "opacity-disabled", tokens.get("form-control-opacity-disabled"));
   }
 }
 
@@ -32,18 +32,18 @@ $-fill: css.get("radio", "fill", css.get("form-control-choice-fill")) !default;
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: css.get("radio", "background-border-radius", css.get("form-control-choice-background-border-radius"));
-  background-color: oklch(from $-color-checked l c h / css.get("radio", "background-opacity", css.get("form-control-choice-background-opacity")));
+  border-radius: tokens.get("radio", "background-border-radius", tokens.get("form-control-choice-background-border-radius"));
+  background-color: oklch(from $-color-checked l c h / tokens.get("radio", "background-opacity", tokens.get("form-control-choice-background-opacity")));
 }
 
 #{core.bem("radio", "circle")} {
-  @include core.size(css.get("radio", "circle-size", 1.25em));
+  @include core.size(tokens.get("radio", "circle-size", 1.25em));
 
   display: flex;
   align-items: center;
   justify-content: center;
-  border: css.get("radio", "border-width", 2px) solid $-color;
-  border-radius: css.get("radio", "circle-size", 1.25em);
+  border: tokens.get("radio", "border-width", 2px) solid $-color;
+  border-radius: tokens.get("radio", "circle-size", 1.25em);
   color: transparent;
   background-color: $-fill;
 }
@@ -51,7 +51,7 @@ $-fill: css.get("radio", "fill", css.get("form-control-choice-fill")) !default;
 #{core.bem("radio", "dot")} {
   @include core.size(0);
 
-  border-radius: css.get("radio", "dot-size", 0.5em);
+  border-radius: tokens.get("radio", "dot-size", 0.5em);
   opacity: 0;
   background-color: $-fill;
 }
@@ -67,7 +67,7 @@ $-fill: css.get("radio", "fill", css.get("form-control-choice-fill")) !default;
   opacity: 0;
 
   &:hover + #{core.bem("radio", "background")} {
-    background-color: oklch(from $-color-checked l c h / css.get("radio", "background-opacity-hover", css.get("form-control-choice-background-opacity-hover")));
+    background-color: oklch(from $-color-checked l c h / tokens.get("radio", "background-opacity-hover", tokens.get("form-control-choice-background-opacity-hover")));
 
     #{core.bem("radio", "circle")} {
       border-color: $-color-checked;
@@ -76,7 +76,7 @@ $-fill: css.get("radio", "fill", css.get("form-control-choice-fill")) !default;
   }
 
   &:focus + #{core.bem("radio", "background")} {
-    background-color: oklch(from $-color-checked l c h / css.get("radio", "background-opacity-focus", css.get("form-control-choice-background-opacity-focus")));
+    background-color: oklch(from $-color-checked l c h / tokens.get("radio", "background-opacity-focus", tokens.get("form-control-choice-background-opacity-focus")));
 
     #{core.bem("radio", "circle")} {
       border-color: $-color-checked;
@@ -86,7 +86,7 @@ $-fill: css.get("radio", "fill", css.get("form-control-choice-fill")) !default;
 
   &:focus-visible + #{core.bem("radio", "background")},
   &:active + #{core.bem("radio", "background")} {
-    background-color: oklch(from $-color-checked l c h / css.get("radio", "background-opacity-active", css.get("form-control-choice-background-opacity-active")));
+    background-color: oklch(from $-color-checked l c h / tokens.get("radio", "background-opacity-active", tokens.get("form-control-choice-background-opacity-active")));
 
     #{core.bem("radio", "circle")} {
       border-color: $-color-checked;
@@ -101,12 +101,12 @@ $-fill: css.get("radio", "fill", css.get("form-control-choice-fill")) !default;
     }
 
     #{core.bem("radio", "dot")} {
-      @include core.size(css.get("radio", "dot-size", 0.5em));
+      @include core.size(tokens.get("radio", "dot-size", 0.5em));
 
       opacity: 1;
       background-position: center center;
-      transition-timing-function: css.get("radio", "transition-timing-function", css.get("form-control-transition-timing-function"));
-      transition-duration: css.get("radio", "transition-duration", css.get("form-control-transition-duration"));
+      transition-timing-function: tokens.get("radio", "transition-timing-function", tokens.get("form-control-transition-timing-function"));
+      transition-duration: tokens.get("radio", "transition-duration", tokens.get("form-control-transition-duration"));
       transition-property: opacity, width, height;
     }
   }

--- a/packages/radio/src/_radio_size.scss
+++ b/packages/radio/src/_radio_size.scss
@@ -1,12 +1,12 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $-radio-size: config.get("radio-size", "variants");
 
 @each $key, $value in $-radio-size {
   #{core.bem("radio", null, "size", $key)} {
-    @include css.override("radio", "size", $value);
+    @include tokens.override("radio", "size", $value);
   }
 }
 
@@ -14,7 +14,7 @@ $-radio-size: config.get("radio-size", "variants");
   @include core.media-min($value) {
     @each $key, $value in $-radio-size {
       #{core.bem("radio", null, "size", $key, $bp)} {
-        @include css.override("radio", "size", $value);
+        @include tokens.override("radio", "size", $value);
       }
     }
   }

--- a/packages/section/src/_config.scss
+++ b/packages/section/src/_config.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $config: () !default;
 
@@ -30,4 +30,4 @@ $default: (
 );
 
 @include config.apply($config, $default);
-@include css.register("section");
+@include tokens.register("section");

--- a/packages/section/src/_section.scss
+++ b/packages/section/src/_section.scss
@@ -1,23 +1,23 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 #{core.bem("section")} {
   position: relative;
   display: flex;
   flex-direction: column;
-  padding: css.get("section", "padding", 1.5em);
-  color: css.get("section", "foreground", css.get("foreground"));
-  background: css.get("section", "background", transparent);
+  padding: tokens.get("section", "padding", 1.5em);
+  color: tokens.get("section", "foreground", tokens.get("foreground"));
+  background: tokens.get("section", "background", transparent);
 
-  @include css.override("section", "padding", config.get("section-padding", "default"), config.get("section-padding", "breakpoints"));
+  @include tokens.override("section", "padding", config.get("section-padding", "default"), config.get("section-padding", "breakpoints"));
 }
 
 #{core.bem("section", "container")} {
   position: relative;
   z-index: 3;
   width: 100%;
-  max-width: css.get("section", "max-width", 70rem);
+  max-width: tokens.get("section", "max-width", 70rem);
   margin: auto;
 }
 
@@ -36,6 +36,6 @@
 
 #{core.bem("section", "screen")} {
   z-index: 2;
-  opacity: css.get("section", "screen-opacity", 0.8);
-  background: css.get("section", "screen-background", css.get("background"));
+  opacity: tokens.get("section", "screen-opacity", 0.8);
+  background: tokens.get("section", "screen-background", tokens.get("background"));
 }

--- a/packages/section/src/_section_padding.scss
+++ b/packages/section/src/_section_padding.scss
@@ -1,9 +1,9 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 @each $key, $value in config.get("section-padding", "variants") {
   #{core.bem("section", null, "padding", $key)} {
-    @include css.override("section", "padding", $value, config.get("section-padding", "breakpoints"));
+    @include tokens.override("section", "padding", $value, config.get("section-padding", "breakpoints"));
   }
 }

--- a/packages/switch/src/_config.scss
+++ b/packages/switch/src/_config.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $config: () !default;
 
@@ -10,12 +10,12 @@ $default: (
   // @type map
   "switch-size": (
     "breakpoints": true,
-    "default": css.get("form-control-size"),
-    "sm": css.get("form-control-size-sm"),
-    "md": css.get("form-control-size"),
-    "lg": css.get("form-control-size-lg")
+    "default": tokens.get("form-control-size"),
+    "sm": tokens.get("form-control-size-sm"),
+    "md": tokens.get("form-control-size"),
+    "lg": tokens.get("form-control-size-lg")
   )
 );
 
 @include config.apply($config, $default);
-@include css.register("switch");
+@include tokens.register("switch");

--- a/packages/switch/src/_switch.scss
+++ b/packages/switch/src/_switch.scss
@@ -1,12 +1,12 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
-$-color: css.get("switch", "color", css.get("form-control-choice-color"));
-$-color-checked: css.get("switch", "color-checked", css.get("form-control-choice-color-checked"));
-$-fill: css.get("switch", "fill", css.get("form-control-choice-fill"));
-$-size: css.get("switch", "size", config.get("switch-size", "default"));
-$-thumb-size: calc(css.get("switch", "track-size", 1.25em) - calc(css.get("switch", "border-width", 2px) * 2));
+$-color: tokens.get("switch", "color", tokens.get("form-control-choice-color"));
+$-color-checked: tokens.get("switch", "color-checked", tokens.get("form-control-choice-color-checked"));
+$-fill: tokens.get("switch", "fill", tokens.get("form-control-choice-fill"));
+$-size: tokens.get("switch", "size", config.get("switch-size", "default"));
+$-thumb-size: calc(tokens.get("switch", "track-size", 1.25em) - calc(tokens.get("switch", "border-width", 2px) * 2));
 
 #{core.ce("switch")},
 #{core.bem("switch")} {
@@ -18,14 +18,14 @@ $-thumb-size: calc(css.get("switch", "track-size", 1.25em) - calc(css.get("switc
   align-items: center;
   justify-content: center;
   box-sizing: content-box;
-  padding-right: calc(css.get("core", "form-control-size-calc") * 0.25);
-  padding-left: calc(css.get("core", "form-control-size-calc") * 0.25);
+  padding-right: calc(tokens.get("core", "form-control-size-calc") * 0.25);
+  padding-left: calc(tokens.get("core", "form-control-size-calc") * 0.25);
   font-size: $-size;
   vertical-align: middle;
 
   &:has(:disabled) {
     pointer-events: none;
-    opacity: css.get("switch", "opacity-disabled", css.get("form-control-opacity-disabled"));
+    opacity: tokens.get("switch", "opacity-disabled", tokens.get("form-control-opacity-disabled"));
   }
 }
 
@@ -44,20 +44,20 @@ $-thumb-size: calc(css.get("switch", "track-size", 1.25em) - calc(css.get("switc
     content: "";
     position: absolute;
     top: 0;
-    left: calc(calc(css.get("core", "form-control-size-calc") * 0.25) * -1);
-    border-radius: css.get("switch", "background-border-radius", css.get("form-control-choice-background-border-radius"));
-    background-color: oklch(from $-color-checked l c h / css.get("switch", "background-opacity", css.get("form-control-choice-background-opacity")));
-    transition: left css.get("switch", "transition-duration", css.get("form-control-transition-duration")) css.get("switch", "transition-timing-function", css.get("form-control-transition-timing-function"));
+    left: calc(calc(tokens.get("core", "form-control-size-calc") * 0.25) * -1);
+    border-radius: tokens.get("switch", "background-border-radius", tokens.get("form-control-choice-background-border-radius"));
+    background-color: oklch(from $-color-checked l c h / tokens.get("switch", "background-opacity", tokens.get("form-control-choice-background-opacity")));
+    transition: left tokens.get("switch", "transition-duration", tokens.get("form-control-transition-duration")) tokens.get("switch", "transition-timing-function", tokens.get("form-control-transition-timing-function"));
   }
 }
 
 #{core.bem("switch", "track")} {
-  @include core.size(100%, css.get("switch", "track-size", 1.25em));
+  @include core.size(100%, tokens.get("switch", "track-size", 1.25em));
 
   position: relative;
   display: block;
-  border: css.get("switch", "border-width", 2px) solid $-color;
-  border-radius: css.get("switch", "border-radius", css.get("border-radius-circle"));
+  border: tokens.get("switch", "border-width", 2px) solid $-color;
+  border-radius: tokens.get("switch", "border-radius", tokens.get("border-radius-circle"));
   background-color: oklch(from $-color l c h / 20%);
 }
 
@@ -69,10 +69,10 @@ $-thumb-size: calc(css.get("switch", "track-size", 1.25em) - calc(css.get("switc
   top: 0;
   left: 0;
   display: block;
-  border-radius: css.get("switch", "border-radius", css.get("border-radius-circle"));
+  border-radius: tokens.get("switch", "border-radius", tokens.get("border-radius-circle"));
   background-color: $-fill;
-  box-shadow: 0 0 0 css.get("switch", "border-width", 2px) $-color;
-  transition: left css.get("switch", "transition-duration", css.get("form-control-transition-duration")) css.get("switch", "transition-timing-function", css.get("form-control-transition-timing-function"));
+  box-shadow: 0 0 0 tokens.get("switch", "border-width", 2px) $-color;
+  transition: left tokens.get("switch", "transition-duration", tokens.get("form-control-transition-duration")) tokens.get("switch", "transition-timing-function", tokens.get("form-control-transition-timing-function"));
 }
 
 #{core.bem("switch", "native")} {
@@ -87,38 +87,38 @@ $-thumb-size: calc(css.get("switch", "track-size", 1.25em) - calc(css.get("switc
 
   &:hover + #{core.bem("switch", "background")} {
     &::after {
-      background-color: oklch(from $-color-checked l c h / css.get("switch", "background-opacity-hover", css.get("form-control-choice-background-opacity-hover")));
+      background-color: oklch(from $-color-checked l c h / tokens.get("switch", "background-opacity-hover", tokens.get("form-control-choice-background-opacity-hover")));
     }
 
     #{core.bem("switch", "thumb")} {
-      box-shadow: 0 0 0 css.get("switch", "border-width", 2px) $-color-checked;
+      box-shadow: 0 0 0 tokens.get("switch", "border-width", 2px) $-color-checked;
     }
   }
 
   &:focus + #{core.bem("switch", "background")} {
     &::after {
-      background-color: oklch(from $-color-checked l c h / css.get("switch", "background-opacity-focus", css.get("form-control-choice-background-opacity-focus")));
+      background-color: oklch(from $-color-checked l c h / tokens.get("switch", "background-opacity-focus", tokens.get("form-control-choice-background-opacity-focus")));
     }
 
     #{core.bem("switch", "thumb")} {
-      box-shadow: 0 0 0 css.get("switch", "border-width", 2px) $-color-checked;
+      box-shadow: 0 0 0 tokens.get("switch", "border-width", 2px) $-color-checked;
     }
   }
 
   &:focus-visible + #{core.bem("switch", "background")},
   &:active + #{core.bem("switch", "background")} {
     &::after {
-      background-color: oklch(from $-color-checked l c h / css.get("switch", "background-opacity-active", css.get("form-control-choice-background-opacity-active")));
+      background-color: oklch(from $-color-checked l c h / tokens.get("switch", "background-opacity-active", tokens.get("form-control-choice-background-opacity-active")));
     }
 
     #{core.bem("switch", "thumb")} {
-      box-shadow: 0 0 0 css.get("switch", "border-width", 2px) $-color-checked;
+      box-shadow: 0 0 0 tokens.get("switch", "border-width", 2px) $-color-checked;
     }
   }
 
   &:checked + #{core.bem("switch", "background")} {
     &::after {
-      left: calc(100% - calc(css.get("core", "form-control-size-calc") * 0.75));
+      left: calc(100% - calc(tokens.get("core", "form-control-size-calc") * 0.75));
     }
 
     #{core.bem("switch", "track")} {
@@ -128,7 +128,7 @@ $-thumb-size: calc(css.get("switch", "track-size", 1.25em) - calc(css.get("switc
 
     #{core.bem("switch", "thumb")} {
       left: calc(100% - #{$-thumb-size});
-      box-shadow: 0 0 0 css.get("switch", "border-width", 2px) $-color-checked;
+      box-shadow: 0 0 0 tokens.get("switch", "border-width", 2px) $-color-checked;
     }
   }
 }

--- a/packages/switch/src/_switch_size.scss
+++ b/packages/switch/src/_switch_size.scss
@@ -1,12 +1,12 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $-switch-size: config.get("switch-size", "variants");
 
 @each $key, $value in $-switch-size {
   #{core.bem("switch", null, "size", $key)} {
-    @include css.override("switch", "size", $value);
+    @include tokens.override("switch", "size", $value);
   }
 }
 
@@ -14,7 +14,7 @@ $-switch-size: config.get("switch-size", "variants");
   @include core.media-min($value) {
     @each $key, $value in $-switch-size {
       #{core.bem("switch", null, "size", $key, $bp)} {
-        @include css.override("switch", "size", $value);
+        @include tokens.override("switch", "size", $value);
       }
     }
   }

--- a/packages/table/src/_config.scss
+++ b/packages/table/src/_config.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $config: () !default;
 
@@ -26,4 +26,4 @@ $default: (
 );
 
 @include config.apply($config, $default);
-@include css.register("table");
+@include tokens.register("table");

--- a/packages/table/src/_mixins.scss
+++ b/packages/table/src/_mixins.scss
@@ -1,9 +1,9 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $-attr: config.get("table-mobile", "attr");
-$-border: css.get("table", "border-width", css.get("border-width")) css.get("table", "border-style", css.get("border-style")) css.get("table", "border-color", css.get("border-color"));
+$-border: tokens.get("table", "border-width", tokens.get("border-width")) tokens.get("table", "border-style", tokens.get("border-style")) tokens.get("table", "border-color", tokens.get("border-color"));
 
 @mixin mobile-styles {
   thead,
@@ -27,7 +27,7 @@ $-border: css.get("table", "border-width", css.get("border-width")) css.get("tab
 
   [#{$-attr}] {
     position: relative;
-    padding-left: calc(css.get("table", "mobile-label-width", 8em) + css.get("table", "mobile-label-spacing", 0.75em));
+    padding-left: calc(tokens.get("table", "mobile-label-width", 8em) + tokens.get("table", "mobile-label-spacing", 0.75em));
     white-space: normal;
 
     &::before {
@@ -37,13 +37,13 @@ $-border: css.get("table", "border-width", css.get("border-width")) css.get("tab
       bottom: 0;
       left: 0;
       overflow: hidden;
-      width: css.get("table", "mobile-label-width", 8em);
-      padding: css.get("table", "padding", 0.5em 0.75em);
-      font-weight: css.get("font-weight-bold");
-      color: css.get("table", "mobile-label-foreground", inherit);
+      width: tokens.get("table", "mobile-label-width", 8em);
+      padding: tokens.get("table", "padding", 0.5em 0.75em);
+      font-weight: tokens.get("font-weight-bold");
+      color: tokens.get("table", "mobile-label-foreground", inherit);
       text-overflow: ellipsis;
       white-space: nowrap;
-      background-color: css.get("table", "mobile-label-background", transparent);
+      background-color: tokens.get("table", "mobile-label-background", transparent);
     }
   }
 
@@ -56,7 +56,7 @@ $-border: css.get("table", "border-width", css.get("border-width")) css.get("tab
 
     td + td,
     th + td {
-      border-top: 1px dotted css.get("table", "border-color", css.get("border-color"));
+      border-top: 1px dotted tokens.get("table", "border-color", tokens.get("border-color"));
     }
 
     [#{$-attr}]::before {

--- a/packages/table/src/_table.scss
+++ b/packages/table/src/_table.scss
@@ -1,28 +1,28 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 #{core.bem("table")} {
   width: 100%;
-  color: css.get("table", "foreground", inherit);
+  color: tokens.get("table", "foreground", inherit);
   text-align: left;
-  background-color: css.get("table", "background", css.get("background"));
+  background-color: tokens.get("table", "background", tokens.get("background"));
 
   th,
   td,
   caption {
-    padding: css.get("table", "padding", config.get("table-padding", "default"));
-    vertical-align: css.get("table", "vertical-align", top);
+    padding: tokens.get("table", "padding", config.get("table-padding", "default"));
+    vertical-align: tokens.get("table", "vertical-align", top);
   }
 
   th {
-    font-weight: css.get("font-weight-bold");
-    color: css.get("table", "header-foreground", css.get("foreground-strong"));
+    font-weight: tokens.get("font-weight-bold");
+    color: tokens.get("table", "header-foreground", tokens.get("foreground-strong"));
   }
 
   caption {
     caption-side: bottom;
-    color: css.get("foreground-subtle");
+    color: tokens.get("foreground-subtle");
     text-align: left;
   }
 

--- a/packages/table/src/_table_hover.scss
+++ b/packages/table/src/_table_hover.scss
@@ -1,5 +1,5 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 
 #{core.bem("table", null, "hover")} {
@@ -12,7 +12,7 @@
   tbody tr:focus,
   tbody tr:focus-within {
     z-index: 2;
-    color: css.get("table", "foreground-hover", inherit);
-    background-color: css.get("table", "background-hover", palette.get("primary", $a: 15%));
+    color: tokens.get("table", "foreground-hover", inherit);
+    background-color: tokens.get("table", "background-hover", palette.get("primary", $a: 15%));
   }
 }

--- a/packages/table/src/_table_padding.scss
+++ b/packages/table/src/_table_padding.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $-table-padding: config.get("table-padding", "variants");
 
@@ -9,8 +9,8 @@ $-table-padding: config.get("table-padding", "variants");
     th,
     td,
     caption {
-      @include css.override("table", "padding", $value);
-      @include css.override("table", "mobile-label-spacing", core.get-side($value, "left"));
+      @include tokens.override("table", "padding", $value);
+      @include tokens.override("table", "mobile-label-spacing", core.get-side($value, "left"));
     }
   }
 }
@@ -22,8 +22,8 @@ $-table-padding: config.get("table-padding", "variants");
         th,
         td,
         caption {
-          @include css.override("table", "padding", $value);
-          @include css.override("table", "mobile-label-spacing", core.get-side($value, "left"));
+          @include tokens.override("table", "padding", $value);
+          @include tokens.override("table", "mobile-label-spacing", core.get-side($value, "left"));
         }
       }
     }

--- a/packages/table/src/_table_striped.scss
+++ b/packages/table/src/_table_striped.scss
@@ -1,12 +1,12 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 #{core.bem("table", null, "striped")} {
   thead tr {
-    background-color: css.get("table", "background-striped", css.get("background-alt"));
+    background-color: tokens.get("table", "background-striped", tokens.get("background-alt"));
   }
 
   tr:nth-child(even) {
-    background-color: css.get("table", "background-striped", css.get("background-alt"));
+    background-color: tokens.get("table", "background-striped", tokens.get("background-alt"));
   }
 }

--- a/packages/table/src/_table_style.scss
+++ b/packages/table/src/_table_style.scss
@@ -1,7 +1,7 @@
 @use "@vrembem/core";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
-$-border: css.get("table", "border-width", css.get("border-width")) css.get("table", "border-style", css.get("border-style")) css.get("table", "border-color", css.get("border-color"));
+$-border: tokens.get("table", "border-width", tokens.get("border-width")) tokens.get("table", "border-style", tokens.get("border-style")) tokens.get("table", "border-color", tokens.get("border-color"));
 
 #{core.bem("table", null, "style", "rowed")} {
   border-bottom: $-border;

--- a/packages/utility/src/_config.scss
+++ b/packages/utility/src/_config.scss
@@ -1,6 +1,6 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 
 $config: () !default;
 
@@ -31,9 +31,9 @@ $default: (
   // A map of border-radius utilities to output
   // @type map
   "utility-border-radius": (
-    "": css.get("border-radius"),
-    "lg": css.get("border-radius-lg"),
-    "circle": css.get("border-radius-circle"),
+    "": tokens.get("border-radius"),
+    "lg": tokens.get("border-radius-lg"),
+    "circle": tokens.get("border-radius-circle"),
     "square": 0
   ),
 
@@ -55,22 +55,22 @@ $default: (
   // @type map
   "utility-spacing": (
     "0": 0,
-    "xs": css.get("spacing"),
-    "sm": calc(css.get("spacing") * 2),
-    "": calc(css.get("spacing") * 4),
-    "lg": calc(css.get("spacing") * 8),
-    "xl": calc(css.get("spacing") * 12)
+    "xs": tokens.get("spacing"),
+    "sm": calc(tokens.get("spacing") * 2),
+    "": calc(tokens.get("spacing") * 4),
+    "lg": calc(tokens.get("spacing") * 8),
+    "xl": calc(tokens.get("spacing") * 12)
   ),
 
   // A map of gap utilities to output
   // @type map
   "utility-gap": (
     "0": 0,
-    "xs": css.get("spacing"),
-    "sm": css.get("spacing-sm"),
-    "": css.get("spacing-md"),
-    "lg": css.get("spacing-lg"),
-    "xl": css.get("spacing-xl")
+    "xs": tokens.get("spacing"),
+    "sm": tokens.get("spacing-sm"),
+    "": tokens.get("spacing-md"),
+    "lg": tokens.get("spacing-lg"),
+    "xl": tokens.get("spacing-xl")
   ),
 
   // A map of max-width utilities to output

--- a/packages/utility/src/modules/_background.scss
+++ b/packages/utility/src/modules/_background.scss
@@ -1,6 +1,6 @@
 @use "sass:map";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 @use "../functions" as fun;
 
@@ -32,15 +32,15 @@
   // Theme CSS Variable output
 
   #{fun.selector("background")} {
-    background-color: fun.maybe-important(css.get("background"));
+    background-color: fun.maybe-important(tokens.get("background"));
   }
 
   #{fun.selector("background", "alt")} {
-    background-color: fun.maybe-important(css.get("background-alt"));
+    background-color: fun.maybe-important(tokens.get("background-alt"));
   }
 
   #{fun.selector("background", "shift")} {
-    background-color: fun.maybe-important(css.get("background-shift"));
+    background-color: fun.maybe-important(tokens.get("background-shift"));
   }
 
   // Palette CSS Variable output
@@ -51,12 +51,12 @@
     }
 
     #{fun.selector("background", $name, "auto")} {
-      background-color: fun.maybe-important(css.get("#{$name}-background"));
+      background-color: fun.maybe-important(tokens.get("#{$name}-background"));
     }
 
     @each $key in map.keys(config.get("palette-variants")) {
       #{fun.selector("background", $name, $key)} {
-        background-color: fun.maybe-important(css.get("palette", "#{$name}-#{$key}"));
+        background-color: fun.maybe-important(tokens.get("palette", "#{$name}-#{$key}"));
       }
     }
   }

--- a/packages/utility/src/modules/_border.scss
+++ b/packages/utility/src/modules/_border.scss
@@ -1,25 +1,25 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "../functions" as fun;
 
 @if fun.maybe-output("border") {
   #{fun.selector("border")} {
-    border: fun.maybe-important(css.get("border"));
+    border: fun.maybe-important(tokens.get("border"));
   }
 
   #{fun.selector("border", "top")} {
-    border-top: fun.maybe-important(css.get("border"));
+    border-top: fun.maybe-important(tokens.get("border"));
   }
 
   #{fun.selector("border", "bottom")} {
-    border-bottom: fun.maybe-important(css.get("border"));
+    border-bottom: fun.maybe-important(tokens.get("border"));
   }
 
   #{fun.selector("border", "left")} {
-    border-left: fun.maybe-important(css.get("border"));
+    border-left: fun.maybe-important(tokens.get("border"));
   }
 
   #{fun.selector("border", "right")} {
-    border-right: fun.maybe-important(css.get("border"));
+    border-right: fun.maybe-important(tokens.get("border"));
   }
 
   #{fun.selector("border", "none")} {
@@ -43,11 +43,11 @@
   }
 
   #{fun.selector("border", "color-strong")} {
-    border-color: fun.maybe-important(css.get("border-color-strong"));
+    border-color: fun.maybe-important(tokens.get("border-color-strong"));
   }
 
   #{fun.selector("border", "color-stronger")} {
-    border-color: fun.maybe-important(css.get("border-color-stronger"));
+    border-color: fun.maybe-important(tokens.get("border-color-stronger"));
   }
 
   #{fun.selector("border", "color-transparent")} {

--- a/packages/utility/src/modules/_box-shadow.scss
+++ b/packages/utility/src/modules/_box-shadow.scss
@@ -1,9 +1,9 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "../functions" as fun;
 
 @if fun.maybe-output("box-shadow") {
   #{fun.selector("box-shadow")} {
-    box-shadow: fun.maybe-important(css.get("box-shadow"));
+    box-shadow: fun.maybe-important(tokens.get("box-shadow"));
   }
 
   #{fun.selector("box-shadow", "flat")} {
@@ -11,22 +11,22 @@
   }
 
   #{fun.selector("box-shadow", "1")} {
-    box-shadow: fun.maybe-important(css.get("box-shadow-1"));
+    box-shadow: fun.maybe-important(tokens.get("box-shadow-1"));
   }
 
   #{fun.selector("box-shadow", "2")} {
-    box-shadow: fun.maybe-important(css.get("box-shadow-2"));
+    box-shadow: fun.maybe-important(tokens.get("box-shadow-2"));
   }
 
   #{fun.selector("box-shadow", "3")} {
-    box-shadow: fun.maybe-important(css.get("box-shadow-3"));
+    box-shadow: fun.maybe-important(tokens.get("box-shadow-3"));
   }
 
   #{fun.selector("box-shadow", "4")} {
-    box-shadow: fun.maybe-important(css.get("box-shadow-4"));
+    box-shadow: fun.maybe-important(tokens.get("box-shadow-4"));
   }
 
   #{fun.selector("box-shadow", "5")} {
-    box-shadow: fun.maybe-important(css.get("box-shadow-5"));
+    box-shadow: fun.maybe-important(tokens.get("box-shadow-5"));
   }
 }

--- a/packages/utility/src/modules/_font.scss
+++ b/packages/utility/src/modules/_font.scss
@@ -1,19 +1,19 @@
 @use "@vrembem/core";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "../functions" as fun;
 
 @if fun.maybe-output("font") {
   #{fun.selector("font", "family", "sans")} {
-    font-family: fun.maybe-important(css.get("font-family-sans"));
+    font-family: fun.maybe-important(tokens.get("font-family-sans"));
   }
 
   #{fun.selector("font", "family", "serif")} {
-    font-family: fun.maybe-important(css.get("font-family-serif"));
+    font-family: fun.maybe-important(tokens.get("font-family-serif"));
   }
 
   #{fun.selector("font", "family", "mono")} {
-    font-family: fun.maybe-important(css.get("font-family-mono"));
+    font-family: fun.maybe-important(tokens.get("font-family-mono"));
   }
 
   #{fun.selector("font", "size", "base")} {
@@ -21,15 +21,15 @@
   }
 
   #{fun.selector("font", "size", "sm")} {
-    font-size: fun.maybe-important(css.get("font-size-sm"));
+    font-size: fun.maybe-important(tokens.get("font-size-sm"));
   }
 
   #{fun.selector("font", "size", "lg")} {
-    font-size: fun.maybe-important(css.get("font-size-lg"));
+    font-size: fun.maybe-important(tokens.get("font-size-lg"));
   }
 
   #{fun.selector("font", "line-height")} {
-    line-height: fun.maybe-important(css.get("line-height"));
+    line-height: fun.maybe-important(tokens.get("line-height"));
   }
 
   @each $key, $value in config.get("utility-font-weight") {

--- a/packages/utility/src/modules/_foreground.scss
+++ b/packages/utility/src/modules/_foreground.scss
@@ -1,6 +1,6 @@
 @use "sass:map";
 @use "@vrembem/core/config";
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "@vrembem/core/palette";
 @use "../functions" as fun;
 
@@ -20,23 +20,23 @@
   // Theme CSS Variable output
 
   #{fun.selector("foreground")} {
-    color: fun.maybe-important(css.get("foreground"));
+    color: fun.maybe-important(tokens.get("foreground"));
   }
 
   #{fun.selector("foreground", "strong")} {
-    color: fun.maybe-important(css.get("foreground-strong"));
+    color: fun.maybe-important(tokens.get("foreground-strong"));
   }
 
   #{fun.selector("foreground", "subtle")} {
-    color: fun.maybe-important(css.get("foreground-subtle"));
+    color: fun.maybe-important(tokens.get("foreground-subtle"));
   }
 
   #{fun.selector("foreground", "accent")} {
-    color: fun.maybe-important(css.get("foreground-accent"));
+    color: fun.maybe-important(tokens.get("foreground-accent"));
   }
 
   #{fun.selector("foreground", "accent-alt")} {
-    color: fun.maybe-important(css.get("foreground-accent-alt"));
+    color: fun.maybe-important(tokens.get("foreground-accent-alt"));
   }
 
   // Palette CSS Variable output
@@ -47,12 +47,12 @@
     }
 
     #{fun.selector("foreground", $name, "auto")} {
-      color: fun.maybe-important(css.get("#{$name}-foreground"));
+      color: fun.maybe-important(tokens.get("#{$name}-foreground"));
     }
 
     @each $key in map.keys(config.get("palette-variants")) {
       #{fun.selector("foreground", $name, $key)} {
-        color: fun.maybe-important(css.get("palette", "#{$name}-#{$key}"));
+        color: fun.maybe-important(tokens.get("palette", "#{$name}-#{$key}"));
       }
     }
   }

--- a/packages/utility/src/modules/_transition.scss
+++ b/packages/utility/src/modules/_transition.scss
@@ -1,9 +1,9 @@
-@use "@vrembem/core/css";
+@use "@vrembem/core/tokens";
 @use "../functions" as fun;
 
 @if fun.maybe-output("transition") {
   #{fun.selector("transition")} {
-    transition: fun.maybe-important(all #{css.get("transition-duration")} #{css.get("transition-timing-function")});
+    transition: fun.maybe-important(all #{tokens.get("transition-duration")} #{tokens.get("transition-timing-function")});
   }
 
   #{fun.selector("transition", "none")} {
@@ -11,10 +11,10 @@
   }
 
   #{fun.selector("transition", "duration-short")} {
-    transition-duration: fun.maybe-important(css.get("transition-duration-short"));
+    transition-duration: fun.maybe-important(tokens.get("transition-duration-short"));
   }
 
   #{fun.selector("transition", "duration-long")} {
-    transition-duration: fun.maybe-important(css.get("transition-duration-long"));
+    transition-duration: fun.maybe-important(tokens.get("transition-duration-long"));
   }
 }

--- a/packages/vrembem/index.scss
+++ b/packages/vrembem/index.scss
@@ -1,4 +1,4 @@
-@forward "@vrembem/core/layers";
+@forward "./layers";
 @forward "@vrembem/core" as core-*;
 @forward "@vrembem/base" as base-*;
 @forward "@vrembem/flex" as flex-*;
@@ -19,4 +19,4 @@
 @forward "@vrembem/section" as section-*;
 @forward "@vrembem/table" as table-*;
 @forward "@vrembem/utility" as utility-*;
-@forward "@vrembem/core/tokens";
+@forward "./tokens";

--- a/packages/vrembem/layers.scss
+++ b/packages/vrembem/layers.scss
@@ -1,1 +1,1 @@
-@forward "@vrembem/core/layers";
+@layer tokens, base, components, utilities;

--- a/packages/vrembem/tokens.scss
+++ b/packages/vrembem/tokens.scss
@@ -1,1 +1,9 @@
-@forward "@vrembem/core/tokens";
+@use "@vrembem/core";
+
+@layer tokens {
+  :root {
+    @include core.css-output;
+  }
+
+  @include core.theme-output;
+}

--- a/packages/vrembem/tokens.scss
+++ b/packages/vrembem/tokens.scss
@@ -2,7 +2,7 @@
 
 @layer tokens {
   :root {
-    @include core.css-output;
+    @include core.tokens-output;
   }
 
   @include core.theme-output;


### PR DESCRIPTION
## What changed?

I think the css module is not very clear what it does by how it's named. This PR renames it to tokens which more clearly tells consumers that it's a module for managing design tokens as expressed by CSS variables. 

To help resolve entry collisions with this change, this PR also removes tokens, reset, and layout CSS output from the core and instead moves them to the vrembem package. Documentation has also been updated to reflect these changes.

**Additional changes**

- `docs`: Better implementation of layer with existing docs components.
