### PR TITLE
Refactor the JS exports and rename collection classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -970,7 +970,7 @@ https://lerna.js.org/docs/features/version-and-publish
 ### :tada: New Feature
 * `core`, `drawer`, `modal`, `popover`
   * [#853](https://github.com/sebnitu/vrembem/pull/853) Refactor and improve the modal JS module
-    * Modal stacking: multiple modals can now be open at the same time. Use `data-modal-replace` trigger or `modal.replace()` method for support of close to open functionality between modals.
+    * Modal stacking: multiple modals can now be open at the same time. Use `data-modal-replace` trigger or `modals.replace()` method for support of close to open functionality between modals.
     * Teleport: moveModal has been removed in favor of a teleport and teleportReturn API that are now attached to each collection entries modal object.
     * Better handling of accessibility attributes for modals (`role` and `aria-modal`).
     * Better handling of modal specific configurations.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you'd like to use Vrembem for prototyping or just want to take it for a test 
 <!-- Instantiate the component rendered in the document -->
 <script>
   const modal = new vrembem.Modal();
-  modal.mount();
+  modals.mount();
 </script>
 ```
 
@@ -119,11 +119,11 @@ Some packages also have included modules for their functionality. You can includ
 
 ```js
 // Import your component
-import Modal from "@vrembem/modal";
+import { ModalCollection } from "@vrembem/modal";
 
 // Instantiate and mount
-const modal = new Modal();
-modal.mount();
+const modals = new ModalCollection();
+modals.mount();
 ```
 
 #### HTML
@@ -169,13 +169,13 @@ Via your project's JavaScript manifest file:
 ```js
 // Import all under the vb namespace
 import * as vb from "vrembem";
-const drawer = new vb.Drawer();
-await drawer.mount();
+const drawers = new vb.Drawer();
+await drawers.mount();
 
 // Or import individual components
 import { Drawer } from "vrembem";
-const drawer = new Drawer();
-await drawer.mount();
+const drawers = new DrawerCollection();
+await drawers.mount();
 ```
 
 ## Copyright and License

--- a/docs/src/components/CollectionNavi.astro
+++ b/docs/src/components/CollectionNavi.astro
@@ -19,11 +19,16 @@ const { collection, entry } = Astro.props;
 // Store the module if that's what entry is
 const module = entry?.collection === "modules" ? entry : undefined;
 
-// Set the base collection
+// Set the base entry and collection. Modules are always rendered as submenus
+// of a package, so we never want to render them as the base collection navi.
+const baseEntry = module ? undefined : entry;
 const baseCollection = module ? "packages" : collection;
 
 // Get all the collection entries of the current page
-const entries = await getCollection(baseCollection, filterCollection(entry));
+const entries = await getCollection(
+  baseCollection,
+  filterCollection(baseEntry)
+);
 
 // Sort packages by category, otherwise sort by title/order
 if (baseCollection === "packages") {

--- a/docs/src/content/modules/core/plugins/attr-config.mdx
+++ b/docs/src/content/modules/core/plugins/attr-config.mdx
@@ -17,16 +17,16 @@ To pass custom configurations to specific collection entries using a data attrib
 
 <CodeExample lang="js">
 ```js
-import Modal from "@vrembem/modal";
+import { ModalCollection } from "@vrembem/modal";
 import { attrConfig } from "@vrembem/core";
 
-const modal = new Modal({
+const modals = new ModalCollection({
   plugins: [
     attrConfig()
   ]
 });
 
-await modal.mount();
+await modals.mount();
 ```
 </CodeExample>
 

--- a/docs/src/content/modules/core/plugins/css-config.mdx
+++ b/docs/src/content/modules/core/plugins/css-config.mdx
@@ -17,16 +17,16 @@ To pass custom configuration to collection entries using CSS custom properties, 
 
 <CodeExample lang="js">
 ```js
-import Popover from "@vrembem/popover";
+import { PopoverCollection } from "@vrembem/popover";
 import { cssConfig } from "@vrembem/core";
 
-const popover = new Popover({
+const popovers = new PopoverCollection({
   plugins: [
     cssConfig()
   ]
 });
 
-await popover.mount();
+await popovers.mount();
 ```
 </CodeExample>
 
@@ -49,7 +49,7 @@ Properties are prefixed with the components name and Vrembem custom properties p
 <CodeExample lang="js">
 ```js
 // Config option:
-popover.config.shiftPadding
+popovers.config.shiftPadding
 
 // Custom property equivalent:
 // --vb-popover-shift-padding

--- a/docs/src/content/modules/core/plugins/focus-trap.mdx
+++ b/docs/src/content/modules/core/plugins/focus-trap.mdx
@@ -17,16 +17,16 @@ To implement a focus trap in a collection entry, add the `focusTrap` plugin to y
 
 <CodeExample lang="js">
 ```js
-import Modal from "@vrembem/modal";
+import { ModalCollection } from "@vrembem/modal";
 import { focusTrap } from "@vrembem/core";
 
-const modal = new Modal({
+const modals = new ModalCollection({
   plugins: [
     focusTrap()
   ]
 });
 
-await modal.mount();
+await modals.mount();
 ```
 </CodeExample>
 
@@ -34,7 +34,7 @@ This will create a focus trap instance for each entry and setup an enable and di
 
 <CodeExample lang="js">
 ```js
-const modal = new Modal({
+const modals = new ModalCollection({
   plugins: [
     focusTrap({
       condition: ({ entry }) => {

--- a/docs/src/content/modules/core/plugins/media-query.mdx
+++ b/docs/src/content/modules/core/plugins/media-query.mdx
@@ -17,16 +17,16 @@ To implement media queries in collection entries, add the `mediaQuery` plugin to
 
 <CodeExample lang="js">
 ```js
-import Drawer from "@vrembem/Drawer";
+import { DrawerCollection } from "@vrembem/Drawer";
 import { mediaQuery } from "@vrembem/core";
 
-const drawer = new Drawer({
+const drawers = new DrawerCollection({
   plugins: [
     mediaQuery()
   ]
 });
 
-await drawer.mount();
+await drawers.mount();
 ```
 </CodeExample>
 
@@ -44,7 +44,7 @@ To provide a custom `onChange` event for a breakpoint, you can pass in a custom 
 
 <CodeExample lang="js">
 ```js
-const drawer = new Drawer({
+const drawers = new DrawerCollection({
   plugins: [
     mediaQuery({
       onChange(event, entry) {
@@ -78,7 +78,7 @@ Alternatively, a breakpoint key can be provided that maps to a value in a CSS cu
 
 <CodeExample lang="js">
 ```js
-const drawer = new Drawer({
+const drawers = new DrawerCollection({
   plugins: [
     mediaQuery({
       breakpoints: {
@@ -95,7 +95,7 @@ Finally, a default breakpoint can be set using the `breakpoint` option. All entr
 
 <CodeExample lang="js">
 ```js
-const drawer = new Drawer({
+const drawers = new DrawerCollection({
   plugins: [
     mediaQuery({
       breakpoint: "700px"
@@ -119,7 +119,7 @@ Here is an example of providing a custom media query to a specific drawer entry:
 
 <CodeExample lang="js">
 ```js
-const drawer = new Drawer({
+const drawers = new DrawerCollection({
   plugins: [
     mediaQuery({
       mediaQueries: {

--- a/docs/src/content/modules/core/plugins/prop-store.mdx
+++ b/docs/src/content/modules/core/plugins/prop-store.mdx
@@ -145,10 +145,10 @@ There are two common use cases for `propStore` in Modal and Drawer components. F
 
 <CodeExample lang="js">
 ```js
-import Modal from "@vrembem/modal";
+import { ModalCollection } from "@vrembem/modal";
 import { propStore } from "@vrembem/core";
 
-const modal = new Modal({
+const modals = new ModalCollection({
   selectorInert: "main",
   plugins: [
     propStore({
@@ -171,7 +171,7 @@ const modal = new Modal({
   ]
 });
 
-await modal.mount();
+await modals.mount();
 ```
 </CodeExample>
 
@@ -179,16 +179,16 @@ For Drawers, it is common to persist the state of inline drawers. Drawers come w
 
 <CodeExample lang="js">
 ```js
-import Drawer from "@vrembem/drawer";
+import { DrawerCollection } from "@vrembem/drawer";
 import { propStore } from "@vrembem/core";
 
-const drawer = new Drawer({
+const drawers = new DrawerCollection({
   plugins: [
     propStore()
   ]
 });
 
-await drawer.mount();
+await drawers.mount();
 ```
 </CodeExample>
 

--- a/docs/src/content/modules/core/plugins/teleport.mdx
+++ b/docs/src/content/modules/core/plugins/teleport.mdx
@@ -19,7 +19,7 @@ To teleport collection entry elements to a specific location in the document, ad
 
 <CodeExample lang="js">
 ```js
-import Modal from "@vrembem/modal";
+import { ModalCollection } from "@vrembem/modal";
 import { teleport } from "@vrembem/core";
 
 const modals = new Modal({

--- a/docs/src/content/modules/core/sass-modules/palette.mdx
+++ b/docs/src/content/modules/core/sass-modules/palette.mdx
@@ -22,22 +22,22 @@ The palette module sets up a watcher on the `palette` map of `core/config`. When
 The default color palette defines four colors under semantic names that are used throughout the library. These are base colors:
 
 <div class="flex flex_gap_lg align-items-center">
-  <span class="swatch border-radius background-primary"></span>
+  <span class="swatch background-primary"></span>
   <span>`primary`</span>
 </div>
 
 <div class="flex flex_gap_lg align-items-center">
-  <span class="swatch border-radius background-secondary"></span>
+  <span class="swatch background-secondary"></span>
   <span>`secondary`</span>
 </div>
 
 <div class="flex flex_gap_lg align-items-center">
-  <span class="swatch border-radius background-neutral"></span>
+  <span class="swatch background-neutral"></span>
   <span>`neutral`</span>
 </div>
 
 <div class="flex flex_gap_lg align-items-center">
-  <span class="swatch border-radius background-important"></span>
+  <span class="swatch background-important"></span>
   <span>`important`</span>
 </div>
 

--- a/docs/src/content/packages/drawer.mdx
+++ b/docs/src/content/packages/drawer.mdx
@@ -22,7 +22,7 @@ npm install @vrembem/drawer
 
 <CodeExample lang="js">
   ```js
-  // Import the drawer class
+  // Import the drawer collection class
   import { DrawerCollection } from "@vrembem/drawer";
 
   // Instantiate the drawer collection
@@ -548,7 +548,7 @@ Drawers slide in from the left by default. To create a right side drawer, use th
 
 ## Reference
 
-`Drawer` and `DrawerEntry` extend the [`Collection`](/packages/core/collection-api) and [`CollectionEntry`](/packages/core/collection-entry-api) classes, respectively, and inherit their APIs. This reference contains only drawer-specific API properties and methods. Check out the [collections documentation](/packages/core#collections) for more information on inherited APIs.
+`DrawerCollection` and `DrawerEntry` extend the [`Collection`](/packages/core/collection-api) and [`CollectionEntry`](/packages/core/collection-entry-api) classes, respectively, and inherit their APIs. This reference contains only drawer-specific API properties and methods. Check out the [collections documentation](/packages/core#collections) for more information on inherited APIs.
 
 ### activeModal
 

--- a/docs/src/content/packages/drawer.mdx
+++ b/docs/src/content/packages/drawer.mdx
@@ -23,10 +23,10 @@ npm install @vrembem/drawer
 <CodeExample lang="js">
   ```js
   // Import the drawer class
-  import Drawer from "@vrembem/drawer";
+  import { DrawerCollection } from "@vrembem/drawer";
 
   // Instantiate the drawer collection
-  const drawers = new Drawer();
+  const drawers = new DrawerCollection();
 
   // Mount the drawer collection
   await drawers.mount();
@@ -43,7 +43,7 @@ Drawer comes with the following JavaScript configuration options that customize 
 
 <CodeExpander lang="js">
 ```js
-const drawers = new Drawer({
+const drawers = new DrawerCollection({
   // An object containing pre-configuration options for plugins. Object should
   // contain the name of the plugin to configure as the key and the config
   // object for that plugin as the value.
@@ -480,7 +480,7 @@ Here's an example where we set the `drawer-main` content area to be inaccessible
 
 <CodeExample lang="js">
   ```js
-  const drawers = new Drawer({
+  const drawers = new DrawerCollection({
     selectorInert: ".drawer-main",
     selectorOverflow: "body, .drawer-main"
   });

--- a/docs/src/content/packages/modal.mdx
+++ b/docs/src/content/packages/modal.mdx
@@ -24,7 +24,7 @@ npm install @vrembem/modal
 <CodeExample lang="js">
   ```js
   // Import the modal class
-  import Modal from "@vrembem/modal";
+  import { ModalCollection } from "@vrembem/modal";
 
   // Instantiate the modal collection
   const modals = new Modal();
@@ -67,7 +67,7 @@ const modals = new Modal({
   selectorDialog: ".modal__dialog",
 
   // A valid CSS selector for the element that should be treated as the modal
-  // backdrop. Clicking the backdrop closes the modal.
+  // backdrop. Clicking the backdrop closes the modals.
   // @type string
   selectorBackdrop: ".modal",
 
@@ -168,8 +168,8 @@ Modal uses CSS variables in a reference and fallback pattern. Variables are refe
 
 Modals are composed using classes and data attributes for their triggers. The basic structure of a modal is an element with a unique `id` and the `modal` class containing a child element with the `modal__dialog` class. There are three types of modal triggers, each defined by a data attribute:
 
-- `data-modal-open`: Opens a modal. Takes the ID of the modal to open. Will stack modals if triggered from inside an already opened modal.
-- `data-modal-close`: Closes a modal. Takes the ID of the modal to close or closes the top active modal if left value-less. Setting value to `"*"` will close all open modals.
+- `data-modal-open`: Opens a modals. Takes the ID of the modal to open. Will stack modals if triggered from inside an already opened modals.
+- `data-modal-close`: Closes a modals. Takes the ID of the modal to close or closes the top active modal if left value-less. Setting value to `"*"` will close all open modals.
 - `data-modal-replace`: Replaces currently opened modals with the modal of the id provided.
 
 <CodeExample>
@@ -345,7 +345,7 @@ Modals on the web have an expected set of patterns that this component follows. 
 3. While the modal is active, contents obscured by the modal are inaccessible to all users. Apply the [`focusTrap`](/packages/core/plugins/focus-trap) plugin to enable this behavior.
 4. When a modal is closed, focus is returned to the initial trigger element that opened it.
 
-To take full advantage of modal's accessibility features, it's recommended to set the `selectorInert` option to all elements that are outside the modal. All elements that match the `selectorInert` selector will be given the `inert` attribute, as well as `aria-hidden="true"` when a modal is opened. If modal markup are rendered throughout your document, use the [`teleport`](/packages/core/plugins/teleport) plugin to consolidate all modals in the DOM to a single location.
+To take full advantage of modal's accessibility features, it's recommended to set the `selectorInert` option to all elements that are outside the modals. All elements that match the `selectorInert` selector will be given the `inert` attribute, as well as `aria-hidden="true"` when a modal is opened. If modal markup are rendered throughout your document, use the [`teleport`](/packages/core/plugins/teleport) plugin to consolidate all modals in the DOM to a single location.
 
 #### Example
 
@@ -353,7 +353,7 @@ Here's an example where we set the `<main>` content area to be inaccessible whil
 
 <CodeExample lang="js">
   ```js
-  import Modal from "@vrembem/modal";
+  import { ModalCollection } from "@vrembem/modal";
   import { focusTrap, teleport } from "@vrembem/core";
 
   const modals = new Modal({
@@ -658,7 +658,7 @@ Below is an example implementation of using stack along with the [`propStore`](/
 
 <CodeExample lang="js">
 ```js
-import Modal from "@vrembem/modal";
+import { ModalCollection } from "@vrembem/modal";
 import { propStore } from "@vrembem/core";
 
 const modals = new Modal({
@@ -835,7 +835,7 @@ await modals.closeAll("my-modal");
 
 <ReferenceBar type="string" />
 
-Stores the current state of the modal. Possible states include:
+Stores the current state of the modals. Possible states include:
 
 - `opened`: The modal is currently open, and its content is accessible.
 - `opening`: A transitional state from closed to opened.

--- a/docs/src/content/packages/modal.mdx
+++ b/docs/src/content/packages/modal.mdx
@@ -23,11 +23,11 @@ npm install @vrembem/modal
 
 <CodeExample lang="js">
   ```js
-  // Import the modal class
+  // Import the modal collection class
   import { ModalCollection } from "@vrembem/modal";
 
   // Instantiate the modal collection
-  const modals = new Modal();
+  const modals = new ModalCollection();
 
   // Mount the modal collection
   await modals.mount();
@@ -638,7 +638,7 @@ Adjust the size of a modal by increasing or decreasing its width. These modifier
 
 ## Reference
 
-`Modal` and `ModalEntry` extend the [`Collection`](/packages/core/collection-api) and [`CollectionEntry`](/packages/core/collection-entry-api) classes, respectively, and inherit their APIs. This reference contains only modal-specific API properties and methods. Check out the [collections documentation](/packages/core#collections) for more information on inherited APIs.
+`ModalCollection` and `ModalEntry` extend the [`Collection`](/packages/core/collection-api) and [`CollectionEntry`](/packages/core/collection-entry-api) classes, respectively, and inherit their APIs. This reference contains only modal-specific API properties and methods. Check out the [collections documentation](/packages/core#collections) for more information on inherited APIs.
 
 ### trigger
 

--- a/docs/src/content/packages/popover.mdx
+++ b/docs/src/content/packages/popover.mdx
@@ -25,10 +25,10 @@ npm install @vrembem/popover
 <CodeExample lang="js">
   ```js
   // Import the popover class
-  import Popover from "@vrembem/popover";
+  import { PopoverCollection } from "@vrembem/popover";
 
   // Instantiate the popover collection
-  const popovers = new Popover();
+  const popovers = new PopoverCollection();
 
   // Mount the popover collection
   await popovers.mount();
@@ -45,7 +45,7 @@ Popover comes with the following JavaScript configuration options that customize
 
 <CodeExpander lang="js">
 ```js
-const popovers = new Popover({
+const popovers = new PopoverCollection({
   // A valid CSS selector used to query the document for elements to include as
   // entries in the popover collection.
   // @type string
@@ -210,7 +210,7 @@ There are two event types that can trigger a popover: `click` (the default) and 
 
   ```js
   // Set on instantiation
-  const popovers = new Popover({
+  const popovers = new PopoverCollection({
     event: "click"
   });
 
@@ -246,11 +246,11 @@ Popover uses the [floating UI positioning engine](https://floating-ui.com/) to d
 <CodeExample lang="js">
 ```js
 // Set on instantiation
-const popover = new Popover({
+const popovers = new PopoverCollection({
   placement: "top"
 });
 
-popover.mount();
+popovers.mount();
 ```
 </CodeExample>
 
@@ -373,7 +373,7 @@ Applies styles to create a popover tooltip. The default placement of a tooltip i
 
 ### Multiple popovers
 
-There are cases where a single popover trigger requires both a tooltip and a click toggle popover. This can be achieved by using `aria-controls` and `aria-describedby` attributes with the values of their corresponding popover IDs.
+There are cases where a single popover trigger requires both a tooltip and a click toggle popovers. This can be achieved by using `aria-controls` and `aria-describedby` attributes with the values of their corresponding popover IDs.
 
 <CodeExample>
   <Fragment slot="output">
@@ -527,7 +527,7 @@ await popovers.close();
 
 <ReferenceBar type='"closed" | "opened"' />
 
-Stores the current state of the popover. Possible states include:
+Stores the current state of the popovers. Possible states include:
 
 - `opened`: The popover is currently open, and its content is visible.
 - `closed`: The popover is currently closed, and its content is hidden.

--- a/docs/src/content/packages/popover.mdx
+++ b/docs/src/content/packages/popover.mdx
@@ -24,7 +24,7 @@ npm install @vrembem/popover
 
 <CodeExample lang="js">
   ```js
-  // Import the popover class
+  // Import the popover collection class
   import { PopoverCollection } from "@vrembem/popover";
 
   // Instantiate the popover collection
@@ -435,7 +435,7 @@ Popovers can be anchored to the cursor element by setting the `followCursor` con
 
 ## Reference
 
-`Popover` and `PopoverEntry` extend the [`Collection`](/packages/core/collection-api) and [`CollectionEntry`](/packages/core/collection-entry-api) classes, respectively, and inherit their APIs. This reference contains only popover-specific API properties and methods. Check out the [collections documentation](/packages/core#collections) for more information on inherited APIs.
+`PopoverCollection` and `PopoverEntry` extend the [`Collection`](/packages/core/collection-api) and [`CollectionEntry`](/packages/core/collection-entry-api) classes, respectively, and inherit their APIs. This reference contains only popover-specific API properties and methods. Check out the [collections documentation](/packages/core#collections) for more information on inherited APIs.
 
 ### trigger
 

--- a/docs/src/helpers/filterCollection.ts
+++ b/docs/src/helpers/filterCollection.ts
@@ -2,7 +2,7 @@ import type { CollectionEntry, CollectionKey } from "astro:content";
 import { getModuleMeta } from "@/helpers/getModuleMeta";
 
 export function filterCollection(
-  entry: CollectionEntry<CollectionKey> | undefined
+  entry?: CollectionEntry<CollectionKey>
 ) {
   // Unique filter logic for pages
   if (entry?.collection === "pages") {

--- a/docs/src/helpers/getCollectionPath.ts
+++ b/docs/src/helpers/getCollectionPath.ts
@@ -8,17 +8,22 @@ export function getCollectionPath(
   // Initialize the result
   let result = "/";
 
-  // Prepend the packages path for both packages and modules
-  if (entry.collection === "packages" || entry.collection === "modules") {
-    result += "packages/";
+  // Pages are top-level and receive no prefix
+  // > "/{id}"
+  if (entry.collection === "pages") {
+    result += entry.id;
   }
 
-  // Use the meta path for modules (excludes the group directory)
-  // Otherwise, append the entry id to the result
-  if (entry.collection === "modules") {
-    result += getModuleMeta(entry).path;
-  } else {
-    result += entry.id;
+  // Modules are prefixed with the packages collection
+  // > "/packages/{parent}/{module}"
+  else if (entry.collection === "modules") {
+    result += `packages/${getModuleMeta(entry).path}`;
+  }
+  
+  // Everything else is prefixed with their own collection name
+  // > "/{collection}/{id}"
+  else {
+    result += `${entry.collection}/${entry.id}`;
   }
 
   // Add a hash anchor if it was provided

--- a/docs/src/modules/useDrawer.js
+++ b/docs/src/modules/useDrawer.js
@@ -1,14 +1,14 @@
-import { Drawer } from "vrembem";
 import {
+  DrawerCollection,
   attrConfig,
   cssConfig,
   focusTrap,
   mediaQuery,
   propStore
-} from "@vrembem/core";
+} from "vrembem";
 
 /** @type {import("vrembem").Drawer} */
-const drawers = new Drawer({
+const drawers = new DrawerCollection({
   selector: ".drawer",
   plugins: [cssConfig(), attrConfig(), focusTrap(), mediaQuery(), propStore()]
 });

--- a/docs/src/modules/useModal.js
+++ b/docs/src/modules/useModal.js
@@ -1,8 +1,13 @@
-import { Modal } from "vrembem";
-import { attrConfig, cssConfig, focusTrap, teleport } from "@vrembem/core";
+import {
+  ModalCollection,
+  attrConfig,
+  cssConfig,
+  focusTrap,
+  teleport
+} from "vrembem";
 
 /** @type {import("vrembem").Modal} */
-const modals = new Modal({
+const modals = new ModalCollection({
   selectorInert: "main",
   plugins: [
     cssConfig(),

--- a/docs/src/modules/usePopover.js
+++ b/docs/src/modules/usePopover.js
@@ -1,8 +1,7 @@
-import { Popover } from "vrembem";
-import { cssConfig, teleport } from "@vrembem/core";
+import { PopoverCollection, cssConfig, teleport } from "vrembem";
 
 /** @type {import("vrembem").Popover} */
-const popovers = new Popover({
+const popovers = new PopoverCollection({
   plugins: [cssConfig(), teleport({ where: ".popovers" })]
 });
 

--- a/docs/src/styles/_swatch.scss
+++ b/docs/src/styles/_swatch.scss
@@ -5,6 +5,5 @@
   @include core.size(4rem);
 
   display: inline-block;
-  border: tokens.get("border");
-  border-radius: tokens.get("border-radius");
+  border-radius: tokens.get("border-radius-lg");
 }

--- a/packages/drawer/README.md
+++ b/packages/drawer/README.md
@@ -19,7 +19,7 @@ npm install @vrembem/drawer
 ### JavaScript
 
 ```js
-import Drawer from '@vrembem/drawer';
-const drawer = new Drawer();
-await drawer.mount();
+import { DrawerCollection } from '@vrembem/drawer';
+const drawers = new DrawerCollection();
+await drawers.mount();
 ```

--- a/packages/drawer/index.html
+++ b/packages/drawer/index.html
@@ -8,10 +8,10 @@
   <link rel="icon" type="image/svg+xml" href="https://sebnitu.com/icons/vb-favicon.svg">
   <script type="module">
     import "vrembem/sass";
-    import Drawer from "./index.ts";
+    import { DrawerCollection } from "./index.ts";
     import { focusTrap, mediaQuery, propStore, teleport } from "@vrembem/core";
 
-    const drawer = new Drawer({
+    const drawers = new DrawerCollection({
       plugins: [
         focusTrap(),
         mediaQuery(),
@@ -23,7 +23,7 @@
       ]
     });
 
-    window["drawer"] = await drawer.mount();
+    window["drawer"] = await drawers.mount();
   </script>
 </head>
 <body>

--- a/packages/drawer/index.ts
+++ b/packages/drawer/index.ts
@@ -1,3 +1,1 @@
-import { Drawer } from "./src/js/Drawer";
-
-export default Drawer;
+export { DrawerCollection } from "./src/js/DrawerCollection";

--- a/packages/drawer/src/js/DrawerCollection.ts
+++ b/packages/drawer/src/js/DrawerCollection.ts
@@ -6,7 +6,7 @@ import { open } from "./open";
 import { close } from "./close";
 import { toggle } from "./toggle";
 
-export class Drawer extends Collection<DrawerEntry, DrawerConfig> {
+export class DrawerCollection extends Collection<DrawerEntry, DrawerConfig> {
   readonly entryClass = DrawerEntry;
 
   constructor(options: Partial<DrawerConfig>) {

--- a/packages/drawer/src/js/DrawerEntry.ts
+++ b/packages/drawer/src/js/DrawerEntry.ts
@@ -4,13 +4,13 @@ import { open } from "./open";
 import { close } from "./close";
 import { toggle } from "./toggle";
 import { validate } from "./helpers/validate";
-import type { Drawer } from "./Drawer";
+import type { DrawerCollection } from "./DrawerCollection";
 
 export class DrawerEntry extends CollectionEntry {
   dialog: HTMLElement;
   trigger: HTMLElement | null;
 
-  constructor(parent: Drawer, query: string | HTMLElement) {
+  constructor(parent: DrawerCollection, query: string | HTMLElement) {
     super(parent, query);
 
     // Set the initial state of private store

--- a/packages/drawer/src/js/handlers.ts
+++ b/packages/drawer/src/js/handlers.ts
@@ -1,8 +1,8 @@
-import type { Drawer } from "./Drawer";
+import type { DrawerCollection } from "./DrawerCollection";
 import type { DrawerEntry } from "./DrawerEntry";
 
 export async function handleClick(
-  this: Drawer,
+  this: DrawerCollection,
   event: MouseEvent
 ): Promise<DrawerEntry | void> {
   // Guard if event target property is null
@@ -86,7 +86,7 @@ export async function handleClick(
 }
 
 export function handleKeydown(
-  this: Drawer,
+  this: DrawerCollection,
   event: KeyboardEvent
 ): Promise<DrawerEntry> | void {
   // If escape key was pressed

--- a/packages/drawer/tests/accessibility.test.js
+++ b/packages/drawer/tests/accessibility.test.js
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import Drawer from "../index";
+import { DrawerCollection } from "../index";
 
 document.body.innerHTML = `
   <div class="drawer-frame">
@@ -12,7 +12,7 @@ document.body.innerHTML = `
   </div>
 `;
 
-const drawer = new Drawer({
+const drawers = new DrawerCollection({
   selectorInert: "main",
   selectorOverflow: "body, main"
 });
@@ -33,7 +33,7 @@ test("should set accessibility attributes to modal drawer dialog", async () => {
   expect(dialog.getAttribute("aria-modal")).toBe(null);
   expect(dialog.getAttribute("tabindex")).toBe(null);
 
-  await drawer.mount();
+  await drawers.mount();
 
   expect(dialog.getAttribute("aria-modal")).toBe("true");
   expect(dialog.getAttribute("tabindex")).toBe("-1");

--- a/packages/drawer/tests/api.test.js
+++ b/packages/drawer/tests/api.test.js
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import Drawer from "../index";
+import { DrawerCollection } from "../index";
 
 const markup = `
   <div class="drawer-frame">
@@ -38,26 +38,26 @@ const markupInitState = `
 
 document.body.innerHTML = markup;
 
-const drawer = new Drawer({ transitionDuration: 300 });
+const drawers = new DrawerCollection({ transitionDuration: 300 });
 
 describe("mount() & unmount()", () => {
   it("should correctly register all drawers on mount()", async () => {
-    await drawer.mount();
-    expect(drawer.collection.length).toBe(2);
+    await drawers.mount();
+    expect(drawers.collection.length).toBe(2);
   });
 
   it("should correctly deregister all drawers on unmount()", async () => {
-    await drawer.unmount();
-    expect(drawer.collection.length).toBe(0);
+    await drawers.unmount();
+    expect(drawers.collection.length).toBe(0);
   });
 
   it("should mount with custom config passed on mount", async () => {
-    drawer.updateConfig({ eventListeners: false });
-    await drawer.mount();
-    expect(drawer.collection.length).toBe(2);
-    expect(drawer.config.eventListeners).toBe(false);
-    await drawer.unmount();
-    expect(drawer.collection.length).toBe(0);
+    drawers.updateConfig({ eventListeners: false });
+    await drawers.mount();
+    expect(drawers.collection.length).toBe(2);
+    expect(drawers.config.eventListeners).toBe(false);
+    await drawers.unmount();
+    expect(drawers.collection.length).toBe(0);
   });
 });
 
@@ -67,12 +67,12 @@ describe("open(), close() & toggle()", () => {
   });
 
   it("should open and close using open() and close() methods", async () => {
-    await drawer.mount();
-    const entry = drawer.get("drawer-1");
+    await drawers.mount();
+    const entry = drawers.get("drawer-1");
     expect(entry.state).toBe("closed");
     expect(entry.mode).toBe("inline");
 
-    drawer.open("drawer-1");
+    drawers.open("drawer-1");
     expect(entry.el).toHaveClass("is-opening");
     expect(entry.state).toBe("opening");
 
@@ -81,7 +81,7 @@ describe("open(), close() & toggle()", () => {
     expect(entry.state).toBe("opened");
     expect(entry.dialog).toBe(document.activeElement);
 
-    drawer.close("drawer-1");
+    drawers.close("drawer-1");
     expect(entry.el).toHaveClass("is-closing");
     expect(entry.state).toBe("closing");
 
@@ -92,11 +92,11 @@ describe("open(), close() & toggle()", () => {
   });
 
   it("should open and close using toggle() method", async () => {
-    const entry = drawer.get("drawer-2");
+    const entry = drawers.get("drawer-2");
     expect(entry.state).toBe("indeterminate");
     expect(entry.mode).toBe("inline");
 
-    drawer.toggle("drawer-2");
+    drawers.toggle("drawer-2");
     expect(entry.el).toHaveClass("is-closing");
     expect(entry.state).toBe("closing");
 
@@ -104,7 +104,7 @@ describe("open(), close() & toggle()", () => {
     expect(entry.el).toHaveClass("is-closed");
     expect(entry.state).toBe("closed");
 
-    drawer.toggle("drawer-2");
+    drawers.toggle("drawer-2");
     expect(entry.el).toHaveClass("is-opening");
     expect(entry.state).toBe("opening");
 
@@ -115,7 +115,7 @@ describe("open(), close() & toggle()", () => {
   });
 
   it("should throw if trying to open unregistered drawer", async () => {
-    const result = await drawer.open("asdf").catch((error) => {
+    const result = await drawers.open("asdf").catch((error) => {
       return error.message;
     });
     expect(result).toBe(
@@ -127,11 +127,11 @@ describe("open(), close() & toggle()", () => {
 describe("activeModal", () => {
   it("should return entry if drawer modal is active", async () => {
     vi.useFakeTimers();
-    const entry = await drawer.register(await drawer.createEntry("drawer-1"));
+    const entry = await drawers.register(await drawers.createEntry("drawer-1"));
 
     expect(entry.state).toBe("closed");
     expect(entry.mode).toBe("inline");
-    expect(drawer.activeModal).toBe(undefined);
+    expect(drawers.activeModal).toBe(undefined);
 
     entry.mode = "modal";
     entry.open();
@@ -140,58 +140,58 @@ describe("activeModal", () => {
 
     expect(entry.state).toBe("opened");
     expect(entry.mode).toBe("modal");
-    expect(drawer.activeModal).toBe(entry);
+    expect(drawers.activeModal).toBe(entry);
   });
 });
 
 describe("register() & deregister()", () => {
   beforeAll(async () => {
     document.body.innerHTML = markupInitState;
-    await drawer.unmount();
+    await drawers.unmount();
   });
 
   it("should disable setting tabindex on drawer dialog", async () => {
     // Disable tabindex before register
-    drawer.config.setTabindex = false;
-    let entry = await drawer.register(await drawer.createEntry("drawer-1"));
+    drawers.config.setTabindex = false;
+    let entry = await drawers.register(await drawers.createEntry("drawer-1"));
     expect(entry.dialog.getAttribute("tabindex")).toBe(null);
 
     // Deregister the entry before updating the setting and re-registering
-    await drawer.deregister(entry);
+    await drawers.deregister(entry);
 
     // Enable tabindex before register
-    drawer.config.setTabindex = true;
-    entry = await drawer.register(await drawer.createEntry("drawer-1"));
+    drawers.config.setTabindex = true;
+    entry = await drawers.register(await drawers.createEntry("drawer-1"));
     expect(entry.dialog.getAttribute("tabindex")).toBe("-1");
   });
 
   it("should register drawer in its default state", async () => {
-    const entry = await drawer.register(await drawer.createEntry("drawer-1"));
+    const entry = await drawers.register(await drawers.createEntry("drawer-1"));
     expect(entry.mode).toBe("inline");
     expect(entry.state).toBe("indeterminate");
   });
 
   it("should register drawer in its open state", async () => {
-    const entry = await drawer.register(await drawer.createEntry("drawer-2"));
+    const entry = await drawers.register(await drawers.createEntry("drawer-2"));
     expect(entry.mode).toBe("inline");
     expect(entry.state).toBe("opened");
   });
 
   it("should register drawer in its modal state", async () => {
-    const entry = await drawer.register(await drawer.createEntry("drawer-3"));
+    const entry = await drawers.register(await drawers.createEntry("drawer-3"));
     expect(entry.mode).toBe("modal");
     expect(entry.state).toBe("closed");
   });
 
   it("should deregister drawer using entry api", async () => {
-    expect(drawer.collection.length).toBe(3);
-    const entry = await drawer.register(await drawer.createEntry("drawer-3"));
+    expect(drawers.collection.length).toBe(3);
+    const entry = await drawers.register(await drawers.createEntry("drawer-3"));
     await entry.deregister();
-    expect(drawer.collection.length).toBe(2);
+    expect(drawers.collection.length).toBe(2);
   });
 
   it("should use the root drawer element as dialog if selector returned null", async () => {
-    const entry = drawer.register(await drawer.createEntry("drawer-5"));
+    const entry = drawers.register(await drawers.createEntry("drawer-5"));
     expect(entry.el).toBe(entry.dialog);
   });
 });

--- a/packages/drawer/tests/handlers.test.js
+++ b/packages/drawer/tests/handlers.test.js
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import Drawer from "../index";
+import { DrawerCollection } from "../index";
 
 vi.useFakeTimers();
 
@@ -37,9 +37,9 @@ const btnCloseEmpty = document.querySelector(".empty");
 document.body.style.setProperty("--vb-prefix", "vb-");
 drawerEl.style.setProperty("--vb-drawer-transition-duration", "0.3s");
 
-const drawer = new Drawer();
-await drawer.mount();
-const entry = drawer.get("drawer");
+const drawers = new DrawerCollection();
+await drawers.mount();
+const entry = drawers.get("drawer");
 
 test("should open drawer when clicking data-drawer-open button", async () => {
   expect(entry.state).toBe("indeterminate");

--- a/packages/drawer/tests/switchMode.test.js
+++ b/packages/drawer/tests/switchMode.test.js
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import Drawer from "../index";
+import { DrawerCollection } from "../index";
 import { focusTrap, mediaQuery, propStore } from "@vrembem/core";
 import { expect } from "vitest";
 
@@ -51,13 +51,13 @@ function resizeWindow(value, collection) {
   window.dispatchEvent(new Event("resize"));
 }
 
-const drawer = new Drawer({
+const drawers = new DrawerCollection({
   transition: false,
   plugins: [focusTrap(), mediaQuery(), propStore()]
 });
 
 beforeAll(async () => {
-  await drawer.mount();
+  await drawers.mount();
 });
 
 beforeEach(() => {
@@ -66,7 +66,7 @@ beforeEach(() => {
 });
 
 test("should switch drawer to modal when entry.mode property is set to modal", async () => {
-  const entry = drawer.get("drawer-1");
+  const entry = drawers.get("drawer-1");
   expect(entry.el).not.toHaveClass("drawer_modal");
   expect(entry.dialog.getAttribute("aria-modal")).toBe(null);
 
@@ -77,7 +77,7 @@ test("should switch drawer to modal when entry.mode property is set to modal", a
 });
 
 test("should switch drawer to inline when entry.mode property is set to inline", async () => {
-  const entry = drawer.get("drawer-1");
+  const entry = drawers.get("drawer-1");
   expect(entry.el).toHaveClass("drawer_modal");
   expect(entry.dialog.getAttribute("aria-modal")).toBe("true");
 
@@ -88,8 +88,8 @@ test("should switch drawer to inline when entry.mode property is set to inline",
 });
 
 test("should return local store state when switching modes", async () => {
-  const entry = await drawer.register(await drawer.createEntry("drawer-1"));
-  const plugin = drawer.plugins.get("propStore");
+  const entry = await drawers.register(await drawers.createEntry("drawer-1"));
+  const plugin = drawers.plugins.get("propStore");
   await entry.open();
 
   expect(entry.mode).toBe("inline");
@@ -121,7 +121,7 @@ test("should return local store state when switching modes", async () => {
 });
 
 test("should apply indeterminate state when going to inline mode", async () => {
-  const entry = drawer.get("drawer-1");
+  const entry = drawers.get("drawer-1");
   await entry.open();
   entry.state = "indeterminate";
   expect(entry.mode).toBe("inline");
@@ -156,14 +156,14 @@ test("should apply indeterminate state when going to inline mode", async () => {
 });
 
 test("should store inline state when switching to modal", async () => {
-  const entry = drawer.get("drawer-3");
+  const entry = drawers.get("drawer-3");
   expect(entry.mode).toBe("modal");
   expect(entry.state).toBe("closed");
-  expect(drawer.get(entry.id).inlineState).toBe("opened");
+  expect(drawers.get(entry.id).inlineState).toBe("opened");
 });
 
 test("should throw an error when setting mode to an invalid value", async () => {
-  const entry = await drawer.register(await drawer.createEntry("drawer-1"));
+  const entry = await drawers.register(await drawers.createEntry("drawer-1"));
   let result;
   try {
     entry.mode = "asdf";
@@ -174,14 +174,14 @@ test("should throw an error when setting mode to an invalid value", async () => 
 });
 
 test("should setup match media breakpoint for drawer on register", async () => {
-  const entry = drawer.get("drawer-2");
+  const entry = drawers.get("drawer-2");
   expect(entry.mql.media).toBe("(min-width: 600px)");
   expect(entry.mode).toBe("inline");
-  resizeWindow(400, drawer.collection);
+  resizeWindow(400, drawers.collection);
   expect(entry.mode).toBe("modal");
 });
 
 test("should run teardown methods of all plugins when unmounted", async () => {
-  await drawer.unmount();
-  expect(drawer.plugins.length).toBe(0);
+  await drawers.unmount();
+  expect(drawers.plugins.length).toBe(0);
 });

--- a/packages/drawer/tests/teleport.test.js
+++ b/packages/drawer/tests/teleport.test.js
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import Drawer from "../index";
+import { DrawerCollection } from "../index";
 import { teleport } from "@vrembem/core";
 
 document.body.innerHTML = `
@@ -16,7 +16,7 @@ document.body.innerHTML = `
 
 describe("mount()", () => {
   it("should teleport drawers to the provided reference selector using the default method", async () => {
-    const drawer = new Drawer({
+    const drawers = new DrawerCollection({
       plugins: [
         teleport({
           where: ".drawers"
@@ -25,7 +25,7 @@ describe("mount()", () => {
     });
     const div = document.querySelector(".drawers");
     expect(div.children.length).toBe(0);
-    await drawer.mount();
+    await drawers.mount();
     expect(div.children.length).toBe(2);
   });
 });

--- a/packages/drawer/vite.config.js
+++ b/packages/drawer/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
   build: {
     lib: {
       entry: resolve(__dirname, "index.ts"),
-      name: "vrembem.Drawer",
+      name: "vrembem.DrawerCollection",
       fileName: "index"
     },
     emptyOutDir: false,

--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -19,7 +19,7 @@ npm install @vrembem/modal
 ### JavaScript
 
 ```js
-import Modal from '@vrembem/modal';
-const modal = new Modal();
-await modal.mount();
+import { ModalCollection } from '@vrembem/modal';
+const modals = new ModalCollection();
+await modals.mount();
 ```

--- a/packages/modal/index.html
+++ b/packages/modal/index.html
@@ -8,7 +8,7 @@
   <link rel="icon" type="image/svg+xml" href="https://sebnitu.com/icons/vb-favicon.svg">
   <script type="module">
     import "vrembem/sass";
-    import Modal from "./index.ts";
+    import { ModalCollection } from "./index.ts";
     import { focusTrap, propStore, teleport } from "@vrembem/core";
 
     const modals = new Modal({

--- a/packages/modal/index.ts
+++ b/packages/modal/index.ts
@@ -1,3 +1,1 @@
-import { Modal } from "./src/js/Modal";
-
-export default Modal;
+export { ModalCollection } from "./src/js/ModalCollection";

--- a/packages/modal/src/js/ModalCollection.ts
+++ b/packages/modal/src/js/ModalCollection.ts
@@ -8,7 +8,7 @@ import { closeAll } from "./closeAll";
 import { replace } from "./replace";
 import { updateFocusState } from "./helpers/updateFocusState";
 
-export class Modal extends Collection<ModalEntry, ModalConfig> {
+export class ModalCollection extends Collection<ModalEntry, ModalConfig> {
   readonly entryClass = ModalEntry;
   trigger: HTMLElement | null;
   stack: StackArray<ModalEntry>;

--- a/packages/modal/src/js/ModalEntry.ts
+++ b/packages/modal/src/js/ModalEntry.ts
@@ -2,13 +2,13 @@ import { CollectionEntry } from "@vrembem/core";
 import { open } from "./open";
 import { close } from "./close";
 import { replace } from "./replace";
-import type { Modal } from "./Modal";
+import type { ModalCollection } from "./ModalCollection";
 
 export class ModalEntry extends CollectionEntry {
   state: string;
   dialog: HTMLElement;
 
-  constructor(parent: Modal, query: string | HTMLElement) {
+  constructor(parent: ModalCollection, query: string | HTMLElement) {
     super(parent, query);
 
     // Set the initial state

--- a/packages/modal/src/js/closeAll.ts
+++ b/packages/modal/src/js/closeAll.ts
@@ -1,9 +1,9 @@
 import { close } from "./close";
-import type { Modal } from "./Modal";
+import type { ModalCollection } from "./ModalCollection";
 import type { ModalEntry } from "./ModalEntry";
 
 export async function closeAll(
-  parent: Modal,
+  parent: ModalCollection,
   exclude: string = "",
   transition?: boolean
 ): Promise<ModalEntry[]> {

--- a/packages/modal/src/js/config.ts
+++ b/packages/modal/src/js/config.ts
@@ -23,7 +23,7 @@ export const config = {
   selectorDialog: ".modal__dialog",
 
   // A valid CSS selector for the element that should be treated as the modal
-  // backdrop. Clicking the backdrop closes the modal.
+  // backdrop. Clicking the backdrop closes the modals.
   // @type string
   selectorBackdrop: ".modal",
 

--- a/packages/modal/src/js/handlers.ts
+++ b/packages/modal/src/js/handlers.ts
@@ -1,8 +1,8 @@
-import type { Modal } from "./Modal";
+import type { ModalCollection } from "./ModalCollection";
 import type { ModalEntry } from "./ModalEntry";
 
 export async function handleClick(
-  this: Modal,
+  this: ModalCollection,
   event: MouseEvent
 ): Promise<
   | ModalEntry
@@ -75,7 +75,7 @@ export async function handleClick(
 }
 
 export function handleKeydown(
-  this: Modal,
+  this: ModalCollection,
   event: KeyboardEvent
 ): Promise<ModalEntry | undefined> | void {
   // If escape key was pressed

--- a/packages/modal/src/js/helpers/updateFocusState.ts
+++ b/packages/modal/src/js/helpers/updateFocusState.ts
@@ -1,6 +1,6 @@
-import type { Modal } from "../Modal";
+import type { ModalCollection } from "../ModalCollection";
 
-export function updateFocusState(parent: Modal): void {
+export function updateFocusState(parent: ModalCollection): void {
   // Check if there's an active modal
   if (parent.active) {
     const el =

--- a/packages/modal/tests/api.test.js
+++ b/packages/modal/tests/api.test.js
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import Modal from "../index";
+import { ModalCollection } from "../index";
 
 const markup = `
   <main>
@@ -40,27 +40,27 @@ const markupPreOpened = `
 `;
 
 describe("mount() & unmount()", () => {
-  let modal, entry, el, btnOpen;
+  let modals, entry, el, btnOpen;
 
   beforeAll(() => {
     document.body.innerHTML = markup;
-    modal = new Modal();
+    modals = new ModalCollection();
     el = document.querySelector("#modal-default");
     btnOpen = document.querySelector("[data-modal-open]");
   });
 
   it("should mount the modal instance", async () => {
-    modal.updateConfig({ transition: false });
-    await modal.mount();
-    entry = modal.get("modal-default");
+    modals.updateConfig({ transition: false });
+    await modals.mount();
+    entry = modals.get("modal-default");
     btnOpen.click();
     expect(entry.state).toBe("opened");
     expect(entry.el).toHaveClass("is-opened");
   });
 
   it("should unmount the modal instance", async () => {
-    await modal.unmount();
-    expect(modal.collection.length).toBe(0);
+    await modals.unmount();
+    expect(modals.collection.length).toBe(0);
     expect(el).toHaveClass("is-closed");
     btnOpen.click();
     expect(el).toHaveClass("is-closed");
@@ -68,30 +68,30 @@ describe("mount() & unmount()", () => {
 });
 
 describe("register() & deregister()", () => {
-  let modal, entry;
+  let modals, entry;
 
   beforeAll(() => {
     document.body.innerHTML = markup;
-    modal = new Modal({
+    modals = new ModalCollection({
       teleport: ".modals"
     });
   });
 
   it("should register modal in the collection", async () => {
-    expect(modal.collection.length).toBe(0);
-    const result = await modal.register(
-      await modal.createEntry("modal-default")
+    expect(modals.collection.length).toBe(0);
+    const result = await modals.register(
+      await modals.createEntry("modal-default")
     );
-    expect(modal.collection.length).toBe(1);
+    expect(modals.collection.length).toBe(1);
 
-    entry = modal.get("modal-default");
+    entry = modals.get("modal-default");
     expect(result).toBe(entry);
     expect(entry.id).toBe("modal-default");
     expect(entry.state).toBe("closed");
   });
 
   it("should reject promise with error if register is called on non-existent modal", async () => {
-    const result = await modal.createEntry("asdf").catch((error) => {
+    const result = await modals.createEntry("asdf").catch((error) => {
       return error.message;
     });
     expect(result).toBe('Element not found with ID: "asdf"');
@@ -100,48 +100,48 @@ describe("register() & deregister()", () => {
   it("should open and update global state if modal already has opened class", async () => {
     document.body.innerHTML = markupPreOpened;
     const main = document.querySelector("main");
-    modal = new Modal({
+    modals = new ModalCollection({
       selectorInert: "main",
       selectorOverflow: "body, main",
       teleport: ".modals"
     });
-    await modal.mount();
+    await modals.mount();
     expect(document.body.style.overflow).toBe("hidden");
     expect(main.inert).toBe(true);
     expect(main.style.overflow).toBe("hidden");
-    expect(modal.get("modal-default").state).toBe("opened");
+    expect(modals.get("modal-default").state).toBe("opened");
   });
 
   it("re-registering a modal that is already open should retain the open state", async () => {
     document.body.innerHTML = markupPreOpened;
-    modal = new Modal({ teleport: ".modals" });
-    await modal.mount();
-    await modal.open("modal-default");
-    expect(modal.active.id).toBe("modal-default");
-    await modal.register(await modal.createEntry("modal-default"));
-    expect(modal.active.id).toBe("modal-default");
+    modals = new ModalCollection({ teleport: ".modals" });
+    await modals.mount();
+    await modals.open("modal-default");
+    expect(modals.active.id).toBe("modal-default");
+    await modals.register(await modals.createEntry("modal-default"));
+    expect(modals.active.id).toBe("modal-default");
   });
 
   it("should use the root modal element as dialog if selector returned null", async () => {
     document.body.innerHTML = markupMulti;
-    modal = new Modal();
-    const entry = await modal.register(await modal.createEntry("modal-4"));
+    modals = new ModalCollection();
+    const entry = await modals.register(await modals.createEntry("modal-4"));
     expect(entry.el).toBe(entry.dialog);
   });
 });
 
 describe("open() & close()", () => {
-  let modal, el, entry;
+  let modals, el, entry;
 
   beforeAll(async () => {
     document.body.innerHTML = markup;
     document
       .querySelector("#modal-default")
       .style.setProperty("--modal-transition-duration", "0.3s");
-    modal = new Modal();
-    await modal.mount();
+    modals = new ModalCollection();
+    await modals.mount();
     el = document.querySelector(".modal");
-    entry = modal.get("modal-default");
+    entry = modals.get("modal-default");
   });
 
   beforeEach(() => {
@@ -152,7 +152,7 @@ describe("open() & close()", () => {
     expect(el).toHaveClass("modal is-closed");
     expect(entry.state).toBe("closed");
 
-    modal.open("modal-default");
+    modals.open("modal-default");
     await vi.runAllTimers();
 
     expect(el).toHaveClass("modal is-opened");
@@ -163,7 +163,7 @@ describe("open() & close()", () => {
     expect(el).toHaveClass("modal is-opened");
     expect(entry.state).toBe("opened");
 
-    modal.open("modal-default");
+    modals.open("modal-default");
     await vi.runAllTimers();
 
     expect(el).toHaveClass("modal is-opened");
@@ -174,7 +174,7 @@ describe("open() & close()", () => {
     expect(el).toHaveClass("modal is-opened");
     expect(entry.state).toBe("opened");
 
-    modal.close();
+    modals.close();
     await vi.runAllTimers();
 
     expect(el).toHaveClass("modal is-closed");
@@ -185,7 +185,7 @@ describe("open() & close()", () => {
     expect(el).toHaveClass("modal is-closed");
     expect(entry.state).toBe("closed");
 
-    modal.close("modal-default");
+    modals.close("modal-default");
     await vi.runAllTimers();
 
     expect(el).toHaveClass("modal is-closed");
@@ -193,12 +193,12 @@ describe("open() & close()", () => {
   });
 
   it("should open and close modal with transitions option passed", async () => {
-    await modal.open("modal-default", false);
+    await modals.open("modal-default", false);
 
     expect(el).toHaveClass("modal is-opened");
     expect(entry.state).toBe("opened");
 
-    await modal.close("modal-default", false);
+    await modals.close("modal-default", false);
 
     expect(el).toHaveClass("modal is-closed");
     expect(entry.state).toBe("closed");
@@ -206,7 +206,7 @@ describe("open() & close()", () => {
 
   it("should reject promise with error if open is called on non-existent modal", async () => {
     let result;
-    await modal.open("asdf").catch((error) => {
+    await modals.open("asdf").catch((error) => {
       result = error.message;
     });
     expect(result).toBe(
@@ -216,7 +216,7 @@ describe("open() & close()", () => {
 
   it("should reject promise with error if close is called on non-existent modal", async () => {
     let result;
-    await modal.close("asdf").catch((error) => {
+    await modals.close("asdf").catch((error) => {
       result = error.message;
     });
     expect(result).toBe(
@@ -235,79 +235,79 @@ describe("replace()", () => {
   });
 
   it("should close a modal and open a new one simultaneously", async () => {
-    const modal = new Modal();
-    await modal.mount();
+    const modals = new ModalCollection();
+    await modals.mount();
 
-    let entry = modal.get("modal-1");
+    let entry = modals.get("modal-1");
 
-    modal.open("modal-1");
+    modals.open("modal-1");
     expect(entry.el).toHaveClass("is-opening");
     expect(entry.state).toBe("opening");
     await vi.runAllTimers();
     expect(entry.el).toHaveClass("is-opened");
     expect(entry.state).toBe("opened");
 
-    modal.replace("modal-2");
+    modals.replace("modal-2");
     await vi.runAllTimers();
 
     expect(entry.el).toHaveClass("is-closed");
     expect(entry.state).toBe("closed");
 
-    entry = modal.get("modal-2");
+    entry = modals.get("modal-2");
     await vi.runAllTimers();
     expect(entry.el).toHaveClass("is-opened");
     expect(entry.state).toBe("opened");
   });
 
   it("should close all open modals except for the replacement", async () => {
-    const modal = new Modal();
-    await modal.mount();
+    const modals = new ModalCollection();
+    await modals.mount();
 
-    modal.open("modal-1");
-    modal.open("modal-2");
-    modal.open("modal-3");
-    modal.open("modal-4");
+    modals.open("modal-1");
+    modals.open("modal-2");
+    modals.open("modal-3");
+    modals.open("modal-4");
 
     await Promise.all(
-      modal.collection.map(async () => {
+      modals.collection.map(async () => {
         await vi.runAllTimers();
       })
     );
 
-    expect(modal.stack.length).toBe(4);
-    expect(modal.get("modal-1").state).toBe("opened");
-    expect(modal.get("modal-2").state).toBe("opened");
-    expect(modal.get("modal-3").state).toBe("opened");
-    expect(modal.get("modal-4").state).toBe("opened");
+    expect(modals.stack.length).toBe(4);
+    expect(modals.get("modal-1").state).toBe("opened");
+    expect(modals.get("modal-2").state).toBe("opened");
+    expect(modals.get("modal-3").state).toBe("opened");
+    expect(modals.get("modal-4").state).toBe("opened");
 
-    modal.replace("modal-2");
+    modals.replace("modal-2");
 
     await Promise.all(
-      modal.collection.map(async () => {
+      modals.collection.map(async () => {
         await vi.runAllTimers();
       })
     );
 
-    expect(modal.stack.length).toBe(1);
-    expect(modal.get("modal-1").state).toBe("closed");
-    expect(modal.get("modal-2").state).toBe("opened");
-    expect(modal.get("modal-3").state).toBe("closed");
-    expect(modal.get("modal-4").state).toBe("closed");
+    expect(modals.stack.length).toBe(1);
+    expect(modals.get("modal-1").state).toBe("closed");
+    expect(modals.get("modal-2").state).toBe("opened");
+    expect(modals.get("modal-3").state).toBe("closed");
+    expect(modals.get("modal-4").state).toBe("closed");
   });
 
   it("should correctly handle focus management when focus param is passed", async () => {
-    const modal = new Modal({ transition: false });
-    await modal.mount();
-    await modal.open("modal-1");
-    expect(document.activeElement).toBe(modal.get("modal-1").dialog);
-    await modal.replace("modal-2");
-    expect(document.activeElement).toBe(modal.get("modal-2").dialog);
+    const modals = new ModalCollection({ transition: false });
+    await modals.mount();
+    await modals.open("modal-1");
+    expect(document.activeElement).toBe(modals.get("modal-1").dialog);
+    await modals.replace("modal-2");
+    expect(document.activeElement).toBe(modals.get("modal-2").dialog);
   });
 
   it("should reject promise with error if replace is called on non-existent modal", async () => {
-    const modal = new Modal();
+    const modals = new ModalCollection();
     let result;
-    await modal.replace("asdf").catch((error) => {
+    await modals.replace("asdf").catch((error) => {
       result = error.message;
     });
     expect(result).toBe(
@@ -326,79 +326,79 @@ describe("closeAll()", () => {
   });
 
   it("should close all open modals", async () => {
-    const modal = new Modal();
-    await modal.mount();
+    const modals = new ModalCollection();
+    await modals.mount();
 
-    modal.open("modal-1");
-    modal.open("modal-2");
-    modal.open("modal-3");
-    modal.open("modal-4");
+    modals.open("modal-1");
+    modals.open("modal-2");
+    modals.open("modal-3");
+    modals.open("modal-4");
 
-    modal.collection.map(async (entry) => {
+    modals.collection.map(async (entry) => {
       expect(entry.el).toHaveClass("is-opening");
       expect(entry.state).toBe("opening");
     });
 
     await vi.runAllTimers();
 
-    modal.collection.map(async (entry) => {
+    modals.collection.map(async (entry) => {
       expect(entry.el).toHaveClass("is-opened");
       expect(entry.state).toBe("opened");
     });
 
-    modal.closeAll();
+    modals.closeAll();
 
-    modal.collection.map(async (entry) => {
+    modals.collection.map(async (entry) => {
       expect(entry.el).toHaveClass("is-closing");
       expect(entry.state).toBe("closing");
     });
 
     await vi.runAllTimers();
 
-    modal.collection.map(async (entry) => {
+    modals.collection.map(async (entry) => {
       expect(entry.el).toHaveClass("is-closed");
       expect(entry.state).toBe("closed");
     });
   });
 
   it("should return focus to stored trigger when all modals are closed", async () => {
-    const modal = new Modal({ transition: false });
-    await modal.mount();
+    const modals = new ModalCollection({ transition: false });
+    await modals.mount();
 
     const btn = document.querySelector("button");
-    modal.trigger = btn;
+    modals.trigger = btn;
 
-    await modal.open("modal-1");
-    await modal.open("modal-2");
-    await modal.open("modal-3");
-    await modal.open("modal-4");
+    await modals.open("modal-1");
+    await modals.open("modal-2");
+    await modals.open("modal-3");
+    await modals.open("modal-4");
 
-    modal.collection.map(async (entry) => {
+    modals.collection.map(async (entry) => {
       expect(entry.state).toBe("opened");
     });
 
-    await modal.closeAll();
+    await modals.closeAll();
 
     expect(document.activeElement).toBe(btn);
   });
 
   it("should not handle focus when param is set to false", async () => {
-    const modal = new Modal({ transition: false });
-    await modal.mount();
+    const modals = new ModalCollection({ transition: false });
+    await modals.mount();
 
     const btn = document.querySelector("button");
-    modal.trigger = btn;
+    modals.trigger = btn;
 
-    await modal.open("modal-1");
-    await modal.open("modal-2");
-    await modal.open("modal-3");
-    await modal.open("modal-4");
+    await modals.open("modal-1");
+    await modals.open("modal-2");
+    await modals.open("modal-3");
+    await modals.open("modal-4");
 
-    modal.collection.map(async (entry) => {
+    modals.collection.map(async (entry) => {
       expect(entry.state).toBe("opened");
     });
 
-    await modal.closeAll("", false, false);
+    await modals.closeAll("", false, false);
 
     expect(document.activeElement).toBe(document.body);
   });

--- a/packages/modal/tests/collection.test.js
+++ b/packages/modal/tests/collection.test.js
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import Modal from "../index";
+import { ModalCollection } from "../index";
 
 const markup = `
   <div id="modal-1" class="modal">
@@ -11,19 +11,19 @@ const markup = `
 `;
 
 describe("register() & entry.deregister()", () => {
-  let modal, entry1, entry2, el1, el2;
+  let modals, entry1, entry2, el1, el2;
 
   beforeAll(() => {
     document.body.innerHTML = markup;
-    modal = new Modal({ transition: false });
+    modals = new ModalCollection({ transition: false });
     el1 = document.querySelector("#modal-1");
     el2 = document.querySelector("#modal-2");
   });
 
   it("should create collection entry when register is called with modal ID", async () => {
-    expect(modal.collection.length).toBe(0);
-    entry1 = await modal.register(await modal.createEntry("modal-1"));
-    expect(modal.collection.length).toBe(1);
+    expect(modals.collection.length).toBe(0);
+    entry1 = await modals.register(await modals.createEntry("modal-1"));
+    expect(modals.collection.length).toBe(1);
     expect(entry1.el).toBe(el1);
   });
 
@@ -34,42 +34,42 @@ describe("register() & entry.deregister()", () => {
   });
 
   it("should register modal without tabindex if setTabindex is disabled", async () => {
-    modal.config.setTabindex = false;
-    entry2 = await modal.register(await modal.createEntry("modal-2"));
+    modals.config.setTabindex = false;
+    entry2 = await modals.register(await modals.createEntry("modal-2"));
     expect(entry1.dialog.getAttribute("tabindex")).toBe("-1");
     expect(entry2.el).toBe(el2);
   });
 
   it("should not be able to register the same modal multiple times", async () => {
-    expect(modal.collection.length).toBe(2);
-    expect(modal.collection[0].id).toBe("modal-1");
-    expect(modal.collection[1].id).toBe("modal-2");
-    await modal.register(await modal.createEntry("modal-1"));
-    expect(modal.collection.length).toBe(2);
-    expect(modal.collection[0].id).toBe("modal-1");
-    expect(modal.collection[1].id).toBe("modal-2");
+    expect(modals.collection.length).toBe(2);
+    expect(modals.collection[0].id).toBe("modal-1");
+    expect(modals.collection[1].id).toBe("modal-2");
+    await modals.register(await modals.createEntry("modal-1"));
+    expect(modals.collection.length).toBe(2);
+    expect(modals.collection[0].id).toBe("modal-1");
+    expect(modals.collection[1].id).toBe("modal-2");
   });
 
   it("should remove entry from collection when entry method deregister is run", async () => {
-    entry1 = modal.get("modal-1");
-    entry2 = modal.get("modal-2");
+    entry1 = modals.get("modal-1");
+    entry2 = modals.get("modal-2");
     await entry1.deregister();
     await entry2.deregister();
-    expect(modal.collection.length).toBe(0);
+    expect(modals.collection.length).toBe(0);
   });
 });
 
 describe("entry.open() & entry.close() & entry.replace()", () => {
-  let modal;
+  let modals;
 
   beforeAll(async () => {
     document.body.innerHTML = markup;
-    modal = new Modal({ transition: false });
-    await modal.mount();
+    modals = new ModalCollection({ transition: false });
+    await modals.mount();
   });
 
   it("should open modal with transitions disabled", async () => {
-    const entry = modal.get("modal-1");
+    const entry = modals.get("modal-1");
     expect(entry.state).toBe("closed");
     expect(entry.el).toHaveClass("is-closed");
     await entry.open();
@@ -78,7 +78,7 @@ describe("entry.open() & entry.close() & entry.replace()", () => {
   });
 
   it("should close modal with transitions disabled", async () => {
-    const entry = modal.get("modal-1");
+    const entry = modals.get("modal-1");
     expect(entry.state).toBe("opened");
     expect(entry.el).toHaveClass("is-opened");
     await entry.close();
@@ -87,8 +87,8 @@ describe("entry.open() & entry.close() & entry.replace()", () => {
   });
 
   it("should replace modal with transitions disabled", async () => {
-    const entry1 = modal.get("modal-1");
-    const entry2 = modal.get("modal-2");
+    const entry1 = modals.get("modal-1");
+    const entry2 = modals.get("modal-2");
 
     await entry1.open();
     expect(entry1.state).toBe("opened");

--- a/packages/modal/tests/focus.test.js
+++ b/packages/modal/tests/focus.test.js
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import userEvent from "@testing-library/user-event";
-import Modal from "../index";
+import { ModalCollection } from "../index";
 
 const markup = `
   <button data-modal-open="modal-one">Modal One</button>
@@ -34,8 +34,8 @@ beforeEach(() => {
 });
 
 test("should focus modal dialog when opened and refocus trigger when closed", async () => {
-  const modal = new Modal();
-  await modal.mount();
+  const modals = new ModalCollection();
+  await modals.mount();
   const el = document.querySelector("#modal-one");
   const dialog = el.querySelector(".modal__dialog");
   const btnOpen = document.querySelector('[data-modal-open="modal-one"]');
@@ -46,8 +46,8 @@ test("should focus modal dialog when opened and refocus trigger when closed", as
 });
 
 test("should focus inner modal element and refocus trigger when closed", async () => {
-  const modal = new Modal();
-  await modal.mount();
+  const modals = new ModalCollection();
+  await modals.mount();
   const el = document.querySelector("#modal-two");
   const btnOpen = document.querySelector('[data-modal-open="modal-two"]');
   const btnClose = el.querySelector("[data-modal-close]");
@@ -62,8 +62,8 @@ test("should focus inner modal element and refocus trigger when closed", async (
 });
 
 test("should remember initial trigger when opening modal through another modal", async () => {
-  const modal = new Modal();
-  await modal.mount();
+  const modals = new ModalCollection();
+  await modals.mount();
   const elOne = document.querySelector("#modal-one");
   const elTwo = document.querySelector("#modal-two");
   const btnOpen = document.querySelector('[data-modal-open="modal-one"]');
@@ -78,17 +78,17 @@ test("should remember initial trigger when opening modal through another modal",
   expect(elOne).toHaveClass("is-opened");
   expect(elTwo).toHaveClass("is-opened");
 
-  await modal.closeAll("", false);
+  await modals.closeAll("", false);
 
   expect(btnOpen).toHaveFocus();
 });
 
 test("should retain focus on modal if nothing inner is focusable", async () => {
-  const modal = new Modal();
-  await modal.mount();
+  const modals = new ModalCollection();
+  await modals.mount();
   const elModal = document.querySelector("#modal-empty");
   const dialog = elModal.querySelector(".modal__dialog");
-  modal.open("modal-empty");
+  modals.open("modal-empty");
   await vi.runAllTimers();
   expect(elModal).toHaveClass("is-opened");
   expect(dialog).toHaveFocus();

--- a/packages/modal/tests/handlers.test.js
+++ b/packages/modal/tests/handlers.test.js
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import Modal from "../index";
+import { ModalCollection } from "../index";
 
 const keyEsc = new KeyboardEvent("keydown", {
   key: "Escape"
@@ -33,13 +33,13 @@ beforeEach(() => {
 
 test("should close when root modal (screen) is clicked", async () => {
   document.body.innerHTML = markup;
-  const modal = new Modal();
-  await modal.mount();
+  const modals = new ModalCollection();
+  await modals.mount();
   const el = document.querySelector(".modal");
   const dialog = document.querySelector(".modal__dialog");
   const btnOpen = document.querySelector("[data-modal-open]");
 
-  expect(modal.get("modal-default").isRequired).toBe(false);
+  expect(modals.get("modal-default").isRequired).toBe(false);
 
   btnOpen.click();
   await vi.runAllTimers();
@@ -58,8 +58,8 @@ test("should close when root modal (screen) is clicked", async () => {
 
 test("should close when the escape key is pressed", async () => {
   document.body.innerHTML = markup;
-  const modal = new Modal();
-  await modal.mount();
+  const modals = new ModalCollection();
+  await modals.mount();
   const el = document.querySelector(".modal");
   const btnOpen = document.querySelector("[data-modal-open]");
 
@@ -79,8 +79,8 @@ test("should close when the escape key is pressed", async () => {
 
 test("should do nothing if none escape key is pressed", async () => {
   document.body.innerHTML = markup;
-  const modal = new Modal();
-  await modal.mount();
+  const modals = new ModalCollection();
+  await modals.mount();
   const el = document.querySelector(".modal");
   const btnOpen = document.querySelector("[data-modal-open]");
 
@@ -100,8 +100,8 @@ test("should do nothing if none escape key is pressed", async () => {
 
 test("should not be able to close while modal transition is in process", async () => {
   document.body.innerHTML = markup;
-  const modal = new Modal();
-  await modal.mount();
+  const modals = new ModalCollection();
+  await modals.mount();
   const el = document.querySelector(".modal");
   const btnOpen = document.querySelector("[data-modal-open]");
 
@@ -118,13 +118,13 @@ test("should not be able to close while modal transition is in process", async (
 
 test("should prevent escape or screen click closing modal if required", async () => {
   document.body.innerHTML = markupReq;
-  const modal = new Modal();
-  await modal.mount();
+  const modals = new ModalCollection();
+  await modals.mount();
   const el = document.querySelector(".modal");
   const btnOpen = document.querySelector("[data-modal-open]");
   const btnClose = el.querySelector("[data-modal-close]");
 
-  expect(modal.get("modal-default").isRequired).toBe(true);
+  expect(modals.get("modal-default").isRequired).toBe(true);
 
   btnOpen.click();
   await vi.runAllTimers();
@@ -146,8 +146,8 @@ test("should prevent escape or screen click closing modal if required", async ()
 
 test("should run the replace method when replace button is clicked", async () => {
   document.body.innerHTML = markup;
-  const modal = new Modal();
-  await modal.mount();
+  const modals = new ModalCollection();
+  await modals.mount();
   const el = document.querySelector(".modal");
   const btnReplace = document.querySelector("[data-modal-replace]");
 

--- a/packages/modal/tests/inert.test.js
+++ b/packages/modal/tests/inert.test.js
@@ -1,4 +1,4 @@
-import Modal from "../index";
+import { ModalCollection } from "../index";
 
 document.body.innerHTML = `
   <main>
@@ -12,7 +12,7 @@ document.body.innerHTML = `
 `;
 
 const main = document.querySelector("main");
-const modal = new Modal({
+const modals = new ModalCollection({
   selectorInert: "main"
 });
 
@@ -20,7 +20,7 @@ describe("when selectorInert is set:", () => {
   vi.useFakeTimers();
 
   beforeAll(async () => {
-    await modal.mount();
+    await modals.mount();
   });
 
   it("should properly hide content when modal is opened", async () => {

--- a/packages/modal/tests/stack.test.js
+++ b/packages/modal/tests/stack.test.js
@@ -1,8 +1,8 @@
 import "@testing-library/jest-dom/vitest";
 import "./mocks/getComputedStyle.mock";
-import Modal from "../index";
+import { ModalCollection } from "../index";
 
-let modal, modal1, modal2, modal3, btn1, btn2, btn3, btn4, btnCloseAll;
+let modals, modal1, modal2, modal3, btn1, btn2, btn3, btn4, btnCloseAll;
 
 document.body.innerHTML = `
   <button data-modal-open="modal-1">...</button>
@@ -25,12 +25,12 @@ document.body.innerHTML = `
 `;
 
 beforeAll(async () => {
-  modal = new Modal({ transition: false });
-  await modal.mount();
+  modals = new ModalCollection({ transition: false });
+  await modals.mount();
 
-  modal1 = modal.get("modal-1");
-  modal2 = modal.get("modal-2");
-  modal3 = modal.get("modal-3");
+  modal1 = modals.get("modal-1");
+  modal2 = modals.get("modal-2");
+  modal3 = modals.get("modal-3");
 
   btn1 = document.querySelector('[data-modal-open="modal-1"]');
   btn2 = document.querySelector('[data-modal-open="modal-2"]');
@@ -40,14 +40,14 @@ beforeAll(async () => {
 });
 
 test("should allow opening multiple modals at once", async () => {
-  expect(modal.collection.length).toBe(3);
-  expect(modal.stack.length).toBe(0);
+  expect(modals.collection.length).toBe(3);
+  expect(modals.stack.length).toBe(0);
 
   btn1.click();
   btn2.click();
   btn3.click();
 
-  expect(modal.stack.length).toBe(3);
+  expect(modals.stack.length).toBe(3);
   expect(modal1.state).toBe("opened");
   expect(modal2.state).toBe("opened");
   expect(modal3.state).toBe("opened");
@@ -78,16 +78,16 @@ test("should have set focus to the correct modal dialog when stack order is chan
 test("should close the currently opened modal at the top of the stack", async () => {
   expect(modal2.state).toBe("opened");
 
-  modal.close();
+  modals.close();
 
   expect(modal2.state).toBe("closed");
   expect(document.activeElement).toBe(modal3.dialog);
 });
 
 test("should update the stack array and z-index of remaining active modals", () => {
-  expect(modal.stack.length).toBe(2);
-  expect(modal.stack.get(0)).toBe(modal1);
-  expect(modal.stack.get(1)).toBe(modal3);
+  expect(modals.stack.length).toBe(2);
+  expect(modals.stack.get(0)).toBe(modal1);
+  expect(modals.stack.get(1)).toBe(modal3);
 
   expect(modal1.el.style.zIndex).toBe("1001");
   expect(modal2.el.style.zIndex).toBe("");
@@ -97,13 +97,13 @@ test("should update the stack array and z-index of remaining active modals", () 
 test("should close the currently opened modal and update stack array and z-index styles", async () => {
   expect(modal3.state).toBe("opened");
 
-  modal.close();
+  modals.close();
 
   expect(modal3.state).toBe("closed");
   expect(document.activeElement).toBe(modal1.dialog);
 
-  expect(modal.stack.length).toBe(1);
-  expect(modal.stack.get(0)).toBe(modal1);
+  expect(modals.stack.length).toBe(1);
+  expect(modals.stack.get(0)).toBe(modal1);
 
   expect(modal1.el.style.zIndex).toBe("1001");
   expect(modal2.el.style.zIndex).toBe("");
@@ -113,12 +113,12 @@ test("should close the currently opened modal and update stack array and z-index
 test("should focus root trigger when the last modal in stack is closed", async () => {
   expect(modal1.state).toBe("opened");
 
-  modal.close();
+  modals.close();
 
   expect(modal1.state).toBe("closed");
   expect(document.activeElement).toBe(btn1);
 
-  expect(modal.stack.length).toBe(0);
+  expect(modals.stack.length).toBe(0);
 });
 
 test("should close all open modals when close button with value of * is set", async () => {
@@ -126,14 +126,14 @@ test("should close all open modals when close button with value of * is set", as
   btn2.click();
   btn3.click();
 
-  expect(modal.stack.length).toBe(3);
+  expect(modals.stack.length).toBe(3);
   expect(modal1.state).toBe("opened");
   expect(modal2.state).toBe("opened");
   expect(modal3.state).toBe("opened");
 
   btnCloseAll.click();
 
-  expect(modal.stack.length).toBe(0);
+  expect(modals.stack.length).toBe(0);
   expect(modal1.state).toBe("closed");
   expect(modal2.state).toBe("closed");
   expect(modal3.state).toBe("closed");
@@ -143,14 +143,14 @@ test("should properly replace all modal modals with the trigger modal", async ()
   btn1.click();
   btn2.click();
 
-  expect(modal.stack.length).toBe(2);
+  expect(modals.stack.length).toBe(2);
   expect(modal1.state).toBe("opened");
   expect(modal2.state).toBe("opened");
   expect(modal3.state).toBe("closed");
 
-  await modal.replace("modal-3");
+  await modals.replace("modal-3");
 
-  expect(modal.stack.length).toBe(1);
+  expect(modals.stack.length).toBe(1);
   expect(modal1.state).toBe("closed");
   expect(modal2.state).toBe("closed");
   expect(modal3.state).toBe("opened");

--- a/packages/modal/tests/teleport.test.js
+++ b/packages/modal/tests/teleport.test.js
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import Modal from "../index";
+import { ModalCollection } from "../index";
 import { teleport } from "@vrembem/core";
 
 document.body.innerHTML = `
@@ -16,7 +16,7 @@ document.body.innerHTML = `
 
 describe("mount()", () => {
   it("should teleport modals to the provided reference selector using the default method", async () => {
-    const modal = new Modal({
+    const modals = new ModalCollection({
       plugins: [
         teleport({
           where: ".modals"
@@ -25,7 +25,7 @@ describe("mount()", () => {
     });
     const div = document.querySelector(".modals");
     expect(div.children.length).toBe(0);
-    await modal.mount();
+    await modals.mount();
     expect(div.children.length).toBe(2);
   });
 });

--- a/packages/modal/tests/transition.test.js
+++ b/packages/modal/tests/transition.test.js
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import Modal from "../index";
+import { ModalCollection } from "../index";
 import { attrConfig } from "@vrembem/core";
 
 vi.useFakeTimers();
@@ -31,12 +31,12 @@ const markupConfig = `
 
 test("should apply state classes on `click` and `transitionend` events", async () => {
   document.body.innerHTML = markup;
-  const modal = new Modal();
+  const modals = new ModalCollection();
   const el = document.querySelector(".modal");
   const btnOpen = document.querySelector("[data-modal-open]");
   const btnClose = el.querySelector("[data-modal-close]");
 
-  await modal.mount();
+  await modals.mount();
   expect(el).toHaveClass("modal");
 
   btnOpen.click();
@@ -55,13 +55,13 @@ test("should apply state classes on `click` and `transitionend` events", async (
 
 test("should apply custom state classes", async () => {
   document.body.innerHTML = markupCustomState;
-  const modal = new Modal({
+  const modals = new ModalCollection({
     stateOpened: "on",
     stateOpening: "enable",
     stateClosing: "disable",
     stateClosed: "off"
   });
-  await modal.mount();
+  await modals.mount();
   const el = document.querySelector(".modal");
   const btnOpen = document.querySelector("[data-modal-open]");
   const btnClose = el.querySelector("[data-modal-close]");
@@ -83,25 +83,25 @@ test("should apply custom state classes", async () => {
 test("should not apply transition classes when transitions are disabled", async () => {
   document.body.innerHTML = markup;
   const el = document.querySelector(".modal");
-  const modal = new Modal({ transition: false });
-  await modal.mount();
-  await modal.open("modal-default");
+  const modals = new ModalCollection({ transition: false });
+  await modals.mount();
+  await modals.open("modal-default");
   expect(el).toHaveClass("is-opened");
   expect(el.classList.length).toBe(2);
 
-  await modal.close("modal-default");
+  await modals.close("modal-default");
   expect(el).toHaveClass("is-closed");
   expect(el.classList.length).toBe(2);
 });
 
 test("should open and close modal while using the data modal config attribute", async () => {
   document.body.innerHTML = markupConfig;
-  const modal = new Modal({
+  const modals = new ModalCollection({
     plugins: [attrConfig()]
   });
-  await modal.mount();
+  await modals.mount();
 
-  const entry = modal.get("modal-default");
+  const entry = modals.get("modal-default");
   await entry.open();
   expect(entry.el).toHaveClass("is-opened");
   expect(entry.state).toBe("opened");
@@ -113,12 +113,12 @@ test("should open and close modal while using the data modal config attribute", 
 
 test("should return modal config if set, otherwise should return global config", async () => {
   document.body.innerHTML = markupConfig;
-  const modal = new Modal({
+  const modals = new ModalCollection({
     plugins: [attrConfig()]
   });
-  await modal.mount();
+  await modals.mount();
 
-  const entry = modal.get("modal-default");
+  const entry = modals.get("modal-default");
   expect(entry.config.get("transition")).toBe(false);
-  expect(modal.config.transition).toBe(true);
+  expect(modals.config.transition).toBe(true);
 });

--- a/packages/modal/vite.config.js
+++ b/packages/modal/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
   build: {
     lib: {
       entry: resolve(__dirname, "index.ts"),
-      name: "vrembem.Modal",
+      name: "vrembem.ModalCollection",
       fileName: "index"
     },
     emptyOutDir: false,

--- a/packages/popover/README.md
+++ b/packages/popover/README.md
@@ -19,7 +19,7 @@ npm install @vrembem/popover
 ### JavaScript
 
 ```js
-import Popover from '@vrembem/popover';
-const popover = new Popover();
-await popover.mount();
+import { PopoverCollection } from '@vrembem/popover';
+const popovers = new PopoverCollection();
+await popovers.mount();
 ```

--- a/packages/popover/index.html
+++ b/packages/popover/index.html
@@ -8,10 +8,10 @@
   <link rel="icon" type="image/svg+xml" href="https://sebnitu.com/icons/vb-favicon.svg">
   <script type="module">
     import "vrembem/sass";
-    import Popover from "./index.ts";
+    import { PopoverCollection } from "./index.ts";
     import { teleport, cssConfig, attrConfig } from "@vrembem/core";
 
-    const popovers = new Popover({
+    const popovers = new PopoverCollection({
       plugins: [
         cssConfig(),
         attrConfig(),
@@ -69,7 +69,7 @@
         class="popover popover_tooltip"
         style="--vb-popover-event: click; --vb-popover-follow-cursor: true;"
       >
-        Virtual popover...
+        Virtual popovers...
       </div>
 
       <h2 id="popover_size_value"><a href="#popover_size_value">popover_size_[value]</a></h2>
@@ -219,7 +219,7 @@
       <button class="button" aria-controls="popover-multi-1" aria-describedby="popover-multi-2">Multi Popover</button>
 
       <div id="popover-multi-1" class="popover">
-        <div class="padding">Multi popover...</div>
+        <div class="padding">Multi popovers...</div>
       </div>
 
       <div id="popover-multi-2" class="popover popover_tooltip">

--- a/packages/popover/index.ts
+++ b/packages/popover/index.ts
@@ -1,3 +1,1 @@
-import { Popover } from "./src/js/Popover";
-
-export default Popover;
+export { PopoverCollection } from "./src/js/PopoverCollection";

--- a/packages/popover/src/js/PopoverCollection.ts
+++ b/packages/popover/src/js/PopoverCollection.ts
@@ -5,7 +5,7 @@ import { handleKeydown, handleMousemove } from "./handlers";
 import { open } from "./open";
 import { close, closeAll } from "./close";
 
-export class Popover extends Collection<PopoverEntry, PopoverConfig> {
+export class PopoverCollection extends Collection<PopoverEntry, PopoverConfig> {
   readonly entryClass = PopoverEntry;
   trigger: HTMLElement | null = null;
 

--- a/packages/popover/src/js/PopoverEntry.ts
+++ b/packages/popover/src/js/PopoverEntry.ts
@@ -5,13 +5,13 @@ import {
   registerEventListeners,
   deregisterEventListeners
 } from "./eventListeners";
-import type { Popover } from "./Popover";
+import type { PopoverCollection } from "./PopoverCollection";
 
 export class PopoverEntry extends CollectionEntry {
   state: "closed" | "opened" = "closed";
   trigger: HTMLElement | null = null;
 
-  constructor(parent: Popover, query: string | HTMLElement) {
+  constructor(parent: PopoverCollection, query: string | HTMLElement) {
     super(parent, query);
 
     // Set the initial state of private store

--- a/packages/popover/src/js/close.ts
+++ b/packages/popover/src/js/close.ts
@@ -1,5 +1,5 @@
 import { _ } from "@vrembem/core";
-import type { Popover } from "./Popover";
+import type { PopoverCollection } from "./PopoverCollection";
 import type { PopoverEntry } from "./PopoverEntry";
 
 export async function close(entry: PopoverEntry): Promise<PopoverEntry> {
@@ -33,7 +33,9 @@ export async function close(entry: PopoverEntry): Promise<PopoverEntry> {
   return entry;
 }
 
-export async function closeAll(parent: Popover): Promise<PopoverEntry[]> {
+export async function closeAll(
+  parent: PopoverCollection
+): Promise<PopoverEntry[]> {
   const result: PopoverEntry[] = [];
   for (const entry of parent.collection) {
     if (entry.state === "opened") {

--- a/packages/popover/src/js/handlers.ts
+++ b/packages/popover/src/js/handlers.ts
@@ -1,10 +1,13 @@
 import { _ } from "@vrembem/core";
 import { getDelay, setHovered } from "./helpers";
 import { closeAll, closeCheck } from "./close";
-import type { Popover } from "./Popover";
+import type { PopoverCollection } from "./PopoverCollection";
 import type { PopoverEntry } from "./PopoverEntry";
 
-function setCursorElement(parent: Popover, { clientX, clientY }: MouseEvent) {
+function setCursorElement(
+  parent: PopoverCollection,
+  { clientX, clientY }: MouseEvent
+) {
   _(parent).cursorElement = {
     getBoundingClientRect() {
       return {
@@ -22,7 +25,7 @@ function setCursorElement(parent: Popover, { clientX, clientY }: MouseEvent) {
 }
 
 export function handleClick(
-  this: Popover,
+  this: PopoverCollection,
   popover: PopoverEntry,
   event: MouseEvent | Event
 ) {
@@ -46,12 +49,12 @@ export function handleTooltipClick(popover: PopoverEntry) {
   }
 }
 
-export function handleMousemove(this: Popover, event: MouseEvent) {
+export function handleMousemove(this: PopoverCollection, event: MouseEvent) {
   setCursorElement(this, event);
 }
 
 export function handleMouseEnter(
-  this: Popover,
+  this: PopoverCollection,
   popover: PopoverEntry,
   event: Event
 ) {
@@ -117,7 +120,7 @@ export function handleMouseLeave(popover: PopoverEntry, event: Event) {
   }, 1);
 }
 
-export function handleKeydown(this: Popover, event: KeyboardEvent) {
+export function handleKeydown(this: PopoverCollection, event: KeyboardEvent) {
   switch (event.key) {
     case "Escape":
       if (this.trigger) {
@@ -137,7 +140,10 @@ export function handleKeydown(this: Popover, event: KeyboardEvent) {
   }
 }
 
-export function handleDocumentClick(this: Popover, popover: PopoverEntry) {
+export function handleDocumentClick(
+  this: PopoverCollection,
+  popover: PopoverEntry
+) {
   document.addEventListener("click", function _f(event) {
     // Guard if event target property is null
     const target = event.target as HTMLElement | null;

--- a/packages/popover/src/js/helpers/getPopoverElements.ts
+++ b/packages/popover/src/js/helpers/getPopoverElements.ts
@@ -1,8 +1,8 @@
 import { getPopoverID } from "./getPopoverID";
-import type { Popover } from "../Popover";
+import type { PopoverCollection } from "../PopoverCollection";
 
 export function getPopoverElements(
-  this: Popover,
+  this: PopoverCollection,
   query: string | HTMLElement
 ): {
   popover: HTMLElement;

--- a/packages/popover/src/js/helpers/getPopoverID.ts
+++ b/packages/popover/src/js/helpers/getPopoverID.ts
@@ -1,7 +1,7 @@
-import type { Popover } from "../Popover";
+import type { PopoverCollection } from "../PopoverCollection";
 
 export function getPopoverID(
-  this: Popover,
+  this: PopoverCollection,
   obj: string | HTMLElement
 ): string | null {
   // If it's a string, return the string

--- a/packages/popover/tests/api.test.js
+++ b/packages/popover/tests/api.test.js
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import Popover from "../index";
+import { PopoverCollection } from "../index";
 
 vi.useFakeTimers();
 
@@ -15,39 +15,39 @@ const markup = `
 describe("mount() & unmount()", () => {
   it("should mount the popover module when mount is run", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
-    expect(popover.collection.length).toBe(3);
+    const popovers = new PopoverCollection();
+    await popovers.mount();
+    expect(popovers.collection.length).toBe(3);
   });
 
   it("running mount multiple times should not create duplicates in collection", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
-    await popover.mount();
-    expect(popover.collection.length).toBe(3);
+    const popovers = new PopoverCollection();
+    await popovers.mount();
+    await popovers.mount();
+    expect(popovers.collection.length).toBe(3);
   });
 
   it("should be able to pass options through updateConfig method", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover({ selector: ".asdf" });
-    expect(popover.config.selector).toBe(".asdf");
-    popover.updateConfig({ selector: ".popover" });
-    await popover.mount();
-    expect(popover.config.selector).toBe(".popover");
+    const popovers = new PopoverCollection({ selector: ".asdf" });
+    expect(popovers.config.selector).toBe(".asdf");
+    popovers.updateConfig({ selector: ".popover" });
+    await popovers.mount();
+    expect(popovers.config.selector).toBe(".popover");
   });
 
   it("should remove all event listeners and clear collection", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
+    const popovers = new PopoverCollection();
+    await popovers.mount();
 
     const trigger = document.querySelector("button");
     const target = document.querySelector(".popover");
 
-    expect(popover.collection.length).toBe(3);
-    await popover.unmount();
-    expect(popover.collection.length).toBe(0);
+    expect(popovers.collection.length).toBe(3);
+    await popovers.unmount();
+    expect(popovers.collection.length).toBe(0);
     trigger.click();
     vi.advanceTimersByTime(500);
     expect(target).not.toHaveClass("is-active");
@@ -55,11 +55,11 @@ describe("mount() & unmount()", () => {
 
   it("should close open popovers when before being unmounted", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
-    const entry = await popover.get("asdf");
+    const popovers = new PopoverCollection();
+    await popovers.mount();
+    const entry = await popovers.get("asdf");
     await entry.open();
-    await popover.unmount();
+    await popovers.unmount();
     const el = document.getElementById("asdf");
     expect(el).not.toHaveClass("is-active");
   });
@@ -68,72 +68,72 @@ describe("mount() & unmount()", () => {
 describe("register() & deregister()", () => {
   it("should be able to manually register a popover", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
+    const popovers = new PopoverCollection();
 
-    expect(popover.collection.length).toBe(0);
+    expect(popovers.collection.length).toBe(0);
 
     const el = document.querySelector(".popover");
     const trigger = document.querySelector("button");
 
-    await popover.register(await popover.createEntry(el));
-    expect(popover.collection.length).toBe(1);
-    expect(popover.collection[0].el).toBe(el);
-    expect(popover.collection[0].trigger).toBe(trigger);
+    await popovers.register(await popovers.createEntry(el));
+    expect(popovers.collection.length).toBe(1);
+    expect(popovers.collection[0].el).toBe(el);
+    expect(popovers.collection[0].trigger).toBe(trigger);
   });
 
   it("should be able to manually deregister a popover", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
+    const popovers = new PopoverCollection();
+    await popovers.mount();
 
-    expect(popover.collection.length).toBe(3);
-    await popover.deregister(popover.collection[0]);
-    expect(popover.collection.length).toBe(2);
+    expect(popovers.collection.length).toBe(3);
+    await popovers.deregister(popovers.collection[0]);
+    expect(popovers.collection.length).toBe(2);
   });
 });
 
 describe("open() & close()", () => {
   it("should open the provided popover", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
+    const popovers = new PopoverCollection();
+    await popovers.mount();
 
     const target = document.querySelector(".popover");
 
     expect(target).not.toHaveClass("is-active");
-    await popover.open(popover.collection[0].id);
+    await popovers.open(popovers.collection[0].id);
     expect(target).toHaveClass("is-active");
   });
 
   it("should close the provided popover", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
+    const popovers = new PopoverCollection();
+    await popovers.mount();
 
     const target = document.querySelector(".popover");
 
-    await popover.open(popover.collection[0].id);
-    await popover.close(popover.collection[0].id);
+    await popovers.open(popovers.collection[0].id);
+    await popovers.close(popovers.collection[0].id);
     expect(target).not.toHaveClass("is-active");
   });
 
   it("should close all popovers", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
+    const popovers = new PopoverCollection();
+    await popovers.mount();
 
-    for (const item of popover.collection) {
-      await popover.open(item.id);
+    for (const item of popovers.collection) {
+      await popovers.open(item.id);
     }
 
-    for (const item of popover.collection) {
+    for (const item of popovers.collection) {
       expect(item.state).toBe("opened");
       expect(item.el).toHaveClass("is-active");
     }
 
-    await popover.close();
+    await popovers.close();
 
-    for (const item of popover.collection) {
+    for (const item of popovers.collection) {
       expect(item.state).toBe("closed");
       expect(item.el).not.toHaveClass("is-active");
     }
@@ -141,11 +141,11 @@ describe("open() & close()", () => {
 
   it("should reject promise with error when open is run on popover it could not find", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
+    const popovers = new PopoverCollection();
+    await popovers.mount();
 
     let catchError = false;
-    await popover.open("missing").catch((error) => {
+    await popovers.open("missing").catch((error) => {
       expect(error.message).toBe(
         'Popover entry not found in collection with id of "missing"'
       );
@@ -156,11 +156,11 @@ describe("open() & close()", () => {
 
   it("should reject promise with error when close is run on popover it could not find", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
+    const popovers = new PopoverCollection();
+    await popovers.mount();
 
     let catchError = false;
-    await popover.close("missing").catch((error) => {
+    await popovers.close("missing").catch((error) => {
       expect(error.message).toBe(
         'Popover entry not found in collection with id of "missing"'
       );
@@ -171,21 +171,21 @@ describe("open() & close()", () => {
 });
 
 describe("active() & activeHover()", () => {
-  it("should return the active popover when popover.active is called", async () => {
+  it("should return the active popover when popovers.active is called", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
-    expect(popover.active).toBe(undefined);
-    await popover.get("asdf").open();
-    expect(popover.active).toBe(popover.get("asdf"));
+    const popovers = new PopoverCollection();
+    await popovers.mount();
+    expect(popovers.active).toBe(undefined);
+    await popovers.get("asdf").open();
+    expect(popovers.active).toBe(popovers.get("asdf"));
   });
 
-  it("should return the active tooltip popover when popover.activeHover is called", async () => {
+  it("should return the active tooltip popover when popovers.activeHover is called", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
-    expect(popover.activeHover).toBe(undefined);
-    await popover.get("tooltip").open();
-    expect(popover.activeHover).toBe(popover.get("tooltip"));
+    const popovers = new PopoverCollection();
+    await popovers.mount();
+    expect(popovers.activeHover).toBe(undefined);
+    await popovers.get("tooltip").open();
+    expect(popovers.activeHover).toBe(popovers.get("tooltip"));
   });
 });

--- a/packages/popover/tests/close.test.js
+++ b/packages/popover/tests/close.test.js
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import Popover from "../index";
+import { PopoverCollection } from "../index";
 import { closeAll, closeCheck } from "../src/js/close";
 
 vi.useFakeTimers();
@@ -16,9 +16,9 @@ const markup = `
 describe("close()", () => {
   it("should close the provided popover", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
-    const entry = popover.get("asdf");
+    const popovers = new PopoverCollection();
+    await popovers.mount();
+    const entry = popovers.get("asdf");
     expect(entry.state).toBe("opened");
     expect(entry.el).toHaveClass("is-active");
     expect(entry.trigger.getAttribute("aria-expanded")).toBe("true");
@@ -30,9 +30,9 @@ describe("close()", () => {
 
   it("should close the provided popover tooltip", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
-    const entry = popover.get("afsd");
+    const popovers = new PopoverCollection();
+    await popovers.mount();
+    const entry = popovers.get("afsd");
     expect(entry.state).toBe("opened");
     expect(entry.el).toHaveClass("is-active");
     expect(entry.trigger.hasAttribute("aria-expanded")).toBe(false);
@@ -46,45 +46,45 @@ describe("close()", () => {
 describe("closeAll()", () => {
   it("should close all popovers", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
-    expect(popover.collection.length).toBe(3);
-    expect(popover.collection[0].el).toHaveClass("is-active");
-    expect(popover.collection[1].el).toHaveClass("is-active");
-    await closeAll(popover);
-    expect(popover.collection[0].el).not.toHaveClass("is-active");
-    expect(popover.collection[1].el).not.toHaveClass("is-active");
+    const popovers = new PopoverCollection();
+    await popovers.mount();
+    expect(popovers.collection.length).toBe(3);
+    expect(popovers.collection[0].el).toHaveClass("is-active");
+    expect(popovers.collection[1].el).toHaveClass("is-active");
+    await closeAll(popovers);
+    expect(popovers.collection[0].el).not.toHaveClass("is-active");
+    expect(popovers.collection[1].el).not.toHaveClass("is-active");
   });
 });
 
 describe("closeCheck()", () => {
   it("should close popover if closeCheck does not detect a hover or focus on trigger or popover elements", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
-    expect(popover.collection.length).toBe(3);
-    closeCheck(popover.collection[0]);
+    const popovers = new PopoverCollection();
+    await popovers.mount();
+    expect(popovers.collection.length).toBe(3);
+    closeCheck(popovers.collection[0]);
     vi.advanceTimersByTime(100);
-    expect(popover.collection[0].el).not.toHaveClass("is-active");
+    expect(popovers.collection[0].el).not.toHaveClass("is-active");
   });
 
   it("should keep popover open if closeCheck detects trigger element is focused", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
-    popover.collection[0].trigger.focus();
-    closeCheck(popover.collection[0]);
+    const popovers = new PopoverCollection();
+    await popovers.mount();
+    popovers.collection[0].trigger.focus();
+    closeCheck(popovers.collection[0]);
     vi.advanceTimersByTime(100);
-    expect(popover.collection[0].el).toHaveClass("is-active");
+    expect(popovers.collection[0].el).toHaveClass("is-active");
   });
 
   it("should keep popover open if closeCheck detects popover element or its children are focused", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
-    popover.collection[0].el.focus();
-    closeCheck(popover.collection[0]);
+    const popovers = new PopoverCollection();
+    await popovers.mount();
+    popovers.collection[0].el.focus();
+    closeCheck(popovers.collection[0]);
     vi.advanceTimersByTime(100);
-    expect(popover.collection[0].el).toHaveClass("is-active");
+    expect(popovers.collection[0].el).toHaveClass("is-active");
   });
 });

--- a/packages/popover/tests/collection.test.js
+++ b/packages/popover/tests/collection.test.js
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import Popover from "../index";
+import { PopoverCollection } from "../index";
 
 vi.useFakeTimers();
 
@@ -28,38 +28,38 @@ beforeAll(() => {
 describe("register() & entry.deregister()", () => {
   it("should register a popover using the provided ID", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
+    const popovers = new PopoverCollection();
     const trigger = document.querySelector("#asdf-trigger");
     const target = document.querySelector("#asdf");
-    await popover.register(await popover.createEntry("asdf"));
-    expect(popover.collection.length).toBe(1);
-    expect(popover.collection[0].trigger).toBe(trigger);
-    expect(popover.collection[0].el).toBe(target);
+    await popovers.register(await popovers.createEntry("asdf"));
+    expect(popovers.collection.length).toBe(1);
+    expect(popovers.collection[0].trigger).toBe(trigger);
+    expect(popovers.collection[0].el).toBe(target);
     trigger.click();
     vi.advanceTimersByTime(500);
-    expect(popover.collection[0].el).toHaveClass("is-active");
+    expect(popovers.collection[0].el).toHaveClass("is-active");
   });
 
   it("should return an error if the provided id has no associated popover", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await expect(popover.createEntry("missing")).rejects.toThrow(
+    const popovers = new PopoverCollection();
+    await expect(popovers.createEntry("missing")).rejects.toThrow(
       'Element not found with ID: "missing"'
     );
   });
 
   it("should attach hover event listeners when registered", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.register(await popover.createEntry("fdsa"));
-    expect(popover.collection.length).toBe(1);
+    const popovers = new PopoverCollection();
+    await popovers.register(await popovers.createEntry("fdsa"));
+    expect(popovers.collection.length).toBe(1);
   });
 
   it("should attach open and close methods to registered popover", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.register(await popover.createEntry("asdf"));
-    const entry = popover.get("asdf");
+    const popovers = new PopoverCollection();
+    await popovers.register(await popovers.createEntry("asdf"));
+    const entry = popovers.get("asdf");
 
     await entry.open();
     expect(entry.state).toBe("opened");
@@ -72,9 +72,9 @@ describe("register() & entry.deregister()", () => {
 
   it("should attach deregister method to registered popover", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.register(await popover.createEntry("asdf"));
-    const entry = popover.get("asdf");
+    const popovers = new PopoverCollection();
+    await popovers.register(await popovers.createEntry("asdf"));
+    const entry = popovers.get("asdf");
     expect(entry.id).toBe("asdf");
     await entry.deregister();
   });
@@ -83,9 +83,11 @@ describe("register() & entry.deregister()", () => {
 describe("entry.isTooltip", () => {
   it("should return whether or not a popover is a tooltip", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    const entry1 = await popover.register(await popover.createEntry("asdf"));
-    const entry2 = await popover.register(await popover.createEntry("tooltip"));
+    const popovers = new PopoverCollection();
+    const entry1 = await popovers.register(await popovers.createEntry("asdf"));
+    const entry2 = await popovers.register(
+      await popovers.createEntry("tooltip")
+    );
     expect(entry1.isTooltip).toBe(false);
     expect(entry2.isTooltip).toBe(true);
   });

--- a/packages/popover/tests/handlers.test.js
+++ b/packages/popover/tests/handlers.test.js
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import { delay } from "./helpers/delay";
-import Popover from "../index";
+import { PopoverCollection } from "../index";
 import { attrConfig } from "@vrembem/core";
 import {
   handleClick,
@@ -67,51 +67,51 @@ const multiplePopover = `
 describe("handleClick()", () => {
   it("should open popover if it does not contain the active class", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
+    const popovers = new PopoverCollection();
+    await popovers.mount();
 
-    expect(popover.collection.length).toBe(2);
+    expect(popovers.collection.length).toBe(2);
 
-    handleClick.bind(popover, popover.collection[0])();
-    expect(popover.collection[0].el).toHaveClass("is-active");
+    handleClick.bind(popovers, popovers.collection[0])();
+    expect(popovers.collection[0].el).toHaveClass("is-active");
   });
 
   it("should close popover if it contains the active class", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
+    const popovers = new PopoverCollection();
+    await popovers.mount();
 
-    expect(popover.collection.length).toBe(2);
+    expect(popovers.collection.length).toBe(2);
 
-    handleClick.bind(popover, popover.collection[1])();
-    expect(popover.collection[1].el).not.toHaveClass("is-active");
+    handleClick.bind(popovers, popovers.collection[1])();
+    expect(popovers.collection[1].el).not.toHaveClass("is-active");
   });
 
   it("should attach document click event listener when popover is opened", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
-    handleClick.bind(popover, popover.collection[0])();
-    expect(popover.get("asdf").el).toHaveClass("is-active");
-    expect(popover.get("fdsa").el).toHaveClass("is-active");
+    const popovers = new PopoverCollection();
+    await popovers.mount();
+    handleClick.bind(popovers, popovers.collection[0])();
+    expect(popovers.get("asdf").el).toHaveClass("is-active");
+    expect(popovers.get("fdsa").el).toHaveClass("is-active");
     await delay();
     document.querySelector("#app").click();
     await delay();
-    expect(popover.get("asdf").el).not.toHaveClass("is-active");
-    expect(popover.get("fdsa").el).not.toHaveClass("is-active");
+    expect(popovers.get("asdf").el).not.toHaveClass("is-active");
+    expect(popovers.get("fdsa").el).not.toHaveClass("is-active");
   });
 
   it("should properly clear toggle delay if one exists on click", async () => {
     document.body.innerHTML = multiplePopover;
-    const popover = new Popover();
-    await popover.mount();
+    const popovers = new PopoverCollection();
+    await popovers.mount();
 
     const trigger = document.querySelector("button");
-    const entry1 = popover.get("popover");
-    const entry2 = popover.get("tooltip");
+    const entry1 = popovers.get("popover");
+    const entry2 = popovers.get("tooltip");
 
     const event = new MouseEvent("mouseenter");
-    handleMouseEnter.bind(popover, entry2, event)();
+    handleMouseEnter.bind(popovers, entry2, event)();
     trigger.click();
     await delay(100);
 
@@ -124,12 +124,12 @@ describe("handleClick()", () => {
 describe("handleMouseEnter() & handleMouseLeave()", () => {
   it("should open tooltip when handleMouseEnter() is run", async () => {
     document.body.innerHTML = hoverMarkup;
-    const popover = new Popover({
+    const popovers = new PopoverCollection({
       plugins: [attrConfig()]
     });
-    await popover.mount();
+    await popovers.mount();
 
-    const entry = popover.get("tooltip-1");
+    const entry = popovers.get("tooltip-1");
     expect(entry.isTooltip).toBe(true);
     expect(entry.state).toBe("closed");
 
@@ -141,12 +141,12 @@ describe("handleMouseEnter() & handleMouseLeave()", () => {
 
   it("should close tooltip when handleMouseLeave() is run", async () => {
     document.body.innerHTML = hoverMarkup;
-    const popover = new Popover({
+    const popovers = new PopoverCollection({
       plugins: [attrConfig()]
     });
-    await popover.mount();
+    await popovers.mount();
 
-    const entry = popover.get("tooltip-2");
+    const entry = popovers.get("tooltip-2");
     expect(entry.isTooltip).toBe(true);
     await entry.open();
     expect(entry.state).toBe("opened");
@@ -159,12 +159,12 @@ describe("handleMouseEnter() & handleMouseLeave()", () => {
 
   it("should not close popover if either the popover element or trigger are hovered", async () => {
     document.body.innerHTML = hoverMarkup;
-    const popover = new Popover({
+    const popovers = new PopoverCollection({
       plugins: [attrConfig()]
     });
-    await popover.mount();
+    await popovers.mount();
 
-    const entry = popover.get("popover");
+    const entry = popovers.get("popover");
     expect(entry.config.get("event")).toBe("hover");
 
     const eventEnter = new MouseEvent("mouseenter");
@@ -186,28 +186,28 @@ describe("handleMouseEnter() & handleMouseLeave()", () => {
 
   it("should correctly clear timeout when multiple enter/leave events are run", async () => {
     document.body.innerHTML = hoverMarkup;
-    const popover = new Popover({
+    const popovers = new PopoverCollection({
       plugins: [attrConfig()]
     });
-    await popover.mount();
+    await popovers.mount();
 
-    const entry1 = popover.get("tooltip-1");
-    const entry2 = popover.get("tooltip-2");
+    const entry1 = popovers.get("tooltip-1");
+    const entry2 = popovers.get("tooltip-2");
 
     const eventEnter = new MouseEvent("mouseenter");
-    handleMouseEnter.bind(popover, entry1, eventEnter)();
-    handleMouseEnter.bind(popover, entry2, eventEnter)();
+    handleMouseEnter.bind(popovers, entry1, eventEnter)();
+    handleMouseEnter.bind(popovers, entry2, eventEnter)();
     await delay();
-    handleMouseLeave.bind(popover, entry1, eventEnter)();
+    handleMouseLeave.bind(popovers, entry1, eventEnter)();
     await delay();
-    handleMouseEnter.bind(popover, entry2, eventEnter)();
+    handleMouseEnter.bind(popovers, entry2, eventEnter)();
     await delay();
 
     expect(entry1.state).toBe("closed");
     expect(entry2.state).toBe("opened");
 
     const eventLeave = new MouseEvent("mouseleave");
-    handleMouseLeave.bind(popover, entry2, eventLeave)();
+    handleMouseLeave.bind(popovers, entry2, eventLeave)();
     await delay(100);
 
     expect(entry2.state).toBe("closed");
@@ -215,12 +215,12 @@ describe("handleMouseEnter() & handleMouseLeave()", () => {
 
   it("should not open tooltip if a popover for a trigger is already open", async () => {
     document.body.innerHTML = multiplePopover;
-    const popover = new Popover();
-    await popover.mount();
+    const popovers = new PopoverCollection();
+    await popovers.mount();
 
     const trigger = document.querySelector("button");
-    const entry1 = popover.get("popover");
-    const entry2 = popover.get("tooltip");
+    const entry1 = popovers.get("popover");
+    const entry2 = popovers.get("tooltip");
 
     expect(entry1.config.get("event")).toBe("click");
     expect(entry2.config.get("event")).toBe("hover");
@@ -233,7 +233,7 @@ describe("handleMouseEnter() & handleMouseLeave()", () => {
     expect(entry2.state).toBe("closed");
 
     const event = new Event("mouseenter");
-    handleMouseEnter.bind(popover, entry2, event)();
+    handleMouseEnter.bind(popovers, entry2, event)();
     await delay(100);
 
     expect(entry1.state).toBe("opened");
@@ -242,14 +242,14 @@ describe("handleMouseEnter() & handleMouseLeave()", () => {
 
   it("should guard against focus if the trigger is not focus-visible", async () => {
     document.body.innerHTML = multiplePopover;
-    const popover = new Popover();
-    await popover.mount();
+    const popovers = new PopoverCollection();
+    await popovers.mount();
 
-    const entry1 = popover.get("popover");
-    const entry2 = popover.get("tooltip");
+    const entry1 = popovers.get("popover");
+    const entry2 = popovers.get("tooltip");
 
     const event = new Event("focus");
-    handleMouseEnter.bind(popover, entry2, event)();
+    handleMouseEnter.bind(popovers, entry2, event)();
     await delay(100);
 
     expect(entry1.state).toBe("closed");
@@ -260,36 +260,36 @@ describe("handleMouseEnter() & handleMouseLeave()", () => {
 describe("handlerKeydown()", () => {
   it("should close open popover when escape key is pressed", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
+    const popovers = new PopoverCollection();
+    await popovers.mount();
 
-    expect(popover.collection[1].el).toHaveClass("is-active");
+    expect(popovers.collection[1].el).toHaveClass("is-active");
     document.dispatchEvent(keyEsc);
     await delay();
-    expect(popover.collection[1].el).not.toHaveClass("is-active");
+    expect(popovers.collection[1].el).not.toHaveClass("is-active");
   });
 
   it("should do nothing when a non-escape key is pressed", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
+    const popovers = new PopoverCollection();
+    await popovers.mount();
 
-    expect(popover.collection[1].el).toHaveClass("is-active");
+    expect(popovers.collection[1].el).toHaveClass("is-active");
     document.dispatchEvent(keySpace);
     await delay();
-    expect(popover.collection[1].el).toHaveClass("is-active");
+    expect(popovers.collection[1].el).toHaveClass("is-active");
   });
 
   it("should return focus to the trigger element when escape key is pressed", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
+    const popovers = new PopoverCollection();
+    await popovers.mount();
 
     const button = document.querySelector(".focus-test");
 
-    expect(popover.trigger).toBe(null);
-    popover.collection[0].trigger.click();
-    expect(popover.trigger).toBe(popover.collection[0].trigger);
+    expect(popovers.trigger).toBe(null);
+    popovers.collection[0].trigger.click();
+    expect(popovers.trigger).toBe(popovers.collection[0].trigger);
 
     button.focus();
     expect(document.activeElement).toBe(button);
@@ -298,49 +298,49 @@ describe("handlerKeydown()", () => {
     document.dispatchEvent(keyEsc);
     await delay();
 
-    expect(document.activeElement).toBe(popover.collection[0].trigger);
-    expect(popover.trigger).toBe(null);
+    expect(document.activeElement).toBe(popovers.collection[0].trigger);
+    expect(popovers.trigger).toBe(null);
   });
 
   it("should run close check when the tab key is pressed", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
+    const popovers = new PopoverCollection();
+    await popovers.mount();
 
-    expect(popover.collection.length).toBe(2);
-    expect(popover.collection[1].el).toHaveClass("is-active");
+    expect(popovers.collection.length).toBe(2);
+    expect(popovers.collection[1].el).toHaveClass("is-active");
     document.dispatchEvent(keyTab);
     await delay();
-    expect(popover.collection[1].el).not.toHaveClass("is-active");
+    expect(popovers.collection[1].el).not.toHaveClass("is-active");
   });
 });
 
 describe("documentClick()", () => {
   it("should close other popover instances when a new one is toggled", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
+    const popovers = new PopoverCollection();
+    await popovers.mount();
 
-    expect(popover.collection[0].el).not.toHaveClass("is-active");
-    expect(popover.collection[1].el).toHaveClass("is-active");
+    expect(popovers.collection[0].el).not.toHaveClass("is-active");
+    expect(popovers.collection[1].el).toHaveClass("is-active");
 
-    popover.collection[0].trigger.click();
+    popovers.collection[0].trigger.click();
 
-    expect(popover.collection[0].el).toHaveClass("is-active");
-    expect(popover.collection[1].el).not.toHaveClass("is-active");
+    expect(popovers.collection[0].el).toHaveClass("is-active");
+    expect(popovers.collection[1].el).not.toHaveClass("is-active");
   });
 
   it("should remove document event listener when popover is closed", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
+    const popovers = new PopoverCollection();
+    await popovers.mount();
 
-    expect(popover.collection[0].el).not.toHaveClass("is-active");
-    expect(popover.collection[1].el).toHaveClass("is-active");
+    expect(popovers.collection[0].el).not.toHaveClass("is-active");
+    expect(popovers.collection[1].el).toHaveClass("is-active");
 
-    popover.collection[1].trigger.click();
+    popovers.collection[1].trigger.click();
 
-    expect(popover.collection[0].el).not.toHaveClass("is-active");
-    expect(popover.collection[1].el).not.toHaveClass("is-active");
+    expect(popovers.collection[0].el).not.toHaveClass("is-active");
+    expect(popovers.collection[1].el).not.toHaveClass("is-active");
   });
 });

--- a/packages/popover/tests/helpers.test.js
+++ b/packages/popover/tests/helpers.test.js
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import Popover from "../index";
+import { PopoverCollection } from "../index";
 import { cssConfig } from "@vrembem/core";
 import {
   applyPositionStyle,
@@ -10,7 +10,7 @@ import {
 } from "../src/js/helpers";
 import { expect } from "vitest";
 
-let popover;
+let popovers;
 
 const markup = `
   <button aria-controls="pop-1">...</button>
@@ -48,10 +48,10 @@ beforeAll(() => {
 });
 
 afterEach(() => {
-  if (popover && "unmount" in popover) {
-    popover.unmount();
+  if (popovers && "unmount" in popovers) {
+    popovers.unmount();
   }
-  popover = null;
+  popovers = null;
   document.body.innerHTML = null;
 });
 
@@ -126,40 +126,40 @@ describe("getPadding()", () => {
 describe("getPopoverID()", () => {
   it("should return the popover id using a popover", () => {
     document.body.innerHTML = markup;
-    popover = new Popover();
+    popovers = new PopoverCollection();
     const el = document.querySelector(".popover");
-    const result = getPopoverID.call(popover, el);
+    const result = getPopoverID.call(popovers, el);
     expect(result).toBe("pop-1");
   });
 
   it("should return the popover id using a popover trigger", () => {
     document.body.innerHTML = markup;
-    popover = new Popover();
+    popovers = new PopoverCollection();
     const el = document.querySelector('[aria-controls="pop-2"]');
-    const result = getPopoverID.call(popover, el);
+    const result = getPopoverID.call(popovers, el);
     expect(result).toBe("pop-2");
   });
 
   it("should return the popover id using a popover tooltip trigger", () => {
     document.body.innerHTML = markup;
-    popover = new Popover();
+    popovers = new PopoverCollection();
     const el = document.querySelector('[aria-describedby="pop-3"]');
-    const result = getPopoverID.call(popover, el);
+    const result = getPopoverID.call(popovers, el);
     expect(result).toBe("pop-3");
   });
 
   it("should return null if html element does not have the correct attributes", () => {
     document.body.innerHTML = markup;
-    popover = new Popover();
+    popovers = new PopoverCollection();
     const trigger = document.querySelector("#missing-attribute");
-    const result = getPopoverID.call(popover, trigger);
+    const result = getPopoverID.call(popovers, trigger);
     expect(result).toBe(null);
   });
 
   it("should return null if passed object does not resolve an ID", () => {
     document.body.innerHTML = markup;
-    popover = new Popover();
-    const result = getPopoverID.call(popover, true);
+    popovers = new PopoverCollection();
+    const result = getPopoverID.call(popovers, true);
     expect(result).toBe(null);
   });
 });
@@ -169,16 +169,16 @@ describe("getPopoverElements()", () => {
     document.body.innerHTML = markup;
     const trigger = document.querySelector('[aria-controls="pop-1"]');
     const target = document.querySelector("#pop-1");
-    popover = new Popover();
-    const result = getPopoverElements.call(popover, "pop-1");
+    popovers = new PopoverCollection();
+    const result = getPopoverElements.call(popovers, "pop-1");
     expect(result.popover).toBe(target);
     expect(result.trigger).toBe(trigger);
   });
 
   it("should throw error if no popover elements are found using an ID", () => {
     document.body.innerHTML = markup;
-    popover = new Popover();
-    expect(() => getPopoverElements.call(popover, "pop-4")).toThrow(
+    popovers = new PopoverCollection();
+    expect(() => getPopoverElements.call(popovers, "pop-4")).toThrow(
       'No popover elements found using the ID: "pop-4".'
     );
   });
@@ -186,8 +186,8 @@ describe("getPopoverElements()", () => {
   it("should throw error if no popover is found using a trigger element", () => {
     document.body.innerHTML = markup;
     const trigger = document.querySelector('[aria-controls="asdf"]');
-    popover = new Popover();
-    expect(() => getPopoverElements.call(popover, trigger)).toThrow(
+    popovers = new PopoverCollection();
+    expect(() => getPopoverElements.call(popovers, trigger)).toThrow(
       'No popover associated with the provided popover trigger: "asdf".'
     );
   });
@@ -195,8 +195,8 @@ describe("getPopoverElements()", () => {
   it("should throw error if no popover trigger is found using a popover", () => {
     document.body.innerHTML = markup;
     const target = document.querySelector("#fdsa");
-    popover = new Popover();
-    expect(() => getPopoverElements.call(popover, target)).toThrow(
+    popovers = new PopoverCollection();
+    expect(() => getPopoverElements.call(popovers, target)).toThrow(
       'No popover trigger associated with the provided popover: "fdsa".'
     );
   });
@@ -204,8 +204,8 @@ describe("getPopoverElements()", () => {
   it("should throw error if unable to resolve a popover ID with provided query", () => {
     document.body.innerHTML = markup;
     const trigger = document.querySelector("#missing-attribute");
-    popover = new Popover();
-    expect(() => getPopoverElements.call(popover, trigger)).toThrow(
+    popovers = new PopoverCollection();
+    expect(() => getPopoverElements.call(popovers, trigger)).toThrow(
       "Could not resolve the popover ID."
     );
   });
@@ -214,13 +214,13 @@ describe("getPopoverElements()", () => {
 describe("getDelay()", () => {
   it("should return the appropriate delay based on the provided index", async () => {
     document.body.innerHTML = markup;
-    popover = new Popover({
+    popovers = new PopoverCollection({
       toggleDelay: 200
     });
-    const entry1 = await popover.register(await popover.createEntry("pop-1"));
+    const entry1 = await popovers.register(await popovers.createEntry("pop-1"));
     expect(getDelay(entry1, 0)).toBe(200);
 
-    const entry2 = popover.get("pop-1");
+    const entry2 = popovers.get("pop-1");
     entry2.config.set({
       toggleDelay: [300, 600]
     });
@@ -230,22 +230,22 @@ describe("getDelay()", () => {
 
   it("should create an array if the provided delay is a string", async () => {
     document.body.innerHTML = customPropertyMarkup;
-    popover = new Popover({
+    popovers = new PopoverCollection({
       plugins: [cssConfig()]
     });
-    await popover.mount();
-    expect(getDelay(popover.get("asdf"), 0)).toBe(200);
-    expect(getDelay(popover.get("asdf"), 1)).toBe(400);
-    expect(getDelay(popover.get("fdsa"), 0)).toBe(400);
-    expect(getDelay(popover.get("fdsa"), 1)).toBe(800);
+    await popovers.mount();
+    expect(getDelay(popovers.get("asdf"), 0)).toBe(200);
+    expect(getDelay(popovers.get("asdf"), 1)).toBe(400);
+    expect(getDelay(popovers.get("fdsa"), 0)).toBe(400);
+    expect(getDelay(popovers.get("fdsa"), 1)).toBe(800);
   });
 
   it("should throw an error if the provided delay is not a number", async () => {
     document.body.innerHTML = markup;
-    popover = new Popover({
+    popovers = new PopoverCollection({
       toggleDelay: "asdf"
     });
-    const entry1 = await popover.register(await popover.createEntry("pop-1"));
+    const entry1 = await popovers.register(await popovers.createEntry("pop-1"));
     expect(() => getDelay(entry1, 0)).toThrow(
       'Provided delay value is not a number: "asdf"'
     );

--- a/packages/popover/tests/open.test.js
+++ b/packages/popover/tests/open.test.js
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import Popover from "../index";
+import { PopoverCollection } from "../index";
 
 vi.useFakeTimers();
 
@@ -16,9 +16,9 @@ const markup = `
 describe("open()", () => {
   it("should open the provided popover", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
-    const entry = popover.get("asdf");
+    const popovers = new PopoverCollection();
+    await popovers.mount();
+    const entry = popovers.get("asdf");
     expect(entry.state).toBe("closed");
     expect(entry.el).not.toHaveClass("is-active");
     expect(entry.trigger.getAttribute("aria-expanded")).toBe("false");
@@ -30,9 +30,9 @@ describe("open()", () => {
 
   it("should open the provided popover tooltip", async () => {
     document.body.innerHTML = markup;
-    const popover = new Popover();
-    await popover.mount();
-    const entry = popover.get("fdsa");
+    const popovers = new PopoverCollection();
+    await popovers.mount();
+    const entry = popovers.get("fdsa");
     expect(entry.state).toBe("closed");
     expect(entry.el).not.toHaveClass("is-active");
     expect(entry.trigger.hasAttribute("aria-expanded")).toBe(false);

--- a/packages/popover/tests/teleport.test.js
+++ b/packages/popover/tests/teleport.test.js
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import Popover from "../index";
+import { PopoverCollection } from "../index";
 import { teleport } from "@vrembem/core";
 
 document.body.innerHTML = `
@@ -18,7 +18,7 @@ document.body.innerHTML = `
   <div class="popovers"></div>
 `;
 
-const popover = new Popover({
+const popovers = new PopoverCollection({
   plugins: [
     teleport({
       where: ".popovers"
@@ -31,16 +31,16 @@ const div = document.querySelector(".popovers");
 describe("mount()", () => {
   it("should teleport popovers to the provided reference selector using the default method", async () => {
     expect(div.children.length).toBe(0);
-    await popover.mount();
+    await popovers.mount();
     expect(div.children.length).toBe(2);
   });
 
   it("should return teleport when a popover is deregistered", async () => {
-    let entry = popover.get("popover-1");
-    await popover.deregister(await popover.destroyEntry(entry));
+    let entry = popovers.get("popover-1");
+    await popovers.deregister(await popovers.destroyEntry(entry));
     expect(div.children.length).toBe(1);
-    entry = popover.get("popover-2");
-    await popover.deregister(await popover.destroyEntry(entry));
+    entry = popovers.get("popover-2");
+    await popovers.deregister(await popovers.destroyEntry(entry));
     expect(div.children.length).toBe(0);
   });
 });

--- a/packages/popover/vite.config.js
+++ b/packages/popover/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
   build: {
     lib: {
       entry: resolve(__dirname, "index.ts"),
-      name: "vrembem.Popover",
+      name: "vrembem.PopoverCollection",
       fileName: "index"
     },
     emptyOutDir: false,

--- a/packages/vrembem/README.md
+++ b/packages/vrembem/README.md
@@ -56,15 +56,10 @@ Customize core variables which all components inherit from. The example below wi
 Import and mount the components you'll need:
 
 ```js
-// Import all under the vb namespace
-import * as vb from 'vrembem';
-const drawer = new vb.Drawer();
-await drawer.mount();
-
-// Or import individual components
+// Import individual components
 import { Drawer } from 'vrembem';
-const drawer = new Drawer();
-await drawer.mount();
+const drawers = new DrawerCollection();
+await drawers.mount();
 ```
 
 ## Markup

--- a/packages/vrembem/index.html
+++ b/packages/vrembem/index.html
@@ -63,7 +63,7 @@
       ]
     });
 
-    const drawer = new vb.Drawer({
+    const drawers = new vb.Drawer({
       plugins: [
         vb.core.teleport({
           where: ".drawer-main",
@@ -72,8 +72,8 @@
       ]
     });
 
-    window["modal"] = await modal.mount();
-    window["drawer"] = await drawer.mount();
+    window["modal"] = await modals.mount();
+    window["drawer"] = await drawers.mount();
 
     /**
      * Setup drawer form updater

--- a/packages/vrembem/index.ts
+++ b/packages/vrembem/index.ts
@@ -1,6 +1,4 @@
-import * as core from "@vrembem/core";
-import Drawer from "@vrembem/drawer";
-import Modal from "@vrembem/modal";
-import Popover from "@vrembem/popover";
-
-export { core, Drawer, Modal, Popover };
+export * from "@vrembem/core";
+export { DrawerCollection } from "@vrembem/drawer";
+export { ModalCollection } from "@vrembem/modal";
+export { PopoverCollection } from "@vrembem/popover";


### PR DESCRIPTION
## What changed?

This refactors the JavaScript exports of the all-in-one `vrembem` package by exporting the members of the core package directly instead of in a core namespace wrapper. This allows consumers to import a component along with plugins from the same import declaration:

```js
import { ModalCollection, focusTrap } from "vrembem";
```

As part of this update, all three JavaScript components have been renamed to better describe what they are and their purpose. Documentation and tests have also been update to reflect these changes.

- `Drawer` > `DrawerCollection`
- `Modal` > `ModalCollection`
- `Popover` > `PopoverCollection`
