### PR TITLE
Fix restore inline state when drawer switches to inline mode

### DIFF
--- a/packages/dialog/src/_dialog.scss
+++ b/packages/dialog/src/_dialog.scss
@@ -17,7 +17,7 @@
   box-shadow: tokens.get("dialog", "box-shadow", tokens.get("box-shadow-4"));
   transition-timing-function: tokens.get("dialog", "transition-timing-function", tokens.get("transition-timing-function"));
   transition-duration: tokens.get("dialog", "transition-duration", tokens.get("transition-duration"));
-  transition-property: tokens.get("dialog", "transition-duration", (outline, border-color));
+  transition-property: tokens.get("dialog", "transition-property", (outline, border-color));
 
   &:focus-visible,
   &[role="alertdialog"] {

--- a/packages/drawer/index.html
+++ b/packages/drawer/index.html
@@ -56,7 +56,6 @@
 
           <ul class="list">
             <li><button class="link" data-drawer-toggle="drawer-default">default</button></li>
-            <li><button class="link" data-drawer-toggle="drawer-indeterminate">Indeterminate</button></li>
             <li><button class="link" data-drawer-toggle="drawer-modal">modal</button></li>
             <li><button class="link" data-drawer-toggle="drawer-modal-switch">modal switch</button></li>
             <li><button class="link" data-drawer-toggle="drawer-breakpoint">breakpoint</button></li>
@@ -66,14 +65,6 @@
             <div class="drawer__dialog dialog">
               <div class="dialog__body">
                 drawer-default
-              </div>
-            </div>
-          </div>
-
-          <div id="drawer-indeterminate" class="drawer">
-            <div class="drawer__dialog dialog">
-              <div class="dialog__body">
-                drawer-indeterminate
               </div>
             </div>
           </div>
@@ -124,7 +115,7 @@
             </div>
           </div>
 
-          <div id="drawer-breakpoint" class="drawer is-closed" data-breakpoint="md">
+          <div id="drawer-breakpoint" class="drawer is-closed" data-breakpoint="lg">
             <div class="drawer__dialog dialog">
               <div class="dialog__body">
                 drawer-breakpoint

--- a/packages/drawer/src/js/switchMode.ts
+++ b/packages/drawer/src/js/switchMode.ts
@@ -27,7 +27,13 @@ async function toInline(entry: DrawerEntry): Promise<DrawerEntry> {
   );
 
   // Restore the inline state
-  entry.state = entry.inlineState;
+  if (entry.inlineState === "opened") {
+    await entry.open(false, false);
+  } else if (entry.inlineState === "closed") {
+    await entry.close(false, false);
+  } else {
+    entry.state = entry.inlineState;
+  }
 
   // Emit the switchMode event
   await entry.parent.emit("switchMode", entry);

--- a/packages/drawer/src/scss/_drawer.scss
+++ b/packages/drawer/src/scss/_drawer.scss
@@ -2,8 +2,6 @@
 @use "@vrembem/core/config";
 @use "@vrembem/core/tokens";
 
-$-transition-base: tokens.get("drawer", "transition-duration", tokens.get("transition-duration")) tokens.get("drawer", "transition-timing-function", tokens.get("transition-timing-function"));
-
 #{core.bem(config.get("drawer-classes", "frame"))} {
   position: relative;
   overflow: hidden auto;
@@ -16,7 +14,6 @@ $-transition-base: tokens.get("drawer", "transition-duration", tokens.get("trans
   overflow: auto;
   flex: 1 1 auto;
   height: 100%;
-  transition: margin $-transition-base;
 }
 
 #{core.bem("drawer")} {
@@ -60,10 +57,10 @@ $-transition-base: tokens.get("drawer", "transition-duration", tokens.get("trans
 
 #{core.bem("drawer")}.is-opening,
 #{core.bem("drawer")}.is-closing {
-  transition: opacity $-transition-base;
+  transition: opacity tokens.get("transition");
 
   #{core.bem("drawer", "dialog")} {
-    transition: transform $-transition-base;
+    transition: transform tokens.get("transition");
   }
 }
 

--- a/packages/drawer/src/scss/_drawer_switch.scss
+++ b/packages/drawer/src/scss/_drawer_switch.scss
@@ -19,6 +19,14 @@
   border-left: none;
 }
 
+// Apply margin transition styles if drawer is in a transitioning state
+#{core.bem("drawer")}:not(#{core.bem("drawer", null, "modal")}) {
+  &.is-opening ~ #{core.bem(config.get("drawer-classes", "main"))},
+  &.is-closing ~ #{core.bem(config.get("drawer-classes", "main"))} {
+    transition: margin tokens.get("transition");
+  }
+}
+
 // IS .drawer NOT .drawer_switch OR .drawer_modal
 #{core.bem("drawer")}:not(#{core.bem("drawer", null, "switch")}, #{core.bem("drawer", null, "modal")}) {
   &.is-opening ~ #{core.bem(config.get("drawer-classes", "main"))},


### PR DESCRIPTION
## What changed?

This PR fixes a bug where we weren't properly restoring the stored inline state when switching from modal to inline modes.

**Additional Changes**

- `drawer`: Fixed the use of `transition-duration` in transition property styles.
- `drawer`: Only apply margin transitions to `drawer-main` when the drawer is in a transitioning state. This prevents transition styles from taking effect when a drawer is going between states without transitions.
- `drawer`: Use new transition shorthand tokens instead of explicitly setting duration and timing function.
