### PR TITLE
Add externals to vrembem barrel package

### DIFF
--- a/vite.config.shared.js
+++ b/vite.config.shared.js
@@ -6,16 +6,30 @@ export function createViteConfig(data, entry) {
     ? data.name.replace("@", "").split("/")
     : [data.name, data.name];
 
+  // Externalize all package dependencies
+  const packageNames = [
+    ...Object.keys(data.dependencies ?? {}),
+    ...Object.keys(data.peerDependencies ?? {})
+  ];
+
+  const external = (id) => {
+    return packageNames.some((pkg) => id === pkg || id.startsWith(`${pkg}/`));
+  };
+
   // Return a vite config object using the provided data and optional entry
   return defineConfig({
     ...(entry && {
       build: {
         lib: {
           entry,
-          formats: ["es"]
+          formats: ["es"],
+          fileName: (format, entryName) => `${entryName}.js`
         },
         emptyOutDir: false,
-        sourcemap: true
+        sourcemap: true,
+        rollupOptions: {
+          external
+        }
       }
     }),
     define: {


### PR DESCRIPTION
## What changed?

This PR ensures that all package dependencies and peer dependencies are now automatically externalized in the Vite build, preventing them from being bundled into the output. This is achieved by generating an `external` function for Rollup that matches any dependency or peer dependency.
