### PR TITLE
Use appearance base-select to style the select input element

### DIFF
--- a/docs/src/content/pages/packages/input.mdx
+++ b/docs/src/content/pages/packages/input.mdx
@@ -86,7 +86,10 @@ Input uses design token CSS variables in a reference and fallback pattern. Varia
   "--vb-input-foreground-placeholder": "var(--vb-foreground-lighter)",
 
   "--vb-input-opacity-disabled": "var(--vb-form-control-opacity-disabled)",
-  "--vb-input-background-disabled": "var(--vb-form-control-background-disabled)"
+  "--vb-input-background-disabled": "var(--vb-form-control-background-disabled)",
+
+  "--vb-input-select-icon-size": "0.8em",
+  "--vb-input-select-icon-color": "currentcolor"
 }} />
 
 ## Basic usage

--- a/packages/input/build.scss
+++ b/packages/input/build.scss
@@ -1,6 +1,0 @@
-@use "./index";
-@use "@vrembem/core/tokens";
-
-@layer tokens {
-  @include tokens.output("input");
-}

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -30,8 +30,8 @@
     "build": "npm-run-all clean styles",
     "clean": "del dev && del dist",
     "styles": "npm-run-all styles:dev styles:dist",
-    "styles:dev": "sass build.scss dev/index.css --load-path=../../node_modules",
-    "styles:dist": "sass build.scss dist/index.css --load-path=../../node_modules --style=compressed",
+    "styles:dev": "sass index.scss dev/index.css --load-path=../../node_modules",
+    "styles:dist": "sass index.scss dist/index.css --load-path=../../node_modules --style=compressed",
     "watch": "npm run watch:styles",
     "watch:styles": "concurrently 'npm run styles:dev -- --watch' 'npm run styles:dist -- --watch'"
   },

--- a/packages/input/src/_config.scss
+++ b/packages/input/src/_config.scss
@@ -25,18 +25,3 @@ $default: (
 
 @include config.apply($config, $default);
 @include tokens.register("input");
-
-// prettier-ignore
-@include tokens.set(
-  "input", 
-  (
-    "light": (
-      "type": "theme",
-      "select-icon": url(core.svg("expand", ("color": black)))
-    ),
-    "dark": (
-      "type": "theme",
-      "select-icon": url(core.svg("expand", ("color": white)))
-    )
-  )
-);

--- a/packages/input/src/_input.scss
+++ b/packages/input/src/_input.scss
@@ -22,14 +22,12 @@
   }
 
   &:focus {
+    @include core.focus-ring-color(tokens.get("input", "accent", tokens.get("form-control-accent")));
+
     border-color: tokens.get("input", "border-color-focus", "border-color", tokens.get("input", "accent", tokens.get("form-control-accent")));
     color: tokens.get("input", "foreground-focus", "foreground", tokens.get("form-control-foreground"));
     background-color: tokens.get("input", "background-focus", "background", tokens.get("form-control-background"));
     box-shadow: tokens.get("input", "box-shadow-focus", none);
-  }
-
-  &:focus-visible {
-    @include core.focus-ring-color(tokens.get("input", "accent", tokens.get("form-control-accent")));
   }
 
   &:read-only {

--- a/packages/input/src/_input_type.scss
+++ b/packages/input/src/_input_type.scss
@@ -4,10 +4,18 @@
 #{core.bem("input", null, "type", "select")} {
   cursor: pointer;
   position: relative;
-  padding-right: 2em;
-  background-image: tokens.get("input", "select-icon");
-  background-repeat: no-repeat;
-  background-position: calc(100% - 0.75em) center;
+  display: flex;
+  gap: calc(tokens.get("form-control-padding-y") * 2);
+  align-items: center;
+  appearance: base-select;
+
+  &::picker-icon {
+    @include core.size(tokens.get("input", "select-icon-size", 0.8em));
+
+    content: "";
+    background-color: tokens.get("input", "select-icon-color", currentcolor);
+    mask: url(core.svg("expand")) center center / 100% no-repeat;
+  }
 
   &:read-only {
     background-color: tokens.get("input", "background", tokens.get("background"));

--- a/packages/vrembem/build/tokens.scss
+++ b/packages/vrembem/build/tokens.scss
@@ -1,2 +1,1 @@
-@use "@vrembem/input/src/config";
 @forward "../tokens";


### PR DESCRIPTION
## What changed?

This PR adds select input styles using the new `appearance: base-select` property/value to allow more control over the styles of the select element and it's parts. This also removed the need to use theme tokens for the select-icon and token output files have been updated to reflect that. Input focus-ring styles have also been moved from `focus-visible` to `focus` to reduce redundancy.

Partly addresses: #2806
