### PR TITLE
Update umd ext from .cjs to .js

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.umd.cjs"
+      "require": "./dist/index.umd.js"
     },
     "./config": "./src/scss/modules/_config.scss",
     "./tokens": "./src/scss/modules/_tokens.scss",

--- a/packages/core/vite.config.js
+++ b/packages/core/vite.config.js
@@ -9,7 +9,10 @@ export default defineConfig({
     lib: {
       entry: resolve(__dirname, "index.ts"),
       name: "vrembem.core",
-      fileName: "index"
+      fileName: (format) => {
+        if (format === "umd") return "index.umd.js";
+        return "index.js";
+      }
     },
     emptyOutDir: false,
     sourcemap: true

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -18,7 +18,7 @@
       "style": "./dist/index.css",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.umd.cjs"
+      "require": "./dist/index.umd.js"
     },
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",

--- a/packages/drawer/vite.config.js
+++ b/packages/drawer/vite.config.js
@@ -9,7 +9,10 @@ export default defineConfig({
     lib: {
       entry: resolve(__dirname, "index.ts"),
       name: "vrembem.DrawerCollection",
-      fileName: "index"
+      fileName: (format) => {
+        if (format === "umd") return "index.umd.js";
+        return "index.js";
+      }
     },
     emptyOutDir: false,
     sourcemap: true

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -18,7 +18,7 @@
       "style": "./dist/index.css",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.umd.cjs"
+      "require": "./dist/index.umd.js"
     },
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",

--- a/packages/modal/vite.config.js
+++ b/packages/modal/vite.config.js
@@ -9,7 +9,10 @@ export default defineConfig({
     lib: {
       entry: resolve(__dirname, "index.ts"),
       name: "vrembem.ModalCollection",
-      fileName: "index"
+      fileName: (format) => {
+        if (format === "umd") return "index.umd.js";
+        return "index.js";
+      }
     },
     emptyOutDir: false,
     sourcemap: true

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -18,7 +18,7 @@
       "style": "./dist/index.css",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.umd.cjs"
+      "require": "./dist/index.umd.js"
     },
     "./dev/*": "./dev/*",
     "./dist/*": "./dist/*",

--- a/packages/popover/vite.config.js
+++ b/packages/popover/vite.config.js
@@ -9,7 +9,10 @@ export default defineConfig({
     lib: {
       entry: resolve(__dirname, "index.ts"),
       name: "vrembem.PopoverCollection",
-      fileName: "index"
+      fileName: (format) => {
+        if (format === "umd") return "index.umd.js";
+        return "index.js";
+      }
     },
     emptyOutDir: false,
     sourcemap: true

--- a/packages/vrembem/package.json
+++ b/packages/vrembem/package.json
@@ -18,7 +18,7 @@
       "style": "./dist/index.css",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.umd.cjs"
+      "require": "./dist/index.umd.js"
     },
     "./styles": {
       "sass": "./styles.scss",

--- a/packages/vrembem/vite.config.js
+++ b/packages/vrembem/vite.config.js
@@ -7,7 +7,10 @@ export default defineConfig({
     lib: {
       entry: resolve(__dirname, "index.js"),
       name: "vrembem",
-      fileName: "index"
+      fileName: (format) => {
+        if (format === "umd") return "index.umd.js";
+        return "index.js";
+      }
     },
     emptyOutDir: false,
     sourcemap: true


### PR DESCRIPTION
## What changed?

For better compatibility with CDNs and serving the correct MIME types, this PR renames the default Vite output of UMD bundles from `.cjs` to `.js`.