### PR TITLE
Add content for philosophy and why pages

### DIFF
--- a/docs/public/tpl/drawer-starter.html
+++ b/docs/public/tpl/drawer-starter.html
@@ -48,12 +48,12 @@
           <div class="section__container content spacing text-align-center">
             <h1>Hello World</h1>
             <p>A drawer based starter template powered by Vrembem via CDN.</p>
-            <div class="flex justify-content-center foreground-subtle margin-bottom-lg">
+            <div class="flex justify-content-center foreground-subtle">
               <a class="link" href="https://vrembem.com/">Docs</a>
               <span>/</span>
               <a class="link" href="https://github.com/sebnitu/vrembem">GitHub</a>
             </div>
-            <button class="button" data-drawer-toggle="drawer-sidebar" type="button">Toggle drawer</button>
+            <button class="button margin-top-lg" data-drawer-toggle="drawer-sidebar" type="button">Toggle drawer</button>
           </div>
         </div>
       </main>

--- a/docs/public/tpl/modal-starter.html
+++ b/docs/public/tpl/modal-starter.html
@@ -22,12 +22,12 @@
       <div class="section__container content spacing text-align-center">
         <h1>Hello World</h1>
         <p>A modal based starter template powered by Vrembem via CDN.</p>
-        <div class="flex justify-content-center foreground-subtle margin-bottom-lg">
+        <div class="flex justify-content-center foreground-subtle">
           <a class="link" href="https://vrembem.com/">Docs</a>
           <span>/</span>
           <a class="link" href="https://github.com/sebnitu/vrembem">GitHub</a>
         </div>
-        <button class="button" data-modal-open="modal-example" type="button">Open modal</button>
+        <button class="button margin-top-lg" data-modal-open="modal-example" type="button">Open modal</button>
       </div>
     </main>
 

--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -47,6 +47,7 @@ const { classes = "" } = Astro.props;
       class="button button_icon button_size_sm"
       data-modal-close=""
       type="button"
+      aria-label="Close menu"
     >
       <Icon name="x" />
     </button>

--- a/docs/src/components/Intro.astro
+++ b/docs/src/components/Intro.astro
@@ -14,7 +14,5 @@ function slugify(value: string) {
 }
 ---
 
-<div class={`content ${data.description ? "margin-bottom-lg" : ""}`.trim()}>
-  <h1 id={slugify(data.title)}>{data.title}</h1>
-  {data.description && <p>{data.description}</p>}
-</div>
+<h1 id={slugify(data.title)}>{data.title}</h1>
+{data.description && <p>{data.description}</p>}

--- a/docs/src/components/OnThisPage.astro
+++ b/docs/src/components/OnThisPage.astro
@@ -6,7 +6,9 @@ const { headings, menuClass = "" } = Astro.props;
 // Filter the headings to only display the ones we want
 const filteredHeadings = build(
   headings.filter((item) => {
-    return item.depth === 2 || item.depth === 3;
+    return (
+      item.slug !== "footnote-label" && (item.depth === 2 || item.depth === 3)
+    );
   })
 );
 

--- a/docs/src/components/ThemeSwitcherMenu.astro
+++ b/docs/src/components/ThemeSwitcherMenu.astro
@@ -2,7 +2,7 @@
 import Icon from "@/components/Icon.astro";
 ---
 
-<ul class="menu menu_themes">
+<ul class="menu">
   <li class="menu__item">
     <button type="button" data-set-theme="auto" class="menu__action">
       <svg

--- a/docs/src/content/data/tokens-core.json
+++ b/docs/src/content/data/tokens-core.json
@@ -1,5 +1,5 @@
 {
-  "--vb-prefix": "vb",
+  "--vb-prefix-tokens": "vb",
   "--vb-prefix-themes": "vb-theme",
   "--vb-breakpoint-xs": "480px",
   "--vb-breakpoint-sm": "620px",

--- a/docs/src/content/pages/guide/index.mdx
+++ b/docs/src/content/pages/guide/index.mdx
@@ -100,9 +100,13 @@ Use this minimal starter template to begin prototyping with Vrembem now. Just co
 
 <CodeExample iframe="/tpl/minimal-starter.html" style="--vb-iframe-height: 18rem;" />
 
+#### Modal starter
+
 A starter template using the modal component:
 
 <CodeExample iframe="/tpl/modal-starter.html" />
+
+#### Drawer starter
 
 A starter template using the drawer component:
 

--- a/docs/src/content/pages/guide/philosophy.mdx
+++ b/docs/src/content/pages/guide/philosophy.mdx
@@ -11,10 +11,10 @@ The main goal of Vrembem is to provide front-end systems that every project need
 
 It's a common misconception that using BEM means you can never deviate from it. Vrembem takes a practical utility-first approach to authoring BEM components. This is the methodology in practice:
 
-- Add utilities first. These are typically one-off single property classes. Vrembem uses a verbose utility naming convention to reduce over-reliance on CSS abstractions[^1].
-- If an element is starting to contain too many utilities, that's a sign that a block class is needed.
-- Add utilities to a block when adjustments are needed.
-- If a block starts to accumulate too many utilities, that's a sign that a modifier class is needed.
+1. Add utilities first. These are typically one-off single property classes. Vrembem uses a verbose utility naming convention to reduce over-reliance on CSS abstractions[^1].
+2. If an element is starting to contain too many utilities, that's a sign that a block class is needed.
+3. Add utilities to a block when adjustments are needed.
+4. If a block starts to accumulate too many utilities, that's a sign that a modifier class is needed.
 
 The benefits to this approach are that it reduces bloat that can exist from early abstractions. Since blocks and modifiers are only created organically once patterns emerge, they become less rigid and more open to composition-based architecture.
 
@@ -28,11 +28,13 @@ This approach allows components to be highly composable with each other, built w
 
 Vrembem uses modern CSS features and native browser APIs to build fast and responsive components for all devices. Purely optional JavaScript modules are available to enhance your projects, or bring-your-own JavaScript. Vrembem implements the following features:
 
-- Design tokens powered by CSS custom properties (variables).
-- Custom palette tokens using the `oklch` color space.
-- Layout components that leverage Flex and Grid.
-- Cascade layers using the `@layer` CSS at-rule for tokens, base, components, and utilities.
-- Native browser APIs are used for things like the dialog element, modals, and popovers.
+<ul class="list list_pros">
+  <li>Design tokens powered by CSS custom properties (variables).</li>
+  <li>Custom palette tokens using the `oklch` color space.</li>
+  <li>Layout components that leverage Flex and Grid.</li>
+  <li>Cascade layers using the `@layer` CSS at-rule for tokens, base, components, and utilities.</li>
+  <li>Native browser APIs are used for things like the dialog element, modals, and popovers.</li>
+</ul>
 
 Vrembem is in active development and will continue to receive the benefits of modern CSS and native APIs as they become available and more widely adopted.
 

--- a/docs/src/content/pages/guide/philosophy.mdx
+++ b/docs/src/content/pages/guide/philosophy.mdx
@@ -3,4 +3,35 @@ title: Philosophy
 order: 2
 ---
 
-...
+Vrembem is a framework-agnostic CSS component library built for people who love writing CSS and the BEM methodology. It merges battle-tested CSS authoring conventions with modern CSS features.
+
+The main goal of Vrembem is to provide front-end systems that every project needs and allow them to be easily customized and expanded. This allows authors to focus on the aspects of a project that are unique to them.
+
+## Utility-first BEM
+
+It's a misconception that you should never break out of the BEM naming convention. Vrembem takes a utility-first approach to writing CSS. This is the approach Vrembem recommends when authoring a UI:
+
+- Add utilities first. These are typically one-off single property classes. Vrembem uses verbose utility names for this reason.
+- If an element is starting to contain too many utilities, that's a sign that a block class is needed.
+- Add utilities to a block when slight adjustments are needed.
+- If a block starts to accumulate too many utilities, that's a sign it's time to write a modifier.
+
+The benefits to this approach are that it reduces bloat that can exist from early abstractions. Since blocks and modifiers are only created once the need arises, they become less rigid and more open to composition-based front-ends.
+
+## Composability
+
+The catalog of available components Vrembem provides is intentionally focused. Instead of having a component for every scenario, primitives are provided for very purposeful roles such as layout, containers, or actions. These can then be combined to create context-specific blocks and views.
+
+This approach allows components to be highly composable with each other, built with the idea that they will be mixed, nested together, and expanded. Only the most common interface patterns are added to keep Vrembem lean and intuitive.
+
+## Modern CSS
+
+Vrembem uses modern CSS features and native browser APIs to build fast and responsive components for all devices. Purely optional JavaScript modules are available to enhance your projects, or bring-your-own JavaScript. Vrembem implements the following features:
+
+- Design tokens powered by CSS custom properties (variables).
+- Custom palette tokens using the `oklch` color space.
+- Layout components that leverage Flex and Grid.
+- Cascade layers using the `@layer` CSS at-rule for tokens, base, components, and utilities.
+- Native browser APIs are used for things like the dialog element, modals, and popovers.
+
+Vrembem is in active development and will continue to receive the benefits of modern CSS and native APIs as they become available and more widely adopted.

--- a/docs/src/content/pages/guide/philosophy.mdx
+++ b/docs/src/content/pages/guide/philosophy.mdx
@@ -9,14 +9,14 @@ The main goal of Vrembem is to provide front-end systems that every project need
 
 ## Utility-first BEM
 
-It's a misconception that you should never break out of the BEM naming convention. Vrembem takes a utility-first approach to writing CSS. This is the approach Vrembem recommends when authoring a UI:
+It's a common misconception that using BEM means you can never deviate from it. Vrembem takes a practical utility-first approach to authoring BEM components. This is the methodology in practice:
 
-- Add utilities first. These are typically one-off single property classes. Vrembem uses verbose utility names for this reason.
+- Add utilities first. These are typically one-off single property classes. Vrembem uses a verbose utility naming convention to reduce over-reliance on CSS abstractions[^1].
 - If an element is starting to contain too many utilities, that's a sign that a block class is needed.
-- Add utilities to a block when slight adjustments are needed.
-- If a block starts to accumulate too many utilities, that's a sign it's time to write a modifier.
+- Add utilities to a block when adjustments are needed.
+- If a block starts to accumulate too many utilities, that's a sign that a modifier class is needed.
 
-The benefits to this approach are that it reduces bloat that can exist from early abstractions. Since blocks and modifiers are only created once the need arises, they become less rigid and more open to composition-based front-ends.
+The benefits to this approach are that it reduces bloat that can exist from early abstractions. Since blocks and modifiers are only created organically once patterns emerge, they become less rigid and more open to composition-based architecture.
 
 ## Composability
 
@@ -35,3 +35,5 @@ Vrembem uses modern CSS features and native browser APIs to build fast and respo
 - Native browser APIs are used for things like the dialog element, modals, and popovers.
 
 Vrembem is in active development and will continue to receive the benefits of modern CSS and native APIs as they become available and more widely adopted.
+
+[^1]: CSS abstraction refers to when utility classes act as a replacement for writing CSS entirely. With a more verbose utility naming convention, utilities match their property and value mapping more explicitly.

--- a/docs/src/content/pages/guide/philosophy.mdx
+++ b/docs/src/content/pages/guide/philosophy.mdx
@@ -11,8 +11,8 @@ The main goal of Vrembem is to provide front-end systems that every project need
 
 It's a common misconception that using BEM means you can never deviate from it. Vrembem takes a practical utility-first approach to authoring BEM components. This is the methodology in practice:
 
-<ol class="list">
-  <li>Add utilities first. These are typically one-off single property classes. Vrembem uses a verbose utility naming convention to reduce over-reliance on CSS abstractions[^1].</li>
+<ol class="list list_prog">
+  <li>Add utilities first. These are typically one-off single property classes. Vrembem uses a verbose utility naming convention to reduce over-reliance on CSS abstractions.[^1]</li>
   <li>If an element is starting to contain too many utilities, that's a sign that a block class is needed.</li>
   <li>Add utilities to a block when adjustments are needed.</li>
   <li>If a block starts to accumulate too many utilities, that's a sign that a modifier class is needed.</li>

--- a/docs/src/content/pages/guide/philosophy.mdx
+++ b/docs/src/content/pages/guide/philosophy.mdx
@@ -5,7 +5,7 @@ order: 2
 
 Vrembem is a framework-agnostic CSS component library built for people who love writing CSS and the BEM methodology. It merges battle-tested CSS authoring conventions with modern CSS features.
 
-The main goal of Vrembem is to provide front-end systems that every project needs and allow them to be easily customized and expanded. This allows authors to focus on the aspects of a project that are unique to them.
+The main goal of Vrembem is to provide front-end systems that every project needs while making it easy to customize and expand. This allows authors to focus on the aspects of a project that are unique to them.
 
 ## Utility-first BEM
 

--- a/docs/src/content/pages/guide/philosophy.mdx
+++ b/docs/src/content/pages/guide/philosophy.mdx
@@ -11,10 +11,12 @@ The main goal of Vrembem is to provide front-end systems that every project need
 
 It's a common misconception that using BEM means you can never deviate from it. Vrembem takes a practical utility-first approach to authoring BEM components. This is the methodology in practice:
 
-1. Add utilities first. These are typically one-off single property classes. Vrembem uses a verbose utility naming convention to reduce over-reliance on CSS abstractions[^1].
-2. If an element is starting to contain too many utilities, that's a sign that a block class is needed.
-3. Add utilities to a block when adjustments are needed.
-4. If a block starts to accumulate too many utilities, that's a sign that a modifier class is needed.
+<ol class="list">
+  <li>Add utilities first. These are typically one-off single property classes. Vrembem uses a verbose utility naming convention to reduce over-reliance on CSS abstractions[^1].</li>
+  <li>If an element is starting to contain too many utilities, that's a sign that a block class is needed.</li>
+  <li>Add utilities to a block when adjustments are needed.</li>
+  <li>If a block starts to accumulate too many utilities, that's a sign that a modifier class is needed.</li>
+</ol>
 
 The benefits to this approach are that it reduces bloat that can exist from early abstractions. Since blocks and modifiers are only created organically once patterns emerge, they become less rigid and more open to composition-based architecture.
 

--- a/docs/src/content/pages/guide/why.mdx
+++ b/docs/src/content/pages/guide/why.mdx
@@ -3,4 +3,32 @@ title: Why Vrembem
 order: 3
 ---
 
-...
+Vrembem was created to be a foundational starting point for design-system-based user interfaces. It provides the patterns and building blocks for creating rich and focused applications using sensible defaults. These systems include:
+
+<ul class="list list_pros">
+  <li>Utility-first BEM methodology</li>
+  <li>Design tokens via CSS variables</li>
+  <li>Sass config and token modules</li>
+  <li>Collections API for JavaScript components</li>
+</ul>
+
+## Why BEM
+
+The BEM naming convention remains a powerful methodology for creating style-encapsulated components. Though the problems BEM originally solved are typically handled by modern front-end frameworks, BEM is a solution that works everywhere. When used alongside front-end frameworks, BEM still provides human-readable context for components and how they relate to one another.
+
+Taking a utility-first approach with BEM also resolves issues such as bloat from early abstractions, having to come up with class names for small tweaks, and making every child of a block its element. Along with native CSS cascade layers, Vrembem provides the methodology for a robust and predictable style system.
+
+## Framework-agnostic
+
+Vrembem works everywhere. At its core, it's just a collection of CSS classes and some opt-in JavaScript behavior powered by native browser APIs. This CSS-first approach makes Vrembem framework-agnostic and even vanilla HTML friendly.
+
+Vrembem avoids vendor lock-in because it's a modular library built on open methodologies. If your project already uses BEM, you have the option of using `@vrembem/menu` or writing your own menu component. The classes or HTML wouldn't need to change at all.
+
+## Embrace CSS
+
+Vrembem embraces CSS rather than abstracting it away. Instead of hiding styles behind proprietary APIs or shorthand conventions, Vrembem provides systems that work with CSS, letting authors take full advantage of its features directly.
+
+<ul class="list list_pros">
+  <li>Components are styled with CSS custom properties, making them easy to customize or extend without overriding specificity. Write CSS the way you normally would.</li>
+  <li>Utility class names map directly to their CSS property and value (e.g., `margin-bottom-lg` instead of `mb-8`), keeping the abstraction layer thin and readable.</li>
+</ul>

--- a/docs/src/content/pages/packages/content.mdx
+++ b/docs/src/content/pages/packages/content.mdx
@@ -108,7 +108,7 @@ Content modules each have their own output styles. These are all output by defau
 
 ```scss
 @include config.set("content-output-exceptions", (
-  "global", "headings"
+  "content", "headings"
 ));
 ```
 </ReferenceCard>
@@ -130,11 +130,11 @@ Use the `content-output` configuration to toggle output for all modules. Add exc
   "pre"
 ));
 
-// Disable the output of all modules except for "global" and "headings"
+// Disable the output of all modules except for "content" and "headings"
 @include config.set((
   "content-output": false
   "content-output-exceptions": (
-    "global",
+    "content",
     "headings"
   )
 ));

--- a/docs/src/content/pages/packages/content.mdx
+++ b/docs/src/content/pages/packages/content.mdx
@@ -57,12 +57,11 @@ Content comes with the following Sass configuration options that can be set usin
     // value of a font-size and optional line-height (space separated).
     // @type map
     "content-headings": (
-      "h1": 2.75em,
-      "h2": 2em,
-      "h3": 1.75em,
-      "h4": 1.5em,
-      "h5": 1.25em,
-      "h6": 1em
+      "h1": 2.75em 1.1,
+      "h2": 2em 1.25,
+      "h3": 1.75em 1.3,
+      "h4": 1.5em 1.35,
+      "h5": 1.25em 1.4
     ),
 
     // Map modules to their preferred content selectors

--- a/docs/src/content/pages/packages/menu.mdx
+++ b/docs/src/content/pages/packages/menu.mdx
@@ -48,7 +48,9 @@ Menu comes with the following Sass configuration options that can be set using e
 Menu uses design token CSS variables in a reference and fallback pattern. Variables are referenced in the component's styles but are not directly defined; instead, they are provided with sensible fallbacks.
 
 <ReferenceTable id="tokens-menu" valueLabel="Fallback" expandable={true} data={{
-  // Base styles
+  // Menu base
+  "--vb-menu-size": "var(--vb-font-size)",
+  "--vb-menu-line-height": "var(--vb-line-height)",
   "--vb-menu-padding": "0.5em 1em",
   "--vb-menu-border-radius": "var(--vb-border-radius)",
 

--- a/docs/src/content/pages/packages/menu.mdx
+++ b/docs/src/content/pages/packages/menu.mdx
@@ -48,9 +48,7 @@ Menu comes with the following Sass configuration options that can be set using e
 Menu uses design token CSS variables in a reference and fallback pattern. Variables are referenced in the component's styles but are not directly defined; instead, they are provided with sensible fallbacks.
 
 <ReferenceTable id="tokens-menu" valueLabel="Fallback" expandable={true} data={{
-  // Form control fallbacks
-  "--vb-menu-size": "var(--vb-font-size)",
-  "--vb-menu-line-height": "var(--vb-line-height)",
+  // Base styles
   "--vb-menu-padding": "0.5em 1em",
   "--vb-menu-border-radius": "var(--vb-border-radius)",
 

--- a/docs/src/content/pages/packages/vrembem.mdx
+++ b/docs/src/content/pages/packages/vrembem.mdx
@@ -4,9 +4,7 @@ package: "vrembem"
 category: all
 ---
 
-<div class="margin-top-0 margin-bottom-lg">
-  Vrembem is a collection of packages built with Sass and TypeScript that compile to CSS and JavaScript. Each package can be installed individually, or the entire library can be used by installing the `vrembem` package:
-</div>
+Vrembem is a collection of packages built with Sass and TypeScript that compile to CSS and JavaScript. Each package can be installed individually, or the entire library can be used by installing the `vrembem` package:
 
 ```sh
 npm install vrembem

--- a/docs/src/content/pages/reference/collections/plugins/css-config.mdx
+++ b/docs/src/content/pages/reference/collections/plugins/css-config.mdx
@@ -56,7 +56,7 @@ popovers.config.shiftPadding
 ```
 </CodeExample>
 
-The prefix is defined under the custom property `--vb-prefix`, which defaults to `vb`.
+The prefix is defined under the custom property `--vb-prefix-tokens`, which defaults to `vb`.
 
 ## Configuration
 

--- a/docs/src/modules/headingAnchor.js
+++ b/docs/src/modules/headingAnchor.js
@@ -16,7 +16,11 @@ const headingAnchor = {
       const els = document.querySelectorAll(`${config.prefix} ${heading}`);
       els.forEach((el) => {
         // Return if heading has the `no-anchor` class
-        if (el.classList.contains("no-anchor")) return;
+        if (
+          el.classList.contains("no-anchor") ||
+          el.classList.contains("sr-only")
+        )
+          return;
 
         // Return if heading is in a code example
         if (el.closest(".code-example")) return;

--- a/docs/src/styles/_footnotes.scss
+++ b/docs/src/styles/_footnotes.scss
@@ -1,11 +1,11 @@
 @use "@vrembem/core/tokens";
 
 .footnotes {
-  font-size: tokens.get("font-size-sm");
-  line-height: tokens.get("line-height");
-  padding-top: 2em;
   margin-top: 2em !important;
+  padding-top: 2em;
   border-top: tokens.get("border");
+  font-size: tokens.get("font-size");
+  line-height: tokens.get("line-height");
 
   ol {
     margin-left: tokens.get("list", "indent", tokens.get("spacing-lg"));
@@ -18,14 +18,15 @@
 }
 
 [data-footnote-ref] {
-  background-color: tokens.get("palette", "primary", $a: 10%);
-  padding: 0.25em 0.5em;
-  border-radius: tokens.get("border-radius-circle");
-  text-decoration: none;
-  min-width: fit-content;
   aspect-ratio: 1;
+  min-width: fit-content;
+  padding: 0.125em 0.5em;
+  border-radius: tokens.get("border-radius-circle");
+  font-family: tokens.get("font-family-mono");
   font-size: tokens.get("font-size-sm");
   line-height: tokens.get("line-height");
+  text-decoration: none;
+  background-color: tokens.get("palette", "primary", $a: 10%);
 
   &:hover {
     background-color: tokens.get("palette", "primary", $a: 20%);

--- a/docs/src/styles/_footnotes.scss
+++ b/docs/src/styles/_footnotes.scss
@@ -1,0 +1,33 @@
+@use "@vrembem/core/tokens";
+
+.footnotes {
+  font-size: tokens.get("font-size-sm");
+  line-height: tokens.get("line-height");
+  padding-top: 2em;
+  margin-top: 2em !important;
+  border-top: tokens.get("border");
+
+  ol {
+    margin-left: tokens.get("list", "indent", tokens.get("spacing-lg"));
+  }
+
+  li li,
+  li + li {
+    margin-top: tokens.get("list", "spacing", tokens.get("spacing-sm"));
+  }
+}
+
+[data-footnote-ref] {
+  background-color: tokens.get("palette", "primary", $a: 10%);
+  padding: 0.25em 0.5em;
+  border-radius: tokens.get("border-radius-circle");
+  text-decoration: none;
+  min-width: fit-content;
+  aspect-ratio: 1;
+  font-size: tokens.get("font-size-sm");
+  line-height: tokens.get("line-height");
+
+  &:hover {
+    background-color: tokens.get("palette", "primary", $a: 20%);
+  }
+}

--- a/docs/src/styles/_global.scss
+++ b/docs/src/styles/_global.scss
@@ -45,14 +45,6 @@ html {
     position: relative;
     outline: none;
   }
-
-  h3 {
-    font-weight: 500;
-  }
-
-  h4 {
-    font-size: 1.25em;
-  }
 }
 
 /**

--- a/docs/src/styles/_list_prog.scss
+++ b/docs/src/styles/_list_prog.scss
@@ -2,16 +2,16 @@
 @use "@vrembem/core/tokens";
 
 .list_prog {
-  display: block;
   counter-reset: item;
+  display: block;
   margin-left: 0;
   list-style: none;
 
   li {
     position: relative;
-    padding-left: 3em;
     margin: 0;
     padding-bottom: 1em;
+    padding-left: 3em;
 
     &:last-child {
       padding-bottom: 0;
@@ -20,26 +20,27 @@
 
   li::before {
     @include core.size(2em);
+
+    content: counter(item);
+    counter-increment: item;
     position: absolute;
     z-index: 2;
     inset: 0 auto auto 0;
     display: block;
     flex-shrink: 0;
-    text-align: center;
-    content: counter(item);
-    counter-increment: item;
     border: tokens.get("border");
     border-radius: tokens.get("border-radius-circle");
+    text-align: center;
     background-color: tokens.get("background");
   }
 
   li:not(:last-child)::after {
     content: "";
-    background-color: tokens.get("border-color");
     position: absolute;
     z-index: 1;
     inset: 0 auto 0 1em;
     width: 1px;
     height: 100%;
+    background-color: tokens.get("border-color");
   }
 }

--- a/docs/src/styles/_list_prog.scss
+++ b/docs/src/styles/_list_prog.scss
@@ -1,0 +1,45 @@
+@use "@vrembem/core";
+@use "@vrembem/core/tokens";
+
+.list_prog {
+  display: block;
+  counter-reset: item;
+  margin-left: 0;
+  list-style: none;
+
+  li {
+    position: relative;
+    padding-left: 3em;
+    margin: 0;
+    padding-bottom: 1em;
+
+    &:last-child {
+      padding-bottom: 0;
+    }
+  }
+
+  li::before {
+    @include core.size(2em);
+    position: absolute;
+    z-index: 2;
+    inset: 0 auto auto 0;
+    display: block;
+    flex-shrink: 0;
+    text-align: center;
+    content: counter(item);
+    counter-increment: item;
+    border: tokens.get("border");
+    border-radius: tokens.get("border-radius-circle");
+    background-color: tokens.get("background");
+  }
+
+  li:not(:last-child)::after {
+    content: "";
+    background-color: tokens.get("border-color");
+    position: absolute;
+    z-index: 1;
+    inset: 0 auto 0 1em;
+    width: 1px;
+    height: 100%;
+  }
+}

--- a/docs/src/styles/_main.scss
+++ b/docs/src/styles/_main.scss
@@ -59,7 +59,7 @@
     }
 
     .drawer__container {
-      padding: tokens.get("main", "content-padding-y") tokens.get("layout", "padding");
+      padding: tokens.get("main", "content-padding-y") tokens.get("layout", "padding") tokens.get("main", "content-padding-y") 0;
     }
   }
 }

--- a/docs/src/styles/_menu_minimal.scss
+++ b/docs/src/styles/_menu_minimal.scss
@@ -1,10 +1,9 @@
+@use "@vrembem/core";
 @use "@vrembem/core/tokens";
 
 .menu_minimal {
-  @include tokens.override("menu", "size", tokens.get("font-size-sm"));
-
-  .menu {
-    @include tokens.override("menu", "size", 1em);
+  @include core.media-min("aside") {
+    font-size: tokens.get("font-size-sm");
   }
 
   .menu__action {

--- a/docs/src/styles/_menu_minimal.scss
+++ b/docs/src/styles/_menu_minimal.scss
@@ -3,7 +3,7 @@
 
 .menu_minimal {
   @include core.media-min("aside") {
-    font-size: tokens.get("font-size-sm");
+    @include tokens.override("menu", "size", tokens.get("font-size-sm"));
   }
 
   .menu__action {

--- a/docs/src/styles/_menu_minimal.scss
+++ b/docs/src/styles/_menu_minimal.scss
@@ -1,13 +1,11 @@
 @use "@vrembem/core/tokens";
 
 .menu_minimal {
-  @include tokens.override(
-    "menu",
-    (
-      "gap": 0,
-      "size": tokens.get("font-size-sm")
-    )
-  );
+  @include tokens.override("menu", "size", tokens.get("font-size-sm"));
+
+  .menu {
+    @include tokens.override("menu", "size", 1em);
+  }
 
   .menu__action {
     &::before {

--- a/docs/src/styles/_menu_themes.scss
+++ b/docs/src/styles/_menu_themes.scss
@@ -1,9 +1,0 @@
-@use "@vrembem/core/tokens";
-
-.menu_themes {
-  @include tokens.override("menu", "action-gap", 1rem);
-
-  .popover & {
-    font-size: tokens.get("font-size-sm");
-  }
-}

--- a/docs/src/styles/app.scss
+++ b/docs/src/styles/app.scss
@@ -33,9 +33,11 @@
   @include meta.load-css("./compare");
   @include meta.load-css("./doc-block");
   @include meta.load-css("./fold-shadow");
+  @include meta.load-css("./footnotes");
   @include meta.load-css("./heading-anchor");
   @include meta.load-css("./icon_external");
   @include meta.load-css("./layout-demo");
+  @include meta.load-css("./list_prog");
   @include meta.load-css("./menu_collection");
   @include meta.load-css("./menu_minimal");
   @include meta.load-css("./pagi");

--- a/docs/src/styles/app.scss
+++ b/docs/src/styles/app.scss
@@ -38,7 +38,6 @@
   @include meta.load-css("./layout-demo");
   @include meta.load-css("./menu_collection");
   @include meta.load-css("./menu_minimal");
-  @include meta.load-css("./menu_themes");
   @include meta.load-css("./pagi");
   @include meta.load-css("./popover_copy");
   @include meta.load-css("./reference-bar");

--- a/packages/content/src/_config.scss
+++ b/packages/content/src/_config.scss
@@ -30,12 +30,11 @@ $default: (
   // value of a font-size and optional line-height (space separated).
   // @type map
   "content-headings": (
-    "h1": 2.75em,
-    "h2": 2em,
-    "h3": 1.75em,
-    "h4": 1.5em,
-    "h5": 1.25em,
-    "h6": 1em
+    "h1": 2.75em 1.1,
+    "h2": 2em 1.25,
+    "h3": 1.75em 1.3,
+    "h4": 1.5em 1.35,
+    "h5": 1.25em 1.4
   ),
 
   // Map modules to their preferred content selectors

--- a/packages/content/src/_config.scss
+++ b/packages/content/src/_config.scss
@@ -30,11 +30,11 @@ $default: (
   // value of a font-size and optional line-height (space separated).
   // @type map
   "content-headings": (
-    "h1": 2.75rem 1.125,
+    "h1": 2.75rem 1.25,
     "h2": 2rem 1.25,
-    "h3": 1.75rem 1.3,
-    "h4": 1.5rem 1.35,
-    "h5": 1.25rem 1.4
+    "h3": 1.75rem 1.25,
+    "h4": 1.5rem 1.375,
+    "h5": 1.25rem
   ),
 
   // Map modules to their preferred content selectors

--- a/packages/content/src/_config.scss
+++ b/packages/content/src/_config.scss
@@ -30,11 +30,11 @@ $default: (
   // value of a font-size and optional line-height (space separated).
   // @type map
   "content-headings": (
-    "h1": 2.75em 1.1,
-    "h2": 2em 1.25,
-    "h3": 1.75em 1.3,
-    "h4": 1.5em 1.35,
-    "h5": 1.25em 1.4
+    "h1": 2.75rem 1.125,
+    "h2": 2rem 1.25,
+    "h3": 1.75rem 1.3,
+    "h4": 1.5rem 1.35,
+    "h5": 1.25rem 1.4
   ),
 
   // Map modules to their preferred content selectors

--- a/packages/core/src/js/helpers/getPrefix.ts
+++ b/packages/core/src/js/helpers/getPrefix.ts
@@ -1,11 +1,11 @@
 /**
- * Get the Vrembem variables prefix from the `--vb-prefix` custom property.
+ * Get the Vrembem variables prefix from the `--vb-prefix-tokens` custom property.
  *
  * @returns {string} The value of the defined prefix variable.
  */
 export function getPrefix(delimiter: string = ""): string {
   const prefix = getComputedStyle(document.body)
-    .getPropertyValue("--vb-prefix")
+    .getPropertyValue("--vb-prefix-tokens")
     .trim();
   return prefix ? `${prefix}${delimiter}` : "";
 }

--- a/packages/core/src/scss/tokens/_prefix.scss
+++ b/packages/core/src/scss/tokens/_prefix.scss
@@ -4,7 +4,7 @@
 // are output. This allows prefix to be modified before output.
 @include tokens.set(
   "core",
-  "prefix",
+  "prefix-tokens",
   (
     "config": (
       "prefix-tokens",

--- a/packages/core/src/scss/tokens/_typography.scss
+++ b/packages/core/src/scss/tokens/_typography.scss
@@ -16,8 +16,8 @@
       monospace
     ),
     "font-size": 1rem,
-    "font-size-sm": 0.875rem,
-    "font-size-lg": 1.125rem,
+    "font-size-sm": 0.875em,
+    "font-size-lg": 1.125em,
     "line-height": 1.5,
     "font-weight-thin": 100,
     "font-weight-extra-light": 200,

--- a/packages/core/src/scss/tokens/_typography.scss
+++ b/packages/core/src/scss/tokens/_typography.scss
@@ -16,8 +16,8 @@
       monospace
     ),
     "font-size": 1rem,
-    "font-size-sm": 0.875em,
-    "font-size-lg": 1.125em,
+    "font-size-sm": 0.875rem,
+    "font-size-lg": 1.125rem,
     "line-height": 1.5,
     "font-weight-thin": 100,
     "font-weight-extra-light": 200,

--- a/packages/core/tests/helpers/cssVar.test.js
+++ b/packages/core/tests/helpers/cssVar.test.js
@@ -4,7 +4,7 @@ document.body.style.setProperty("--background-color", "pink");
 document.body.style.setProperty("--vb-background-color", "green");
 
 beforeEach(() => {
-  document.body.style.removeProperty("--vb-prefix");
+  document.body.style.removeProperty("--vb-prefix-tokens");
 });
 
 test("should return a CSS custom property", () => {
@@ -18,7 +18,7 @@ test("should return a CSS custom property with no prefix defined", () => {
 });
 
 test("should return a CSS custom property with vrembem prefix", () => {
-  document.body.style.setProperty("--vb-prefix", "vb");
+  document.body.style.setProperty("--vb-prefix-tokens", "vb");
   const data = cssVar("background-color");
   expect(data).toBe("green");
 });

--- a/packages/core/tests/helpers/getPrefix.test.js
+++ b/packages/core/tests/helpers/getPrefix.test.js
@@ -5,11 +5,11 @@ test("should return an empty string if no prefix is found", () => {
 });
 
 test("should return the vrembem prefix value", () => {
-  document.body.style.setProperty("--vb-prefix", "vb");
+  document.body.style.setProperty("--vb-prefix-tokens", "vb");
   expect(getPrefix()).toBe("vb");
 });
 
 test("should return the vrembem prefix value with an affixed delimiter", () => {
-  document.body.style.setProperty("--vb-prefix", "vb");
+  document.body.style.setProperty("--vb-prefix-tokens", "vb");
   expect(getPrefix("-")).toBe("vb-");
 });

--- a/packages/drawer/tests/accessibility.test.js
+++ b/packages/drawer/tests/accessibility.test.js
@@ -22,7 +22,7 @@ const dialog = document.querySelector(".drawer__dialog");
 const main = document.querySelector(".drawer-main");
 const btn = document.querySelector("[data-drawer-toggle]");
 
-document.body.style.setProperty("--vb-prefix", "vb-");
+document.body.style.setProperty("--vb-prefix-tokens", "vb");
 el.style.setProperty("--vb-drawer-transition-duration", "0.3s");
 
 beforeEach(() => {

--- a/packages/drawer/tests/handlers.test.js
+++ b/packages/drawer/tests/handlers.test.js
@@ -34,7 +34,7 @@ const btnClose = document.querySelector('[data-drawer-close="drawer"]');
 const btnCloseInner = document.querySelector(".drawer [data-drawer-close]");
 const btnCloseEmpty = document.querySelector(".empty");
 
-document.body.style.setProperty("--vb-prefix", "vb-");
+document.body.style.setProperty("--vb-prefix-tokens", "vb");
 drawerEl.style.setProperty("--vb-drawer-transition-duration", "0.3s");
 
 const drawers = new DrawerCollection();

--- a/packages/menu/src/_menu.scss
+++ b/packages/menu/src/_menu.scss
@@ -6,6 +6,8 @@
   flex-direction: column;
   gap: tokens.get("menu", "gap", 1px);
   align-items: stretch;
+  font-size: tokens.get("menu", "size", tokens.get("font-size"));
+  line-height: tokens.get("menu", "line-height", tokens.get("line-height"));
   list-style: none;
 }
 

--- a/packages/menu/src/_menu.scss
+++ b/packages/menu/src/_menu.scss
@@ -6,8 +6,6 @@
   flex-direction: column;
   gap: tokens.get("menu", "gap", 1px);
   align-items: stretch;
-  font-size: tokens.get("menu", "size", tokens.get("font-size"));
-  line-height: tokens.get("menu", "line-height", tokens.get("line-height"));
   list-style: none;
 }
 

--- a/packages/popover/tests/collection.test.js
+++ b/packages/popover/tests/collection.test.js
@@ -22,7 +22,7 @@ const markup = `
 `;
 
 beforeAll(() => {
-  document.body.style.setProperty("--vb-prefix", "vb-");
+  document.body.style.setProperty("--vb-prefix-tokens", "vb");
 });
 
 describe("register() & entry.deregister()", () => {

--- a/packages/popover/tests/helpers.test.js
+++ b/packages/popover/tests/helpers.test.js
@@ -44,7 +44,7 @@ const customPropertyMarkup = `
 `;
 
 beforeAll(() => {
-  document.body.style.setProperty("--vb-prefix", "vb");
+  document.body.style.setProperty("--vb-prefix-tokens", "vb");
 });
 
 afterEach(() => {

--- a/packages/select/src/_select.scss
+++ b/packages/select/src/_select.scss
@@ -21,7 +21,7 @@
   &::picker(select) {
     cursor: default;
     transform: translateY(0);
-    margin-block: tokens.get("select", "picker-offset", 0.25em);
+    margin-block: tokens.get("select", "picker-offset", tokens.get("focus-ring-width"));
     padding: tokens.get("select", "picker-padding", 0.5em 0);
     border: tokens.get("select", "picker-border", 1px solid tokens.get("border-color-strong"));
     border-radius: tokens.get("select", "border-radius", tokens.get("form-control-border-radius"));


### PR DESCRIPTION
## What changed?

This PR adds content for the "Philosophy" and "Why Vrembem" pages of the documentation website.

**Additional changes**

- `core`: Rename `--vb-prefix` to `--vb-prefix-tokens` so that it's purpose is more clear.
- `content`: Add appropriate line-height heading sizes.
- `select`: Improve offset value of select picker.
- `docs`: Add styles and modifiers for footnotes and progress lists.
- `docs`: Simplify menu modifier overrides.
