### PR TITLE
Fix notice color modifier output

### DIFF
--- a/packages/notice/src/_notice--color.scss
+++ b/packages/notice/src/_notice--color.scss
@@ -3,11 +3,11 @@
 @use "@vrembem/core/config";
 @use "@vrembem/core/tokens";
 
-@each $key in map.keys(config.get("palette")) {
-  @if tokens.has("#{$key}-foreground") and tokens.has("#{$key}-background") {
-    #{core.bem("notice", null, "color", $key)} {
-      @include tokens.override("notice", "foreground", tokens.get("#{$key}-foreground"));
-      @include tokens.override("notice", "background", tokens.get("#{$key}-background"));
+@each $name in map.keys(config.get("palette")) {
+  @if tokens.has("core", "themes", "light", "#{$name}-background") and tokens.has("core", "themes", "light", "#{$name}-foreground") {
+    #{core.bem("notice", null, "color", $name)} {
+      @include tokens.override("notice", "foreground", tokens.get("#{$name}-foreground"));
+      @include tokens.override("notice", "background", tokens.get("#{$name}-background"));
     }
   }
 }


### PR DESCRIPTION
## What changed?

This PR fixes the output of `notice--color-[key]` modifier output by fixing the conditionals `css.has` checks.
