### PR TITLE
Add with type for json imports and use mjs ext for vite configs

### DIFF
--- a/packages/button/vite.config.mjs
+++ b/packages/button/vite.config.mjs
@@ -1,4 +1,4 @@
 import { createViteConfig } from "../../vite.config.shared.js";
-import data from "./package.json";
+import data from "./package.json" with { type: "json" };
 
 export default createViteConfig(data);

--- a/packages/card/vite.config.mjs
+++ b/packages/card/vite.config.mjs
@@ -1,4 +1,4 @@
 import { createViteConfig } from "../../vite.config.shared.js";
-import data from "./package.json";
+import data from "./package.json" with { type: "json" };
 
 export default createViteConfig(data);

--- a/packages/checkbox/vite.config.mjs
+++ b/packages/checkbox/vite.config.mjs
@@ -1,4 +1,4 @@
 import { createViteConfig } from "../../vite.config.shared.js";
-import data from "./package.json";
+import data from "./package.json" with { type: "json" };
 
 export default createViteConfig(data);

--- a/packages/content/vite.config.mjs
+++ b/packages/content/vite.config.mjs
@@ -1,4 +1,4 @@
 import { createViteConfig } from "../../vite.config.shared.js";
-import data from "./package.json";
+import data from "./package.json" with { type: "json" };
 
 export default createViteConfig(data);

--- a/packages/core/vite.config.js
+++ b/packages/core/vite.config.js
@@ -1,4 +1,4 @@
 import { createViteConfig } from "../../vite.config.shared.js";
-import data from "./package.json";
+import data from "./package.json" with { type: "json" };
 
 export default createViteConfig(data);

--- a/packages/drawer/vite.config.mjs
+++ b/packages/drawer/vite.config.mjs
@@ -1,5 +1,5 @@
 import { resolve } from "path";
 import { createViteConfig } from "../../vite.config.shared.js";
-import data from "./package.json";
+import data from "./package.json" with { type: "json" };
 
 export default createViteConfig(data, resolve(import.meta.dirname, "index.ts"));

--- a/packages/flex/vite.config.mjs
+++ b/packages/flex/vite.config.mjs
@@ -1,4 +1,4 @@
 import { createViteConfig } from "../../vite.config.shared.js";
-import data from "./package.json";
+import data from "./package.json" with { type: "json" };
 
 export default createViteConfig(data);

--- a/packages/grid/vite.config.mjs
+++ b/packages/grid/vite.config.mjs
@@ -1,4 +1,4 @@
 import { createViteConfig } from "../../vite.config.shared.js";
-import data from "./package.json";
+import data from "./package.json" with { type: "json" };
 
 export default createViteConfig(data);

--- a/packages/icon/vite.config.mjs
+++ b/packages/icon/vite.config.mjs
@@ -1,4 +1,4 @@
 import { createViteConfig } from "../../vite.config.shared.js";
-import data from "./package.json";
+import data from "./package.json" with { type: "json" };
 
 export default createViteConfig(data);

--- a/packages/input/vite.config.mjs
+++ b/packages/input/vite.config.mjs
@@ -1,4 +1,4 @@
 import { createViteConfig } from "../../vite.config.shared.js";
-import data from "./package.json";
+import data from "./package.json" with { type: "json" };
 
 export default createViteConfig(data);

--- a/packages/menu/vite.config.mjs
+++ b/packages/menu/vite.config.mjs
@@ -1,4 +1,4 @@
 import { createViteConfig } from "../../vite.config.shared.js";
-import data from "./package.json";
+import data from "./package.json" with { type: "json" };
 
 export default createViteConfig(data);

--- a/packages/modal/vite.config.mjs
+++ b/packages/modal/vite.config.mjs
@@ -1,4 +1,4 @@
 import { createViteConfig } from "../../vite.config.shared.js";
-import data from "./package.json";
+import data from "./package.json" with { type: "json" };
 
 export default createViteConfig(data);

--- a/packages/notice/vite.config.js
+++ b/packages/notice/vite.config.js
@@ -1,4 +1,4 @@
 import { createViteConfig } from "../../vite.config.shared.js";
-import data from "./package.json";
+import data from "./package.json" with { type: "json" };
 
 export default createViteConfig(data);

--- a/packages/panel/vite.config.mjs
+++ b/packages/panel/vite.config.mjs
@@ -1,4 +1,4 @@
 import { createViteConfig } from "../../vite.config.shared.js";
-import data from "./package.json";
+import data from "./package.json" with { type: "json" };
 
 export default createViteConfig(data);

--- a/packages/popover/vite.config.mjs
+++ b/packages/popover/vite.config.mjs
@@ -1,4 +1,4 @@
 import { createViteConfig } from "../../vite.config.shared.js";
-import data from "./package.json";
+import data from "./package.json" with { type: "json" };
 
 export default createViteConfig(data);

--- a/packages/radio/vite.config.mjs
+++ b/packages/radio/vite.config.mjs
@@ -1,4 +1,4 @@
 import { createViteConfig } from "../../vite.config.shared.js";
-import data from "./package.json";
+import data from "./package.json" with { type: "json" };
 
 export default createViteConfig(data);

--- a/packages/section/vite.config.mjs
+++ b/packages/section/vite.config.mjs
@@ -1,4 +1,4 @@
 import { createViteConfig } from "../../vite.config.shared.js";
-import data from "./package.json";
+import data from "./package.json" with { type: "json" };
 
 export default createViteConfig(data);

--- a/packages/select/vite.config.mjs
+++ b/packages/select/vite.config.mjs
@@ -1,4 +1,4 @@
 import { createViteConfig } from "../../vite.config.shared.js";
-import data from "./package.json";
+import data from "./package.json" with { type: "json" };
 
 export default createViteConfig(data);

--- a/packages/switch/vite.config.mjs
+++ b/packages/switch/vite.config.mjs
@@ -1,4 +1,4 @@
 import { createViteConfig } from "../../vite.config.shared.js";
-import data from "./package.json";
+import data from "./package.json" with { type: "json" };
 
 export default createViteConfig(data);

--- a/packages/table/vite.config.mjs
+++ b/packages/table/vite.config.mjs
@@ -1,4 +1,4 @@
 import { createViteConfig } from "../../vite.config.shared.js";
-import data from "./package.json";
+import data from "./package.json" with { type: "json" };
 
 export default createViteConfig(data);

--- a/packages/utility/vite.config.mjs
+++ b/packages/utility/vite.config.mjs
@@ -1,4 +1,4 @@
 import { createViteConfig } from "../../vite.config.shared.js";
-import data from "./package.json";
+import data from "./package.json" with { type: "json" };
 
 export default createViteConfig(data);

--- a/packages/vrembem/vite.config.mjs
+++ b/packages/vrembem/vite.config.mjs
@@ -1,4 +1,4 @@
 import { createViteConfig } from "../../vite.config.shared.js";
-import data from "./package.json";
+import data from "./package.json" with { type: "json" };
 
 export default createViteConfig(data);


### PR DESCRIPTION
## What changed?

This PR fixes two Vite warnings by adding `with { type: "json" }` to json imports and ensuring the vite config files use the `.mjs` extension since packages that don't export JavaScript will not have a type module property.