### PR TITLE
Add theme output toggle and prefers-reduced-motion support

### DIFF
--- a/docs/src/styles/_global.scss
+++ b/docs/src/styles/_global.scss
@@ -16,19 +16,6 @@ html {
   }
 }
 
-@media (prefers-reduced-motion: reduce) {
-  :root {
-    @include core.tokens-override(
-      "core",
-      (
-        "transition-duration": 0s,
-        "transition-duration-short": 0s,
-        "transition-duration-long": 0s
-      )
-    );
-  }
-}
-
 #main {
   outline: none;
 }

--- a/packages/core/src/scss/_config.scss
+++ b/packages/core/src/scss/_config.scss
@@ -61,6 +61,8 @@ $default: (
     "950": (16%, 60%), // The darkest variant in the palette
   ),
 
+  // TODO: Add option to disable theme output
+
   // Sets the default theme option
   // @type string
   "theme-default": "light",

--- a/packages/core/src/scss/_config.scss
+++ b/packages/core/src/scss/_config.scss
@@ -61,7 +61,10 @@ $default: (
     "950": (16%, 60%), // The darkest variant in the palette
   ),
 
-  // TODO: Add option to disable theme output
+  // Whether or not to output theme tokens. If disabled, the default theme is 
+  // output as normal base tokens in the :root selector.
+  // @type boolean
+  "theme-output": true,
 
   // Sets the default theme option
   // @type string

--- a/packages/core/src/scss/modules/_themes.scss
+++ b/packages/core/src/scss/modules/_themes.scss
@@ -134,8 +134,7 @@ $-theme-keys: ();
 }
 
 /// Output all the custom properties and values of a component theme or output a
-/// specific theme from all components. The root selector or theme class is not
-/// included in the output.
+/// specific theme from all components. The output is not wrapped in a selector.
 ///
 /// @param {string} $theme
 ///   The theme to output.
@@ -160,12 +159,15 @@ $-theme-keys: ();
       // Save a copy of the component map from variables
       $component-theme-map: map.get($component-map, "themes", $theme);
 
-      // Get a reference of the color scheme property
-      $color-scheme: map.get($component-theme-map, "color-scheme");
+      // Don't output color-scheme if theme-output is disabled
+      @if config.get(li("theme-output"), true) {
+        // Get a reference of the color scheme property
+        $color-scheme: map.get($component-theme-map, "color-scheme");
 
-      // If a color scheme was stored, output it above everything else
-      @if $color-scheme {
-        color-scheme: #{$color-scheme};
+        // If a color scheme was stored, output it above everything else
+        @if $color-scheme {
+          color-scheme: #{$color-scheme};
+        }
       }
 
       // Output custom properties
@@ -173,6 +175,26 @@ $-theme-keys: ();
         @include tokens.define($component, $prop, $value);
       }
     }
+  }
+}
+
+/// Output all the custom properties and values of the default theme. The output
+/// is not wrapped in a selector.
+///
+/// @param {string} $component ("*")
+///   The component to output. Use "*" to output a theme from all
+///   components.
+///
+/// @access private
+///
+@mixin -output-default($component) {
+  // Only output default theme if theme-output is set to false
+  @if not config.get(li("theme-output"), true) {
+    // Get the default theme
+    $theme: config.get(li("theme-default"), "light");
+
+    // Output the default theme
+    @include -output-theme($theme, $component);
   }
 }
 
@@ -192,42 +214,45 @@ $-theme-keys: ();
 ///   @include theme.output("notice");
 ///
 @mixin -output($component: "*") {
-  // Output the default theme and system preference media query under the root
-  // selector and auto theme. This should come before the theme class output.
-  :root,
-  #{-selector("auto")} {
-    // Get the default theme
-    $theme: config.get(li("theme-default"), "light");
+  // Only output themes if theme-output is enabled (defaults to true)
+  @if config.get(li("theme-output"), true) {
+    // Output the default theme and system preference media query under the root
+    // selector and auto theme. This should come before the theme class output.
+    :root,
+    #{-selector("auto")} {
+      // Get the default theme
+      $theme: config.get(li("theme-default"), "light");
 
-    // Output the default theme
-    @include -output-theme($theme, $component);
+      // Output the default theme
+      @include -output-theme($theme, $component);
 
-    // If the default them is not light mode, output the prefers light media query
-    @if $theme != "light" {
-      @media (prefers-color-scheme: light) {
-        @include -output-theme("light", $component);
+      // If the default them is not light mode, output the prefers light media query
+      @if $theme != "light" {
+        @media (prefers-color-scheme: light) {
+          @include -output-theme("light", $component);
+        }
+      }
+
+      // If the default them is not dark mode, output the prefers dark media query
+      @if $theme != "dark" {
+        @media (prefers-color-scheme: dark) {
+          @include -output-theme("dark", $component);
+        }
       }
     }
 
-    // If the default them is not dark mode, output the prefers dark media query
-    @if $theme != "dark" {
-      @media (prefers-color-scheme: dark) {
-        @include -output-theme("dark", $component);
+    // This outputs all custom modes using their selector
+    @each $key in $-mode-keys {
+      #{-selector($key)} {
+        @include -output-theme($key, $component);
       }
     }
-  }
 
-  // This outputs all custom modes using their selector
-  @each $key in $-mode-keys {
-    #{-selector($key)} {
-      @include -output-theme($key, $component);
-    }
-  }
-
-  // This outputs all custom themes using their selector
-  @each $key in $-theme-keys {
-    #{-selector($key)} {
-      @include -output-theme($key, $component);
+    // This outputs all custom themes using their selector
+    @each $key in $-theme-keys {
+      #{-selector($key)} {
+        @include -output-theme($key, $component);
+      }
     }
   }
 }
@@ -238,4 +263,5 @@ $-theme-keys: ();
 @include tokens.add-hook("setter", "mode", meta.get-function("-type-transform-hook"));
 
 // Add tokens event listener that runs whenever tokens are output
-@include tokens.on("output", "output-theme-tokens", meta.get-mixin("-output"));
+@include tokens.on("root-output", "output-default-theme", meta.get-mixin("-output-default"));
+@include tokens.on("output", "output-theme", meta.get-mixin("-output"));

--- a/packages/core/src/scss/modules/_tokens.scss
+++ b/packages/core/src/scss/modules/_tokens.scss
@@ -673,6 +673,8 @@ $-events: ();
     } @else {
       @include -output-component($component);
     }
+
+    @include -emit-event("root-output", $component);
   }
 
   @include -emit-event("output", $component);

--- a/packages/core/src/scss/tokens/_transition.scss
+++ b/packages/core/src/scss/tokens/_transition.scss
@@ -1,4 +1,5 @@
 @use "../modules/tokens";
+
 @include tokens.set(
   "core",
   (
@@ -16,3 +17,17 @@
     "transition-long": tokens.get("transition-duration-long") tokens.get("transition-timing-function")
   )
 );
+
+// TODO: Add prefers-reduced-motion support, e.g:
+// @media (prefers-reduced-motion: reduce) {
+//   :root {
+//     @include core.tokens-override(
+//       "core",
+//       (
+//         "transition-duration": 0s,
+//         "transition-duration-short": 0s,
+//         "transition-duration-long": 0s
+//       )
+//     );
+//   }
+// }

--- a/packages/core/src/scss/tokens/_transition.scss
+++ b/packages/core/src/scss/tokens/_transition.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 @use "../modules/tokens";
 @include tokens.set(
   "core",
@@ -17,16 +18,12 @@
   )
 );
 
-// TODO: Add prefers-reduced-motion support, e.g:
-// @media (prefers-reduced-motion: reduce) {
-//   :root {
-//     @include core.tokens-override(
-//       "core",
-//       (
-//         "transition-duration": 0s,
-//         "transition-duration-short": 0s,
-//         "transition-duration-long": 0s
-//       )
-//     );
-//   }
-// }
+@mixin -prefers-reduced-motion($args...) {
+  @media (prefers-reduced-motion: reduce) {
+    @include tokens.define("core", "transition-duration", 0s);
+    @include tokens.define("core", "transition-duration-short", 0s);
+    @include tokens.define("core", "transition-duration-long", 0s);
+  }
+}
+
+@include tokens.on("root-output", "prefers-reduced-motion", meta.get-mixin("-prefers-reduced-motion"));

--- a/packages/core/src/scss/tokens/_transition.scss
+++ b/packages/core/src/scss/tokens/_transition.scss
@@ -1,5 +1,4 @@
 @use "../modules/tokens";
-
 @include tokens.set(
   "core",
   (


### PR DESCRIPTION
## What changed?

This pull request introduces a new configuration option for theme output in the SCSS token system, allowing projects to control whether theme tokens are emitted as custom properties or as base tokens. It also applies reduced motion preference to the core library (where transition tokens are initially defined) and removes the need to add overrides in the documentation styles. The changes enhance flexibility and maintainability in theming and accessibility.

**Theme output configuration and refactoring:**

* Added a new `"theme-output"` boolean option in `packages/core/src/scss/_config.scss` to control whether theme tokens are output as custom properties or as base tokens.
* Updated theme mixins in `packages/core/src/scss/modules/_themes.scss` to respect the `"theme-output"` setting, including conditional output of `color-scheme` and theme tokens. [[1]](diffhunk://#diff-587100a829f214bb94d87066092737eb9d0e9d33ad5d879d42d5138f6987832bR162-R171) [[2]](diffhunk://#diff-587100a829f214bb94d87066092737eb9d0e9d33ad5d879d42d5138f6987832bR181-R200) [[3]](diffhunk://#diff-587100a829f214bb94d87066092737eb9d0e9d33ad5d879d42d5138f6987832bR217-R218)
* Refactored the event system to support separate output for default and themed tokens, introducing a new `"root-output"` event and corresponding mixins. [[1]](diffhunk://#diff-587100a829f214bb94d87066092737eb9d0e9d33ad5d879d42d5138f6987832bR258-R267) [[2]](diffhunk://#diff-514583ee522e56dd2862b2db8dcc20053228086a959be2d78daffe764ef70240R676-R677)

**Accessibility and reduced motion support:**

* Moved the reduced motion CSS override from `docs/src/styles/_global.scss` into a new token-based mixin in `packages/core/src/scss/tokens/_transition.scss`, and hooked it into the theme system via the `"root-output"` event. [[1]](diffhunk://#diff-1d1a013961c80728cce02a42aa436a25303ff462db8eb023f37a92695724266bL19-L31) [[2]](diffhunk://#diff-153fdcf13db8a0d5accac46823a4ce8031ac6d658c931d83c911dd442495fd21R1) [[3]](diffhunk://#diff-153fdcf13db8a0d5accac46823a4ce8031ac6d658c931d83c911dd442495fd21R20-R29)

**Documentation and comments:**

* Improved and clarified documentation for theme output mixins, specifying when selectors are included and how the new configuration affects output.

These changes provide greater control over theming and accessibility, making it easier to customize token output for different project needs.

This PR resolves #2823