### PR TITLE
Fix content container style inconsistencies 

### DIFF
--- a/docs/src/content/pages/packages/card.mdx
+++ b/docs/src/content/pages/packages/card.mdx
@@ -26,15 +26,15 @@ Card uses design token CSS variables in a reference and fallback pattern. Variab
 <ReferenceTable id="tokens-card" valueLabel="Fallback" expandable={true} data={{
   "--vb-card-background": "var(--vb-background)",
   "--vb-card-foreground": "var(--vb-foreground-light)",
-  "--vb-card-border": "var(--vb-border)",
+  "--vb-card-border": "none",
   "--vb-card-divider": "var(--vb-border)",
   "--vb-card-border-radius": "var(--vb-border-radius)",
-  "--vb-card-box-shadow": "none",
+  "--vb-card-box-shadow": "0 0 0 1px var(--vb-border-color)",
   "--vb-card-padding": "1.25em",
 
   // Transition vars
-  "--vb-card-transition-duration": "var(--vb-transition-duration)",
   "--vb-card-transition-timing-function": "var(--vb-transition-timing-function)",
+  "--vb-card-transition-duration": "var(--vb-transition-duration)",
   "--vb-card-transition-property": "background-color, border-color, box-shadow, transform",
   
   // Title element
@@ -48,8 +48,6 @@ Card uses design token CSS variables in a reference and fallback pattern. Variab
   "--vb-card-screen-background": "var(--vb-background)",
 
   // Link element
-  "--vb-card-link-box-shadow": "var(--vb-box-shadow-sm)",
-  "--vb-card-link-box-shadow-hover": "var(--vb-box-shadow-lg)",
   "--vb-card-link-offset": "-0.25em",
 }} />
 

--- a/docs/src/content/pages/packages/card.mdx
+++ b/docs/src/content/pages/packages/card.mdx
@@ -26,8 +26,8 @@ Card uses design token CSS variables in a reference and fallback pattern. Variab
 <ReferenceTable id="tokens-card" valueLabel="Fallback" expandable={true} data={{
   "--vb-card-background": "var(--vb-background)",
   "--vb-card-foreground": "var(--vb-foreground-light)",
-  "--vb-card-border": "1px solid var(--vb-border-color)",
-  "--vb-card-sep-border": "1px solid var(--vb-border-color)",
+  "--vb-card-border": "var(--vb-border)",
+  "--vb-card-divider": "var(--vb-border)",
   "--vb-card-border-radius": "var(--vb-border-radius)",
   "--vb-card-box-shadow": "none",
   "--vb-card-padding": "1.25em",

--- a/docs/src/content/pages/packages/panel.mdx
+++ b/docs/src/content/pages/packages/panel.mdx
@@ -27,7 +27,7 @@ Panel uses design token CSS variables in a reference and fallback pattern. Varia
   "--vb-panel-background": "var(--vb-background)",
   "--vb-panel-foreground": "var(--vb-foreground)",
   "--vb-panel-border": "none",
-  "--vb-panel-sep-border": "var(--vb-border)",
+  "--vb-panel-divider": "var(--vb-border)",
   "--vb-panel-border-radius": "var(--vb-border-radius)",
   "--vb-panel-box-shadow": "var(--vb-box-shadow-border)",
   "--vb-panel-padding": "1em",

--- a/docs/src/content/pages/packages/panel.mdx
+++ b/docs/src/content/pages/packages/panel.mdx
@@ -29,7 +29,7 @@ Panel uses design token CSS variables in a reference and fallback pattern. Varia
   "--vb-panel-border": "none",
   "--vb-panel-divider": "var(--vb-border)",
   "--vb-panel-border-radius": "var(--vb-border-radius)",
-  "--vb-panel-box-shadow": "var(--vb-box-shadow-border)",
+  "--vb-panel-box-shadow": "0 0 0 1px var(--vb-border-color)",
   "--vb-panel-padding": "1em",
   "--vb-panel-gap": "0.5em",
   

--- a/docs/src/pages/packages/index.astro
+++ b/docs/src/pages/packages/index.astro
@@ -24,9 +24,9 @@ const entries = (await getCollection("pages"))
   <div class="header-spacer"></div>
   <main id="main" tabindex="-1">
     <div class="section">
-      <div class="content spacing padding-dynamic">
+      <div class="content spacing padding-dynamic max-width-xs">
         <h1>Packages</h1>
-        <p class="max-width-xs">
+        <p>
           Vrembem is organized as a collection of packages. These can be
           included a la carte or using the all inclusively <code>vrembem</code> barrel
           package.

--- a/docs/src/styles/_card--feature.scss
+++ b/docs/src/styles/_card--feature.scss
@@ -3,7 +3,10 @@
 .card--feature {
   gap: tokens.get("spacing-sm");
   padding: tokens.get("padding-dynamic");
-  border: none;
   border-radius: tokens.get("border-radius-lg");
   text-wrap: pretty;
+
+  &:not(a) {
+    box-shadow: none;
+  }
 }

--- a/packages/card/src/_card.scss
+++ b/packages/card/src/_card.scss
@@ -4,6 +4,8 @@
 $-transition-property: background-color, border-color, box-shadow, transform;
 
 #{core.bem("card")} {
+  @include core.focus-ring-base;
+
   position: relative;
   overflow: hidden;
   display: flex;
@@ -17,17 +19,29 @@ $-transition-property: background-color, border-color, box-shadow, transform;
   transition-timing-function: tokens.get("card", "transition-timing-function", tokens.get("transition-timing-function"));
   transition-duration: tokens.get("card", "transition-duration", tokens.get("transition-duration"));
   transition-property: tokens.get("card", "transition-property", $-transition-property);
+
+  &:focus-visible {
+    @include core.focus-ring-color(tokens.get("focus-ring-color"));
+    @include tokens.override("card", "box-shadow", 0 0 0 1px tokens.get("focus-ring-color"));
+  }
 }
 
 a#{core.bem("card")} {
+  @include tokens.override("card", "box-shadow", tokens.get("box-shadow-sm"));
   transform: translate(0, 0);
-  box-shadow: tokens.get("card", "link-box-shadow", tokens.get("box-shadow-sm"));
 
   &:hover,
-  &:focus,
   &:focus-within {
     transform: translate(0, tokens.get("card", "link-offset", -0.25em));
-    box-shadow: tokens.get("card", "link-box-shadow-hover", tokens.get("box-shadow-lg"));
+  }
+
+  &:hover {
+    @include tokens.override("card", "box-shadow", tokens.get("box-shadow-lg"));
+  }
+
+  &:focus-within {
+    @include core.focus-ring-color(tokens.get("focus-ring-color"));
+    @include tokens.override("card", "box-shadow", 0 0 0 1px tokens.get("focus-ring-color"));
   }
 }
 

--- a/packages/card/src/_card.scss
+++ b/packages/card/src/_card.scss
@@ -35,6 +35,7 @@ a#{core.bem("card")} {
 #{core.bem("card", "body")},
 #{core.bem("card", "footer")},
 #{core.bem("card", "image")} {
+  flex: 0 0 auto;
   position: relative;
   z-index: 3;
 
@@ -55,16 +56,16 @@ a#{core.bem("card")} {
   padding: tokens.get("card", "padding", 1.25em);
 }
 
+#{core.bem("card", "header")} {
+  border-bottom: tokens.get("card", "sep-border", 1px solid tokens.get("border-color"));
+}
+
 #{core.bem("card", "body")} {
-  flex: 1 1 auto;
+  flex-grow: 1;
 
   & + & {
     border-top: tokens.get("card", "sep-border", 1px solid tokens.get("border-color"));
   }
-}
-
-#{core.bem("card", "header")} {
-  border-bottom: tokens.get("card", "sep-border", 1px solid tokens.get("border-color"));
 }
 
 #{core.bem("card", "footer")} {
@@ -72,7 +73,6 @@ a#{core.bem("card")} {
 }
 
 #{core.bem("card", "image")} {
-  flex: 0 1 auto;
   width: 100%;
   height: auto;
 }

--- a/packages/card/src/_card.scss
+++ b/packages/card/src/_card.scss
@@ -8,12 +8,12 @@ $-transition-property: background-color, border-color, box-shadow, transform;
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  border: tokens.get("card", "border", 1px solid tokens.get("border-color"));
+  border: tokens.get("card", "border", none);
   border-radius: tokens.get("card", "border-radius", tokens.get("border-radius"));
   color: tokens.get("card", "foreground", tokens.get("foreground"));
   background: tokens.get("card", "background", tokens.get("background"));
   background-clip: padding-box;
-  box-shadow: tokens.get("card", "box-shadow", none);
+  box-shadow: tokens.get("card", "box-shadow", 0 0 0 1px tokens.get("border-color"));
   transition-timing-function: tokens.get("card", "transition-timing-function", tokens.get("transition-timing-function"));
   transition-duration: tokens.get("card", "transition-duration", tokens.get("transition-duration"));
   transition-property: tokens.get("card", "transition-property", $-transition-property);
@@ -57,19 +57,19 @@ a#{core.bem("card")} {
 }
 
 #{core.bem("card", "header")} {
-  border-bottom: tokens.get("card", "sep-border", 1px solid tokens.get("border-color"));
+  border-bottom: tokens.get("card", "divider", tokens.get("border"));
 }
 
 #{core.bem("card", "body")} {
   flex-grow: 1;
 
   & + & {
-    border-top: tokens.get("card", "sep-border", 1px solid tokens.get("border-color"));
+    border-top: tokens.get("card", "divider", tokens.get("border"));
   }
 }
 
 #{core.bem("card", "footer")} {
-  border-top: tokens.get("card", "sep-border", 1px solid tokens.get("border-color"));
+  border-top: tokens.get("card", "divider", tokens.get("border"));
 }
 
 #{core.bem("card", "image")} {

--- a/packages/card/src/_card.scss
+++ b/packages/card/src/_card.scss
@@ -28,6 +28,7 @@ $-transition-property: background-color, border-color, box-shadow, transform;
 
 a#{core.bem("card")} {
   @include tokens.override("card", "box-shadow", tokens.get("box-shadow-sm"));
+
   transform: translate(0, 0);
 
   &:hover,
@@ -49,9 +50,9 @@ a#{core.bem("card")} {
 #{core.bem("card", "body")},
 #{core.bem("card", "footer")},
 #{core.bem("card", "image")} {
-  flex: 0 0 auto;
   position: relative;
   z-index: 3;
+  flex: 0 0 auto;
 
   &:first-child {
     border-top-left-radius: tokens.get("card", "border-radius", tokens.get("border-radius"));

--- a/packages/panel/src/_panel.scss
+++ b/packages/panel/src/_panel.scss
@@ -53,7 +53,7 @@
 
 #{core.bem("panel", "header")} {
   top: 0;
-  border-bottom: tokens.get("panel", "sep-border", tokens.get("border"));
+  border-bottom: tokens.get("panel", "divider", tokens.get("border"));
 
   :where(details) & {
     cursor: pointer;
@@ -68,13 +68,13 @@
   flex-grow: 1;
 
   & + & {
-    border-top: tokens.get("panel", "sep-border", tokens.get("border"));
+    border-top: tokens.get("panel", "divider", tokens.get("border"));
   }
 }
 
 #{core.bem("panel", "footer")} {
   bottom: 0;
-  border-top: tokens.get("panel", "sep-border", tokens.get("border"));
+  border-top: tokens.get("panel", "divider", tokens.get("border"));
 }
 
 #{core.bem("panel", "title")} {

--- a/packages/panel/src/_panel.scss
+++ b/packages/panel/src/_panel.scss
@@ -57,7 +57,11 @@ $-transition-property: outline, box-shadow, border-color;
   top: 0;
   border-bottom: tokens.get("panel", "divider", tokens.get("border"));
 
-  :where(details) & {
+  :where(details:not([open])) > & {
+    border-bottom: none;
+  }
+
+  :where(details) > & {
     cursor: pointer;
   }
 

--- a/packages/panel/src/_panel.scss
+++ b/packages/panel/src/_panel.scss
@@ -1,6 +1,8 @@
 @use "@vrembem/core";
 @use "@vrembem/core/tokens";
 
+$-transition-property: outline, box-shadow, border-color;
+
 #{core.bem("panel")} {
   @include core.focus-ring-base;
 
@@ -16,7 +18,7 @@
   box-shadow: tokens.get("panel", "box-shadow", 0 0 0 1px tokens.get("border-color"));
   transition-timing-function: tokens.get("panel", "transition-timing-function", tokens.get("transition-timing-function"));
   transition-duration: tokens.get("panel", "transition-duration", tokens.get("transition-duration"));
-  transition-property: tokens.get("panel", "transition-property", (outline, box-shadow, border-color));
+  transition-property: tokens.get("panel", "transition-property", $-transition-property);
 
   &:where(details):has(> summary:hover) {
     @include tokens.override("panel", "box-shadow", 0 0 0 1px tokens.get("border-color-stronger"));

--- a/packages/panel/src/_panel.scss
+++ b/packages/panel/src/_panel.scss
@@ -18,10 +18,6 @@
   transition-duration: tokens.get("panel", "transition-duration", tokens.get("transition-duration"));
   transition-property: tokens.get("panel", "transition-property", (outline, box-shadow, border-color));
 
-  > * + * {
-    border-top: tokens.get("panel", "sep-border", tokens.get("border"));
-  }
-
   &:where(details):has(> summary:hover) {
     @include tokens.override("panel", "box-shadow", 0 0 0 1px tokens.get("border-color-stronger"));
   }
@@ -70,6 +66,10 @@
 
 #{core.bem("panel", "body")} {
   flex-grow: 1;
+
+  & + & {
+    border-top: tokens.get("panel", "sep-border", tokens.get("border"));
+  }
 }
 
 #{core.bem("panel", "footer")} {


### PR DESCRIPTION
## What changed?

This PR fixes a few issues between two of our content container components `card` and `panel`. Some of these align their styles so that they're more consistent and predictable between each other and other changes fix style issues that were overlooked previously. These changes include:

- `card`, `panel`: Renamed the `sep-border` tokens to `divider` which aligns better with other tokens and components in the library.
- `card`: Removed border styles in favor of a pseudo border via box-shadow. This aligns with `panel` styles.
- `card`: Added focus-ring styles that are applied for link cards and their `focus-visible` state.
- `panel`: Fixed how divider borders are applied with panel elements. This aligns with `card` styles.
- `panel`: Removes header border when panel is a details element and in the closed state.
- `docs`: Updated internal styles and usage of cards and the card feature modifier.
