### PR TITLE
Refactor and simplify the core config module

### DIFF
--- a/docs/src/content/pages/packages/core/config.mdx
+++ b/docs/src/content/pages/packages/core/config.mdx
@@ -140,39 +140,6 @@ Set an option in the configuration map by providing a key and value to store, or
 ```
 </CodeExample>
 
-### set-default
-
-<ReferenceBar type="mixin" />
-
-An alias mixin for `config.set()` with predefined default argument to `true`. Running this will not override a previously set value.
-
-#### Arguments
-
-<ReferenceCard name="$key" type="string | map">
-  The key in the map to set. Can be passed a map of key/value pairs.
-</ReferenceCard>
-
-<ReferenceCard name="$value" type="any" defaults="null">
-  The value to be stored.
-</ReferenceCard>
-
-#### Example
-
-<CodeExample lang="scss">
-```scss
-// Set the default value of the provided key
-@include config.set-default("theme-default", "light");
-
-// This set call will override the default value of "light"
-@include config.set("theme-default", "dark");
-
-// This will have no effect since "theme-default" has already been set
-@include config.set-default("theme-default", "high-contrast");
-
-@debug config.get("theme-default"); // Debug: dark
-```
-</CodeExample>
-
 ### merge
 
 <ReferenceBar type="mixin" />

--- a/docs/src/content/pages/packages/core/config.mdx
+++ b/docs/src/content/pages/packages/core/config.mdx
@@ -121,10 +121,6 @@ Set an option in the configuration map by providing a key and value to store, or
   The value to be stored.
 </ReferenceCard>
 
-<ReferenceCard name="$default" type="boolean" defaults="false">
-  Whether or not the value being set is a default value. Default values are only set if the value has not already been set.
-</ReferenceCard>
-
 #### Example
 
 <CodeExample lang="scss">

--- a/docs/src/content/pages/packages/core/config.mdx
+++ b/docs/src/content/pages/packages/core/config.mdx
@@ -17,7 +17,7 @@ import ReferenceBar from "@/components/ReferenceBar.astro";
 
 The purpose of `core/config` is to provide an API for managing library-wide configuration options. Configuration options are stored in a private map of key/value pairs.
 
-There are two primary methods to configure options in the config module. The first is import and use the module API directly and the second is the Sass `@use ... with` clause.
+There are two primary methods to configure options in the config module. The first is to import the module API directly and the second is using the Sass `@use ... with` clause.
 
 ### Using config module
 
@@ -36,7 +36,7 @@ To use the configuration module directly, import the `core/config` module. Once 
 ```
 </CodeExample>
 
-Changes to the global config should be done in a file that is loaded before other Vrembem or custom components. This ensures that components use the correct configuration values.
+Changes to the global config should be done in a file that is loaded before other Vrembem or custom components that use them. This ensures components use the correct configuration values when their modules are loaded.
 
 <CodeExample label="style.scss">
 ```scss
@@ -55,7 +55,7 @@ Changes to the global config should be done in a file that is loaded before othe
 
 ### Using with clause
 
-To set configuration options via the Sass `@use ... with` clause, define and set options in the `$config` map. Options set in the `$config` map are stored in the config module.
+To set configuration options via the Sass `@use ... with` clause, define and set options in a `$config` options map. Options set in the `$config` map are stored in the config module and backfilled with the modules defaults.
 
 <CodeExample label="app.scss">
 ```scss
@@ -75,11 +75,11 @@ To set configuration options via the Sass `@use ... with` clause, define and set
 ```
 </CodeExample>
 
-Changes to the global config should be done before loading other Vrembem or custom components. This ensures that components use the correct configuration values.
+Changes to the global config should be done before loading other Vrembem or custom components. This ensures components use the correct configuration values when their modules are loaded.
 
 ## Reference
 
-This reference details the available configuration API, their arguments, and usage examples so you can customize and control global configurations across all Vrembem components.
+This reference details the available configuration API, their arguments, and usage examples so you can customize and control global configurations across Vrembem and custom modules.
 
 ### get
 

--- a/docs/src/content/pages/packages/core/config.mdx
+++ b/docs/src/content/pages/packages/core/config.mdx
@@ -156,32 +156,11 @@ Merges a map value of the configuration object with a provided map value.
   The map to be merged with the existing map value.
 </ReferenceCard>
 
-### remove
+### merge-with-default
 
 <ReferenceBar type="mixin" />
 
-Remove an option from the configuration map.
-
-#### Arguments
-
-<ReferenceCard name="$keys..." type="string">
-  The list of keys to follow and remove from the configuration map.
-</ReferenceCard>
-
-#### Example
-
-<CodeExample lang="scss">
-```scss
-// Remove the theme default option
-@include config.remove("theme-default");
-```
-</CodeExample>
-
-### apply
-
-<ReferenceBar type="mixin" />
-
-Apply a configuration map to the config module based on the values in a default map. The provided configuration map must match the signature of the default map. This mixin is used to allow setting values in the config module using the Sass `with` clause.
+Merges a configuration map to the config module based on the values in a default map. The provided configuration map must match the signature of the default map. This mixin is used to allow setting values in the config module using the Sass `with` clause.
 
 #### Arguments
 
@@ -207,7 +186,7 @@ $default: (
   "config-2": "asdf",
 );
 
-@include config.apply($config, $default);
+@include config.merge-with-default($config, $default);
 ```
 </CodeExample>
 
@@ -246,6 +225,27 @@ We can also set our configuration values before the module is loaded and include
 @use "example";
 
 // More imports here...
+```
+</CodeExample>
+
+### remove
+
+<ReferenceBar type="mixin" />
+
+Remove an option from the configuration map.
+
+#### Arguments
+
+<ReferenceCard name="$keys..." type="string">
+  The list of keys to follow and remove from the configuration map.
+</ReferenceCard>
+
+#### Example
+
+<CodeExample lang="scss">
+```scss
+// Remove the theme default option
+@include config.remove("theme-default");
 ```
 </CodeExample>
 

--- a/packages/button/src/_config.scss
+++ b/packages/button/src/_config.scss
@@ -29,5 +29,5 @@ $default: (
   )
 );
 
-@include config.apply($config, $default);
+@include config.merge-with-default($config, $default);
 @include tokens.register("button");

--- a/packages/content/src/_config.scss
+++ b/packages/content/src/_config.scss
@@ -55,4 +55,4 @@ $default: (
   )
 );
 
-@include config.apply($config, $default);
+@include config.merge-with-default($config, $default);

--- a/packages/core/src/_config.scss
+++ b/packages/core/src/_config.scss
@@ -81,4 +81,4 @@ $default: (
   )
 );
 
-@include config.apply($config, $default);
+@include config.merge-with-default($config, $default);

--- a/packages/core/src/modules/_config.scss
+++ b/packages/core/src/modules/_config.scss
@@ -15,7 +15,7 @@ $-config: ();
 /// Stores the pre-load configuration strategy.
 /// @type map
 /// @access private
-$-config-strategy: ();
+$-config-replace: ();
 
 /// Stores config property watchers.
 /// @type map
@@ -224,7 +224,7 @@ $-flags: ("variants");
   // Store the set strategy if this isn't a default value
   @if not $default {
     @each $key in $keys {
-      $-config-strategy: map.set($-config-strategy, $key, "set") !global;
+      $-config-replace: map.set($-config-replace, $key, true) !global;
     }
   }
 
@@ -280,7 +280,6 @@ $-flags: ("variants");
 }
 
 /// Apply a configuration map to the config module based on the values in a
-/// default map. The provided configuration map must match the signature of the
 /// default map. This mixin is used to allow setting values in the config module
 /// using the Sass `with` clause.
 ///
@@ -289,38 +288,34 @@ $-flags: ("variants");
 /// @param {map} $default
 ///   The default map that is also used as a map signature for `$config`.
 ///
+/// TODO: Maybe rename this to apply-with-clause or apply-with-default
 @mixin apply($config, $default) {
-  @each $key, $value in $config {
-    @if map.has-key($default, $key) {
-      // If the value is a map, merge it with the default value
-      // @if meta.type-of($value) == "map" {
-      //   $value: map.deep-merge(map.get($default, $key), $value);
-      // }
+  @each $key, $default-value in $default {
+    // Initialize the result with the default value
+    $result: $default-value;
 
-      @include set($key, $value);
-    } @else {
-      @error '"#{$key}" is not a valid configuration option';
-    }
-  }
-
-  @each $key, $value in $default {
-    // If the value is a map and has already been set
-    @if meta.type-of($value) == "map" and map.has-key($-config, $key) {
-      // Get the current value from config
-      $current: map.get($-config, $key);
-
-      // Throw an error if breakpoints was set but are not supported
-      @if map.has-key($current, "breakpoints") and not map.has-key($value, "breakpoints") {
-        @error "Breakpoint variants are not supported in #{$key}";
+    // If key has already been set, either merge or replace
+    @if (map.has-key($-config, $key)) {
+      @if meta.type-of($result) == "map" and not map.has-key($-config-replace, $key) {
+        $result: map.deep-merge($result, map.get($-config, $key));
+      } @else {
+        $result: map.get($-config, $key);
       }
-
-      // Merge with defaults if the set strategy was not used
-      @if map.get($-config-strategy, $key) != "set" {
-        @include set($key, map.deep-merge($value, $current));
-      }
-    } @else {
-      @include set-default($key, $value);
     }
+
+    // If provided config contains key, merge with the default
+    @if (map.has-key($config, $key)) {
+      @if meta.type-of($result) == "map" {
+        $result: map.deep-merge($result, map.get($config, $key));
+      } @else {
+        $result: map.get($config, $key);
+      }
+    }
+
+    // Apply the configuration option
+    $-config: map.set($-config, $key, $result) !global;
+    $-config-replace: map.remove($-config-replace, $key) !global;
+    @include -run-watchers($key, "set");
   }
 }
 

--- a/packages/core/src/modules/_config.scss
+++ b/packages/core/src/modules/_config.scss
@@ -233,19 +233,6 @@ $-flags: ("variants");
   }
 }
 
-/// An alias mixin for `config.set()` with predefined default argument to
-/// `true`. Running this will not override a previously set value.
-///
-/// @param {string} $key
-///   The key in the map to set. Can be passed a map of key/value pairs.
-///   - ("key": "value")
-/// @param {any} $value (null)
-///   The value to be stored.
-///
-@mixin set-default($key, $value: null) {
-  @include set($key, $value, $default: true);
-}
-
 /// Merges a map value of the configuration object with a provided map value.
 ///
 /// @param {string} $key

--- a/packages/core/src/modules/_config.scss
+++ b/packages/core/src/modules/_config.scss
@@ -253,6 +253,46 @@ $-flags: ("variants");
   @include -run-watchers($key, "merge");
 }
 
+/// Merges a configuration map to the config module based on the values in a
+/// default map. This mixin is used to allow setting values in the config module
+/// using the Sass `with` clause.
+///
+/// @param {map} $config
+///   The config map to set in the global config object.
+/// @param {map} $default
+///   The default map that is also used as a map signature for `$config`.
+///
+@mixin merge-with-default($config, $default) {
+  @each $key, $default-value in $default {
+    // Initialize the result with the default value
+    $result: $default-value;
+
+    // If key has already been set, either merge or replace
+    @if map.has-key($-config, $key) {
+      @if meta.type-of($result) == "map" and not map.has-key($-config-replace, $key) {
+        $result: map.deep-merge($result, map.get($-config, $key));
+      } @else {
+        $result: map.get($-config, $key);
+      }
+    }
+
+    // If provided config contains key, merge with the default
+    @if map.has-key($config, $key) {
+      @if meta.type-of($result) == "map" {
+        $result: map.deep-merge($result, map.get($config, $key));
+      } @else {
+        $result: map.get($config, $key);
+      }
+    }
+
+    // Apply the configuration option
+    $-config: map.set($-config, $key, $result) !global;
+    $-config-replace: map.remove($-config-replace, $key) !global;
+
+    @include -run-watchers($key, "set");
+  }
+}
+
 /// Remove an option from the configuration map.
 ///
 /// @param {string} $key
@@ -264,46 +304,6 @@ $-flags: ("variants");
   $-config: map.deep-remove($-config, $key, $keys...) !global;
 
   @include -run-watchers($key, "remove");
-}
-
-/// Apply a configuration map to the config module based on the values in a
-/// default map. This mixin is used to allow setting values in the config module
-/// using the Sass `with` clause.
-///
-/// @param {map} $config
-///   The config map to set in the global config object.
-/// @param {map} $default
-///   The default map that is also used as a map signature for `$config`.
-///
-/// TODO: Maybe rename this to apply-with-clause or apply-with-default
-@mixin apply($config, $default) {
-  @each $key, $default-value in $default {
-    // Initialize the result with the default value
-    $result: $default-value;
-
-    // If key has already been set, either merge or replace
-    @if (map.has-key($-config, $key)) {
-      @if meta.type-of($result) == "map" and not map.has-key($-config-replace, $key) {
-        $result: map.deep-merge($result, map.get($-config, $key));
-      } @else {
-        $result: map.get($-config, $key);
-      }
-    }
-
-    // If provided config contains key, merge with the default
-    @if (map.has-key($config, $key)) {
-      @if meta.type-of($result) == "map" {
-        $result: map.deep-merge($result, map.get($config, $key));
-      } @else {
-        $result: map.get($config, $key);
-      }
-    }
-
-    // Apply the configuration option
-    $-config: map.set($-config, $key, $result) !global;
-    $-config-replace: map.remove($-config-replace, $key) !global;
-    @include -run-watchers($key, "set");
-  }
 }
 
 /// Log to console the entire configuration map or a specific value.

--- a/packages/core/src/modules/_config.scss
+++ b/packages/core/src/modules/_config.scss
@@ -234,10 +234,10 @@ $-flags: ("variants");
 ///
 @mixin merge-with-default($config, $default) {
   @each $key, $default-value in $default {
-    // Initialize the result with the default value
+    // Initialize the result with the provided default value
     $result: $default-value;
 
-    // If key has already been set, either merge or replace
+    // If key has already been set, either replace or merge with default
     @if map.has-key($-config, $key) {
       @if meta.type-of($result) == "map" and not map.has-key($-config-replace, $key) {
         $result: map.deep-merge($result, map.get($-config, $key));
@@ -246,7 +246,7 @@ $-flags: ("variants");
       }
     }
 
-    // If provided config contains key, merge with the default
+    // If provided config contains key, merge with the current result
     @if map.has-key($config, $key) {
       @if meta.type-of($result) == "map" {
         $result: map.deep-merge($result, map.get($config, $key));

--- a/packages/core/src/modules/_config.scss
+++ b/packages/core/src/modules/_config.scss
@@ -49,31 +49,6 @@ $-flags: ("variants");
   }
 }
 
-/// Helper function that checks if a value should be set in the config map.
-///
-/// @param {map} $map
-///   The configuration map to update.
-/// @param {string} $key
-///   The key to set in the map.
-/// @param {any} $value
-///   The value to set for the key.
-/// @param {boolean} $default
-///   If true, only set the value if the key does not already exist in the map.
-///   If false, always set the value.
-///
-/// @return {map}
-///   The updated configuration map.
-///
-/// @access private
-///
-@function -maybe-set($map, $key, $value, $default) {
-  @if not $default or not map.has-key($map, $key) {
-    $map: map.set($map, $key, $value);
-  }
-
-  @return $map;
-}
-
 /// Checks whether or not a flag exists within the provided keys.
 ///
 /// @param {list} $keys...
@@ -202,30 +177,25 @@ $-flags: ("variants");
 ///   - ("key": "value")
 /// @param {any} $value (null)
 ///   The value to be stored.
-/// @param {boolean} $default (false)
-///   Whether or not the value being set is a default value.
 ///
-@mixin set($key, $value: null, $default: false) {
+@mixin set($key, $value: null) {
   $result: $-config;
   $keys: ();
 
   @if meta.type-of($key) == "map" {
     @each $key, $value in $key {
       $keys: list.append($keys, $key);
-      $result: -maybe-set($result, $key, $value, $default);
+      $result: map.set($result, $key, $value);
     }
   } @else {
     $keys: list.append($keys, $key);
-    $result: -maybe-set($result, $key, $value, $default);
+    $result: map.set($result, $key, $value);
   }
 
   $-config: $result !global;
 
-  // Store the set strategy if this isn't a default value
-  @if not $default {
-    @each $key in $keys {
-      $-config-replace: map.set($-config-replace, $key, true) !global;
-    }
+  @each $key in $keys {
+    $-config-replace: map.set($-config-replace, $key, true) !global;
   }
 
   @each $key in $keys {

--- a/packages/core/src/modules/_config.scss
+++ b/packages/core/src/modules/_config.scss
@@ -12,6 +12,11 @@
 /// @access private
 $-config: ();
 
+/// Stores the pre-load configuration strategy.
+/// @type map
+/// @access private
+$-config-strategy: ();
+
 /// Stores config property watchers.
 /// @type map
 /// @access private
@@ -216,6 +221,13 @@ $-flags: ("variants");
 
   $-config: $result !global;
 
+  // Store the set strategy if this isn't a default value
+  @if not $default {
+    @each $key in $keys {
+      $-config-strategy: map.set($-config-strategy, $key, "set") !global;
+    }
+  }
+
   @each $key in $keys {
     @include -run-watchers($key, "set");
   }
@@ -242,9 +254,15 @@ $-flags: ("variants");
 ///   The map to be merged with the existing map value.
 ///
 @mixin merge($key, $map) {
-  $map: map.merge(map.get($-config, $key), $map);
+  // Ensure that the key exists before trying to merge
+  @if map.has-key($-config, $key) {
+    $map: map.merge(map.get($-config, $key), $map);
+  }
+
+  // Add the map to the config key
   $-config: map.set($-config, $key, $map) !global;
 
+  // Run the merge watchers
   @include -run-watchers($key, "merge");
 }
 
@@ -275,9 +293,9 @@ $-flags: ("variants");
   @each $key, $value in $config {
     @if map.has-key($default, $key) {
       // If the value is a map, merge it with the default value
-      @if meta.type-of($value) == "map" {
-        $value: map.deep-merge(map.get($default, $key), $value);
-      }
+      // @if meta.type-of($value) == "map" {
+      //   $value: map.deep-merge(map.get($default, $key), $value);
+      // }
 
       @include set($key, $value);
     } @else {
@@ -296,10 +314,10 @@ $-flags: ("variants");
         @error "Breakpoint variants are not supported in #{$key}";
       }
 
-      // Merge the default value with the current value
-      $merged-values: map.deep-merge($value, $current);
-
-      @include set($key, $merged-values);
+      // Merge with defaults if the set strategy was not used
+      @if map.get($-config-strategy, $key) != "set" {
+        @include set($key, map.deep-merge($value, $current));
+      }
     } @else {
       @include set-default($key, $value);
     }

--- a/packages/drawer/src/_config.scss
+++ b/packages/drawer/src/_config.scss
@@ -15,5 +15,5 @@ $default: (
   "drawer-position": "left"
 );
 
-@include config.apply($config, $default);
+@include config.merge-with-default($config, $default);
 @include tokens.register("drawer");

--- a/packages/flex/src/_config.scss
+++ b/packages/flex/src/_config.scss
@@ -54,5 +54,5 @@ $default: (
   )
 );
 
-@include config.apply($config, $default);
+@include config.merge-with-default($config, $default);
 @include tokens.register("flex");

--- a/packages/grid/src/_config.scss
+++ b/packages/grid/src/_config.scss
@@ -46,5 +46,5 @@ $default: (
   )
 );
 
-@include config.apply($config, $default);
+@include config.merge-with-default($config, $default);
 @include tokens.register("grid");

--- a/packages/icon/src/_config.scss
+++ b/packages/icon/src/_config.scss
@@ -27,5 +27,5 @@ $default: (
   )
 );
 
-@include config.apply($config, $default);
+@include config.merge-with-default($config, $default);
 @include tokens.register("icon");

--- a/packages/menu/src/_config.scss
+++ b/packages/menu/src/_config.scss
@@ -15,5 +15,5 @@ $default: (
   "menu-full-breakpoints": true
 );
 
-@include config.apply($config, $default);
+@include config.merge-with-default($config, $default);
 @include tokens.register("menu");

--- a/packages/modal/src/_config.scss
+++ b/packages/modal/src/_config.scss
@@ -23,6 +23,6 @@ $default: (
   )
 );
 
-@include config.apply($config, $default);
+@include config.merge-with-default($config, $default);
 @include tokens.register("modal");
 @include tokens.register("panel");

--- a/packages/popover/src/_config.scss
+++ b/packages/popover/src/_config.scss
@@ -16,5 +16,5 @@ $default: (
   )
 );
 
-@include config.apply($config, $default);
+@include config.merge-with-default($config, $default);
 @include tokens.register("popover");

--- a/packages/section/src/_config.scss
+++ b/packages/section/src/_config.scss
@@ -28,5 +28,5 @@ $default: (
   )
 );
 
-@include config.apply($config, $default);
+@include config.merge-with-default($config, $default);
 @include tokens.register("section");

--- a/packages/table/src/_config.scss
+++ b/packages/table/src/_config.scss
@@ -25,5 +25,5 @@ $default: (
   )
 );
 
-@include config.apply($config, $default);
+@include config.merge-with-default($config, $default);
 @include tokens.register("table");

--- a/packages/utility/src/_config.scss
+++ b/packages/utility/src/_config.scss
@@ -116,4 +116,4 @@ $default: (
   "utility-flex-range": 6
 );
 
-@include config.apply($config, $default);
+@include config.merge-with-default($config, $default);


### PR DESCRIPTION
## What changed?

This PR is a refactor of the core config module. The main issue fixed is that there was no way outside of the `with clause` method to alter a modules default configuration. Changes in this PR ensure that when using the `config.set` mixin, the values set now *replace* instead of *merge* the default value provided by a given module.

**Related changes include:**

- `config.apply` has been renamed to `config.merge-with-default` which makes the mixin's intent more clear.
- Contents of the `core/config` docs page have been updated to reflect these changes.

