### PR TITLE
Remove setting breakpoint property from custom element

### DIFF
--- a/packages/drawer/index.ts
+++ b/packages/drawer/index.ts
@@ -5,7 +5,6 @@ export class Drawer extends HTMLElement {
   drawerContainer!: HTMLDivElement;
   mqList: MediaQueryList | null = null;
   mqHandler: (event: MediaQueryListEvent) => void;
-  breakpoint: string | null = null;
 
   constructor() {
     super();
@@ -105,9 +104,6 @@ export class Drawer extends HTMLElement {
     this.mqList = window.matchMedia(`(min-width: ${bp})`);
     this.mqList.addEventListener("change", this.mqHandler);
     this.evaluateLayout(this.mqList.matches);
-
-    // Update the breakpoint property
-    this.breakpoint = bp;
   }
 
   teardownMediaQuery() {

--- a/packages/drawer/tests/Drawer.test.js
+++ b/packages/drawer/tests/Drawer.test.js
@@ -88,22 +88,22 @@ describe("breakpoint parsing", () => {
   it("should resolve named breakpoint tokens from CSS custom properties", () => {
     setBreakpointVars();
     const el = mount(`<vb-drawer id="d1" breakpoint="md"></vb-drawer>`);
-    expect(el.breakpoint).toBe("760px");
+    expect(el.mqList.media).toBe("(min-width: 760px)");
   });
 
   it("should treat unitless numbers as pixel values", () => {
     const el = mount(`<vb-drawer id="d1" breakpoint="600"></vb-drawer>`);
-    expect(el.breakpoint).toBe("600px");
+    expect(el.mqList.media).toBe("(min-width: 600px)");
   });
 
   it("should pass CSS length values through unchanged", () => {
     const el = mount(`<vb-drawer id="d1" breakpoint="48rem"></vb-drawer>`);
-    expect(el.breakpoint).toBe("48rem");
+    expect(el.mqList.media).toBe("(min-width: 48rem)");
   });
 
   it("should fall back to 760px when no attribute or default is provided", () => {
     const el = mount(`<vb-drawer id="d1"></vb-drawer>`);
-    expect(el.breakpoint).toBe("760px");
+    expect(el.mqList.media).toBe("(min-width: 760px)");
   });
 });
 
@@ -199,7 +199,7 @@ describe("attributeChangedCallback()", () => {
 
     el.setAttribute("breakpoint", "400");
 
-    expect(el.breakpoint).toBe("400px");
+    expect(el.mqList.media).toBe("(min-width: 400px)");
     expect(el).not.toHaveClass("is-modal");
     expect(document.getElementById("child").parentElement).toBe(el);
   });


### PR DESCRIPTION
## What changed?

This PR removes setting the `breakpoint` property on the custom element definition. This was causing an unintended issue in the Vue context where the attribute was being wiped from the element since breakpoint gets initially set as null.