### PR TITLE
Add and apply form-control choice size token

### DIFF
--- a/docs/src/content/data/tokens-core.json
+++ b/docs/src/content/data/tokens-core.json
@@ -105,6 +105,7 @@
   "--vb-form-control-transition-timing-function": "var(--vb-transition-timing-function)",
   "--vb-form-control-transition-duration": "var(--vb-transition-duration-short)",
   "--vb-form-control-transition-property": "(background-color, outline)",
+  "--vb-form-control-choice-size": "1.25em",
   "--vb-form-control-choice-color": "var(--vb-foreground-subtle)",
   "--vb-form-control-choice-accent": "var(--vb-form-control-accent)",
   "--vb-form-control-choice-fill": "var(--vb-form-control-background)",

--- a/packages/checkbox/src/_checkbox.scss
+++ b/packages/checkbox/src/_checkbox.scss
@@ -1,12 +1,13 @@
 @use "@vrembem/core";
 @use "@vrembem/core/tokens";
 
+$-size: tokens.get("checkbox", "size", tokens.get("form-control-choice-size"));
 $-color: tokens.get("checkbox", "color", tokens.get("form-control-choice-color"));
 $-accent: tokens.get("checkbox", "accent", tokens.get("form-control-choice-accent"));
 $-fill: tokens.get("checkbox", "fill", tokens.get("form-control-choice-fill"));
 
 #{core.bem("checkbox")} {
-  @include core.size(1.25em);
+  @include core.size($-size);
   @include core.focus-ring-base;
 
   cursor: pointer;

--- a/packages/core/src/tokens/_form-control.scss
+++ b/packages/core/src/tokens/_form-control.scss
@@ -33,6 +33,7 @@
 @include tokens.set(
   "core",
   (
+    "form-control-choice-size": 1.25em,
     "form-control-choice-color": tokens.get("foreground-subtle"),
     "form-control-choice-accent": tokens.get("form-control-accent"),
     "form-control-choice-fill": tokens.get("form-control-background")

--- a/packages/radio/src/_radio.scss
+++ b/packages/radio/src/_radio.scss
@@ -1,12 +1,13 @@
 @use "@vrembem/core";
 @use "@vrembem/core/tokens";
 
+$-size: tokens.get("radio", "size", tokens.get("form-control-choice-size"));
 $-color: tokens.get("radio", "color", tokens.get("form-control-choice-color")) !default;
 $-accent: tokens.get("radio", "accent", tokens.get("form-control-choice-accent"));
 $-fill: tokens.get("radio", "fill", tokens.get("form-control-choice-fill")) !default;
 
 #{core.bem("radio")} {
-  @include core.size(1.25em);
+  @include core.size($-size);
   @include core.focus-ring-base;
 
   cursor: pointer;

--- a/packages/switch/src/_switch.scss
+++ b/packages/switch/src/_switch.scss
@@ -1,12 +1,13 @@
 @use "@vrembem/core";
 @use "@vrembem/core/tokens";
 
+$-size: tokens.get("switch", "size", tokens.get("form-control-choice-size"));
 $-color: tokens.get("switch", "color", tokens.get("form-control-choice-color"));
 $-accent: tokens.get("switch", "accent", tokens.get("form-control-choice-accent"));
 $-fill: tokens.get("switch", "fill", tokens.get("form-control-choice-fill"));
 
 #{core.bem("switch")} {
-  @include core.size(2.5em, 1.25em);
+  @include core.size(calc($-size * 2), $-size);
   @include core.focus-ring-base;
 
   cursor: pointer;

--- a/packages/vrembem/index.html
+++ b/packages/vrembem/index.html
@@ -42,8 +42,8 @@
           <div class="panel box-shadow-xl" role="dialog" aria-labelledby="dialog-title" aria-describedby="dialog-description" tabindex="-1">
             <div class="panel__header">
               <h2 class="panel__title" id="dialog-title">Panel title</h2>
-              <button class="button button--size-sm padding-xs">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" role="img"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+              <button class="button button--icon button--size-sm">
+                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256"><path d="M208.49,191.51a12,12,0,0,1-17,17L128,145,64.49,208.49a12,12,0,0,1-17-17L111,128,47.51,64.49a12,12,0,0,1,17-17L128,111l63.51-63.52a12,12,0,0,1,17,17L145,128Z"></path></svg>
               </button>
             </div>
             <div class="panel__body">


### PR DESCRIPTION
## What changed?

This PR adds and applies a new `form-control-choice-size` token for setting the desired size of checkbox, radio and switch components.