### PR TITLE
Main docs mobile

### DIFF
--- a/docs/src/components/EditPageLink.astro
+++ b/docs/src/components/EditPageLink.astro
@@ -10,7 +10,7 @@ const { entry } = Astro.props;
 
 const ghBase = "https://github.com/sebnitu/vrembem/blob/main/docs/src/";
 const filePath = entry
-  ? `content/${entry.collection}/${entry.id}`
+  ? `content/${entry.collection}/${entry.id}.mdx`
   : `pages${Astro.url.pathname.replace(/\/$/, "")}.mdx`;
 const url = `${ghBase}${filePath}`;
 ---

--- a/docs/src/components/Intro.astro
+++ b/docs/src/components/Intro.astro
@@ -22,7 +22,7 @@ function slugify(value: string) {
   {
     parent && (
       <a href={`/${parent.id}/`} class="link font-size-base">
-        &larr; Back to {parent.data.title}
+        Back to {parent.data.title}
       </a>
     )
   }

--- a/docs/src/components/OnThisPage.astro
+++ b/docs/src/components/OnThisPage.astro
@@ -1,5 +1,6 @@
 ---
 import OnThisPageList from "@/components/OnThisPageList.astro";
+import Icon from "@/components/Icon.astro";
 
 const { headings, menuClass = "" } = Astro.props;
 
@@ -30,24 +31,39 @@ function build(headings) {
 }
 ---
 
-<nav>
-  <h2 class="sr-only">On this page</h2>
+<div class="panel__header aside:display-none">
+  <h2 class="panel__title">On this page</h2>
+  <button
+    class="button button--icon"
+    command="close"
+    commandfor="main-aside-modal"
+  >
+    <Icon name="x" />
+  </button>
+</div>
+<nav class="panel__body">
   <ul id="on-this-page-menu" class={`menu menu--minimal ${menuClass}`.trim()}>
-    <li>
+    <li class="display-none aside:display-block">
       <a href="#main" class="menu__action" data-scroll-to-top="">
         <strong>On this page</strong>
       </a>
     </li>
-    <li class="menu__divider"></li>
+    <li class="menu__divider display-none aside:display-block"></li>
     {filteredHeadings.map((item) => <OnThisPageList {item} />)}
-    <li class="menu__divider slide-up scroll-spy"></li>
-    <li class="menu__item slide-up scroll-spy">
+    <li
+      class="menu__divider slide-up scroll-spy display-none aside:display-block"
+    >
+    </li>
+    <li class="menu__item slide-up scroll-spy display-none aside:display-block">
       <a href="#main" class="menu__action" data-scroll-to-top="">
         Back to top
       </a>
     </li>
   </ul>
 </nav>
+<div class="panel__footer aside:display-none">
+  <a href="#main" class="button" data-scroll-to-top="">Back to top</a>
+</div>
 
 <script>
   import { scrollSpy } from "../modules/scrollSpy";

--- a/docs/src/components/SidebarNavi.astro
+++ b/docs/src/components/SidebarNavi.astro
@@ -3,10 +3,23 @@ import { config } from "@/navi.config";
 import { buildNaviFromConfig } from "@/modules/navigation";
 import SidebarNaviMenu from "@/components/SidebarNaviMenu.astro";
 import SidebarState from "@/components/SidebarState.astro";
+import Icon from "@/components/Icon.astro";
 
 const { navi } = await buildNaviFromConfig(config.sidebar, Astro.url.pathname);
 ---
 
-<SidebarState>
-  <SidebarNaviMenu tree={navi} />
-</SidebarState>
+<div class="panel__header sidebar:display-none">
+  <h2 class="panel__title">Menu</h2>
+  <button
+    class="button button--icon button--size-sm"
+    command="close"
+    commandfor="layout-sidebar-modal"
+  >
+    <Icon name="x" />
+  </button>
+</div>
+<div class="panel__body">
+  <SidebarState>
+    <SidebarNaviMenu tree={navi} />
+  </SidebarState>
+</div>

--- a/docs/src/components/Toolbar.astro
+++ b/docs/src/components/Toolbar.astro
@@ -18,7 +18,7 @@ const { layout } = Astro.props;
         <button
           commandfor="layout-sidebar-modal"
           command="show-modal"
-          class="button"
+          class="button padding-left-sm"
         >
           <Icon name="sidebar-simple" />
           <span class="text-capitalize">Sidebar</span>
@@ -28,7 +28,7 @@ const { layout } = Astro.props;
         <button
           commandfor="main-aside-modal"
           command="show-modal"
-          class="button margin-left-auto"
+          class="button padding-right-sm margin-left-auto"
         >
           <span>On this page</span>
           <Icon name="map-pin" />

--- a/docs/src/pages/packages/index.astro
+++ b/docs/src/pages/packages/index.astro
@@ -8,8 +8,8 @@ import Icon from "@/components/Icon.astro";
 const entries = (await getCollection("pages"))
   .filter((entry) => entry.id.startsWith("packages/") && entry.data.package)
   .sort((a, b) => {
-    const aIsCore = a.data.category === "core";
-    const bIsCore = b.data.category === "core";
+    const aIsCore = a.data.category === "Core";
+    const bIsCore = b.data.category === "Core";
 
     if (aIsCore !== bIsCore) return aIsCore ? -1 : 1;
 

--- a/docs/src/styles/_layout.scss
+++ b/docs/src/styles/_layout.scss
@@ -19,15 +19,11 @@
 }
 
 .layout__sidebar {
+  @include tokens.override("panel", "background", tokens.get("background-shift"));
   display: none;
-
-  .panel {
-    background-color: tokens.get("background-shift");
-  }
 
   .panel__container {
     position: relative;
-    padding: 1rem;
 
     // Adds a mask for scrolled content that passes sticky summary controls
     &::before {
@@ -55,6 +51,10 @@
     max-height: calc(100vh - tokens.get("layout", "header-height"));
     padding: 0 tokens.get("layout", "padding") tokens.get("layout", "padding");
     box-shadow: none;
+
+    .panel__body {
+      padding: 0;
+    }
 
     // Styles for infinite background
     &::before {

--- a/docs/src/styles/_layout.scss
+++ b/docs/src/styles/_layout.scss
@@ -20,6 +20,7 @@
 
 .layout__sidebar {
   @include tokens.override("panel", "background", tokens.get("background-shift"));
+
   display: none;
 
   .panel__container {
@@ -52,10 +53,6 @@
     padding: 0 tokens.get("layout", "padding") tokens.get("layout", "padding");
     box-shadow: none;
 
-    .panel__body {
-      padding: 0;
-    }
-
     // Styles for infinite background
     &::before {
       content: "";
@@ -79,6 +76,10 @@
       width: 2rem;
       height: 100%;
       background: linear-gradient(268deg, tokens.get("fold-shadow-start") 0, tokens.get("fold-shadow-end") 2rem);
+    }
+
+    .panel__body {
+      padding: 0;
     }
   }
 }

--- a/docs/src/styles/_main.scss
+++ b/docs/src/styles/_main.scss
@@ -25,15 +25,8 @@
 }
 
 .main__aside {
+  @include tokens.override("panel", "background", tokens.get("background-shift"));
   display: none;
-
-  .panel {
-    background-color: tokens.get("background-shift");
-  }
-
-  .panel__container {
-    padding: 1rem;
-  }
 }
 
 @include core.media-min("aside") {
@@ -50,6 +43,10 @@
     max-height: calc(100vh - tokens.get("layout", "header-height"));
     padding: tokens.get("main", "content-padding-y") tokens.get("layout", "padding") tokens.get("main", "content-padding-y") 0;
     box-shadow: none;
+
+    .panel__body {
+      padding: 0;
+    }
   }
 }
 

--- a/docs/src/styles/_main.scss
+++ b/docs/src/styles/_main.scss
@@ -26,6 +26,7 @@
 
 .main__aside {
   @include tokens.override("panel", "background", tokens.get("background-shift"));
+
   display: none;
 }
 

--- a/docs/src/styles/_menu--collection.scss
+++ b/docs/src/styles/_menu--collection.scss
@@ -35,9 +35,6 @@
 
   summary {
     cursor: pointer;
-    position: sticky;
-    z-index: 1;
-    top: 0;
     display: flex;
     gap: 0.75rem;
     align-items: center;

--- a/docs/src/styles/_toolbar.scss
+++ b/docs/src/styles/_toolbar.scss
@@ -7,12 +7,16 @@
   top: -1px;
   display: flex;
   align-items: center;
-  padding: tokens.get("layout", "padding");
+  padding: 0.5rem;
   border-top: 1px solid tokens.get("border-color");
   border-bottom: 1px solid tokens.get("border-color");
   background-color: tokens.get("background-glass");
   background-clip: padding-box;
   backdrop-filter: blur(8px);
+
+  @include core.media-min("xs") {
+    padding: tokens.get("layout", "padding");
+  }
 
   @include core.media-min("sidebar") {
     display: none;

--- a/packages/panel/src/_panel.scss
+++ b/packages/panel/src/_panel.scss
@@ -35,10 +35,6 @@
 
 #{core.bem("panel", "container")} {
   @include core.scroll-flex;
-
-  > * + * {
-    border-top: tokens.get("panel", "sep-border", tokens.get("border"));
-  }
 }
 
 #{core.bem("panel", "header")},
@@ -61,6 +57,7 @@
 
 #{core.bem("panel", "header")} {
   top: 0;
+  border-bottom: tokens.get("panel", "sep-border", tokens.get("border"));
 
   :where(details) & {
     cursor: pointer;
@@ -77,6 +74,7 @@
 
 #{core.bem("panel", "footer")} {
   bottom: 0;
+  border-top: tokens.get("panel", "sep-border", tokens.get("border"));
 }
 
 #{core.bem("panel", "title")} {

--- a/packages/popover/src/_popover--tooltip.scss
+++ b/packages/popover/src/_popover--tooltip.scss
@@ -7,7 +7,7 @@
     (
       "width": fit-content,
       "max-width": 16rem,
-      "padding": 0.5rem 0.75rem,
+      "padding": 0.25rem 0.5rem,
       "font-size": tokens.get("font-size-sm"),
       "background": tokens.get("foreground-strong"),
       "foreground": tokens.get("background"),


### PR DESCRIPTION
## What changed?

This PR improves documentation styles for mobile devices along with other various style improvements. The most important change is with sidebar and aside drawers so that they better make use of the panel component and a header with close buttons.

**Additional changes**

- Fixed edit page link path.
- Removed arrow char from back link.
- Improved spacing of actions in mobile toolbar.
- Fixed sorting logic of packages index.
- `panel`: Moved panel border styles to the header and footer elements.
- `popover`: Reduced the padding of popover tooltips.