### PR TITLE
Implement package import config short-key usage

### DIFF
--- a/docs/src/content/pages/guide/get-started.mdx
+++ b/docs/src/content/pages/guide/get-started.mdx
@@ -221,14 +221,14 @@ When configuring an individual package directly, option keys should not be prefi
 ```
 </CodeExample>
 
-When configuring packages through the `vrembem` library entry, package specific configuratuons should be prefixed with their name. Global core configurations are not prefixed.
+When configuring packages through the `vrembem` library entry, package specific configurations should be prefixed with their name. Core configurations are not prefixed.
 
 <CodeExample lang="scss">
 ```scss
 @use "vrembem" with (
   $config: (
     // Core options are not prefixed
-    "prefix-blocks": "vb",
+    "theme-output": false,
 
     // Package specific option should be prefixed with the package name
     "button-block-breakpoints": false

--- a/docs/src/content/pages/guide/get-started.mdx
+++ b/docs/src/content/pages/guide/get-started.mdx
@@ -204,3 +204,37 @@ For individual packages, the same pattern applies.
     ```
   </TabsPanel>
 </CodeExample>
+
+### Configuration
+
+Vrembem packages expose a `$config` Sass map that can be set using either the [config module](/packages/core/config#using-config-module) or [Sass `with` clause](/packages/core/config#using-with-clause) methods.
+
+When configuring an individual package directly, option keys should not be prefixed with the package name:
+
+<CodeExample lang="scss">
+```scss
+@use "@vrembem/button" with (
+  $config: (
+    "block-breakpoints": false
+  )
+);
+```
+</CodeExample>
+
+When configuring packages through the `vrembem` library entry, package specific configuratuons should be prefixed with their name. Global core configurations are not prefixed.
+
+<CodeExample lang="scss">
+```scss
+@use "vrembem" with (
+  $config: (
+    // Core options are not prefixed
+    "prefix-blocks": "vb",
+
+    // Package specific option should be prefixed with the package name
+    "button-block-breakpoints": false
+  )
+);
+```
+</CodeExample>
+
+Check each package's own documentation page for the specific options it supports. For more on how the configuration system works under the hood, see the [`core/config`](/packages/core/config) module documentation.

--- a/docs/src/content/pages/packages/button.mdx
+++ b/docs/src/content/pages/packages/button.mdx
@@ -33,11 +33,11 @@ Button comes with the following Sass configuration options that can be set using
   $config: (
     // Toggle for outputting button--block modifier breakpoint variants
     // @type boolean
-    "button-block-breakpoints": true,
+    "block-breakpoints": true,
 
     // Map for outputting button--color-[key] modifier variants
     // @type map
-    "button-color": (
+    "color": (
       "default": (
         "color-contrast": white,
         "color-mix": black

--- a/docs/src/content/pages/packages/content.mdx
+++ b/docs/src/content/pages/packages/content.mdx
@@ -36,26 +36,26 @@ Content comes with the following Sass configuration options that can be set usin
     // Controls whether module styles are output. This can be overridden on a per 
     // module basis using the `content-output-exceptions` config option.
     // @type boolean
-    "content-output": true,
+    "output": true,
 
     // Modules to exclude from the output rule set in `content-output`
     // @type list
-    "content-output-exceptions": (),
+    "output-exceptions": (),
 
     // A map containing module names as keys and their preferred class selectors
     // @type map
-    "content-classes": (),
+    "classes": (),
 
     // A prefix to apply to content class selectors. Provided value is automatically 
     // suffixed with a "-" character when applied.
     // @type string
-    "content-prefix": "",
+    "prefix": "",
 
     // Used to output the heading styles and their font-size/line-height CSS 
     // variables. Should contain a key of the heading level to output and the 
     // value of a font-size and optional line-height (space separated).
     // @type map
-    "content-headings": (
+    "headings": (
       "h1": 2.75em 1.1,
       "h2": 2em 1.25,
       "h3": 1.75em 1.3,
@@ -65,7 +65,7 @@ Content comes with the following Sass configuration options that can be set usin
 
     // Map modules to their preferred content selectors
     // @type map
-    "content-selectors": (
+    "selectors": (
       "h1": "> h1",
       "h2": "> h2",
       "h3": "> h3",

--- a/docs/src/content/pages/packages/core/config.mdx
+++ b/docs/src/content/pages/packages/core/config.mdx
@@ -190,7 +190,7 @@ $default: (
 ```
 </CodeExample>
 
-Use the namespace argument to prefix all options with the config package name.
+Use the namespace argument to prefix all options with a package namespace (typically the package name).
 
 <CodeExample label="_example.scss">
 ```scss

--- a/docs/src/content/pages/packages/core/config.mdx
+++ b/docs/src/content/pages/packages/core/config.mdx
@@ -168,6 +168,10 @@ Merges a configuration map to the config module based on the values in a default
   The default map that is also used as a map signature for `$config`.
 </ReferenceCard>
 
+<ReferenceCard name="$namespace" type="string" defaults="null">
+  A package namespace to prefix all provided config and default keys. This allows omitting the package name from config options in package imports.
+</ReferenceCard>
+
 #### Example
 
 We define an empty `$config` map with the `!default` flag and a `$default` map containing the configurations we want to expose and their default values.
@@ -178,49 +182,30 @@ We define an empty `$config` map with the `!default` flag and a `$default` map c
 
 $config: () !default;
 $default: (
-  "config-1": true,
-  "config-2": "asdf",
+  "config-one": true,
+  "config-two": "asdf",
 );
 
 @include config.merge-with-default($config, $default);
 ```
 </CodeExample>
 
-When we use this module, we can define the configuration using the Sass `with` clause:
+Use the namespace argument to prefix all options with the config package name.
 
-<CodeExample label="app.scss">
+<CodeExample label="_example.scss">
 ```scss
-@use "example" with (
-  $config: (
-    "config-1": false
-  )
-);
-
-// More imports here...
-```
-</CodeExample>
-
-We can also set our configuration values before the module is loaded and include our config at the top of our manifest file:
-
-<CodeExample label="_config.scss">
-```scss
-// Import the config module
 @use "@vrembem/core/config";
 
-// These values will be used once the module is loaded
-@include config.set((
-  "config-1": false,
-  "config-2": "fdsa"
-));
-```
-</CodeExample>
+$config: () !default;
+$default: (
+  "one": true,
+  "two": "asdf",
+);
 
-<CodeExample label="app.scss">
-```scss
-@use "config";
-@use "example";
+@include config.merge-with-default($config, $default, "config");
 
-// More imports here...
+// Options are stored with the package namespace prefixed
+// config.get("config-one") => true
 ```
 </CodeExample>
 

--- a/docs/src/content/pages/packages/drawer.mdx
+++ b/docs/src/content/pages/packages/drawer.mdx
@@ -65,11 +65,11 @@ Drawer comes with the following Sass configuration options that can be set using
   $config: (
     // Sets the default breakpoint for drawers
     // @type string | number
-    "drawer-breakpoint": "md",
+    "breakpoint": "md",
 
     // Set the default position of modal drawers
     // @type string
-    "drawer-position": "left"
+    "position": "left"
   )
 );
 ```

--- a/docs/src/content/pages/packages/flex.mdx
+++ b/docs/src/content/pages/packages/flex.mdx
@@ -32,7 +32,7 @@ Flex comes with the following Sass configuration options that can be set using e
   $config: (
     // Map for outputting flex--gap-[key] modifier variants
     // @type map
-    "flex-gap": (
+    "gap": (
       "breakpoints": true,
       "default": tokens.get("spacing-md"),
       "0": 0,
@@ -45,7 +45,7 @@ Flex comes with the following Sass configuration options that can be set using e
 
     // Map for outputting flex--wrap-[key] modifier variants
     // @type map
-    "flex-wrap": (
+    "wrap": (
       "breakpoints": true,
       "default": wrap,
       "": wrap,
@@ -55,7 +55,7 @@ Flex comes with the following Sass configuration options that can be set using e
 
     // Map for outputting flex--direction-[key] modifier variants
     // @type map
-    "flex-direction": (
+    "direction": (
       "breakpoints": true,
       "default": row,
       "row": row,
@@ -67,7 +67,7 @@ Flex comes with the following Sass configuration options that can be set using e
     // Map for outputting flex--items-[key] modifier and flex-item-[key] utility 
     // variants.
     // @type map
-    "flex-items": (
+    "items": (
       "breakpoints": true,
       "initial": initial, // Equivalent: 0 1 auto
       "auto": auto, // Equivalent: 1 1 auto

--- a/docs/src/content/pages/packages/grid.mdx
+++ b/docs/src/content/pages/packages/grid.mdx
@@ -32,7 +32,7 @@ Grid comes with the following Sass configuration options that can be set using e
   $config: (
     // Map for outputting grid--cols-[num] modifier and col-[num] utility variants
     // @type map
-    "grid-cols": (
+    "cols": (
       "breakpoints": true,
       "default": 1,
       "total": 6
@@ -40,7 +40,7 @@ Grid comes with the following Sass configuration options that can be set using e
 
     // Map for outputting grid--rows-[num] modifier and row-[num] utility variants
     // @type map
-    "grid-rows": (
+    "rows": (
       "breakpoints": true,
       "default": 1,
       "total": 6
@@ -48,7 +48,7 @@ Grid comes with the following Sass configuration options that can be set using e
 
     // Map for outputting the grid--gap-[key] modifier variants
     // @type map
-    "grid-gap": (
+    "gap": (
       "breakpoints": true,
       "default": calc(tokens.get("spacing") * 8),
       "0": 0,
@@ -61,7 +61,7 @@ Grid comes with the following Sass configuration options that can be set using e
 
     // Map for outputting the grid--flow-[key] modifier variants
     // @type map
-    "grid-flow": (
+    "flow": (
       "default": dense,
       "row": row,
       "col": column,

--- a/docs/src/content/pages/packages/menu.mdx
+++ b/docs/src/content/pages/packages/menu.mdx
@@ -34,11 +34,11 @@ Menu comes with the following Sass configuration options that can be set using e
   $config: (
     // Toggle for outputting menu--inline modifier breakpoint variants
     // @type boolean
-    "menu-inline-breakpoints": true,
+    "inline-breakpoints": true,
 
     // Toggle for outputting menu--full modifier breakpoint variants
     // @type boolean
-    "menu-full-breakpoints": true
+    "full-breakpoints": true
   )
 );
 ```

--- a/docs/src/content/pages/packages/modal.mdx
+++ b/docs/src/content/pages/packages/modal.mdx
@@ -32,13 +32,13 @@ Modal comes with the following Sass configuration options that can be set using 
   $config: (
     // A map of CSS variable overrides to pass to the panel component if used
     // @type map
-    "modal-panel-override": (
+    "panel-override": (
       "box-shadow": tokens.get("box-shadow-xl")
     ),
 
     // Map for outputting modal--size-[key] modifier variants
     // @type map
-    "modal-size": (
+    "size": (
       "default": 32rem,
       "xs": 16rem,
       "sm": 24rem,

--- a/docs/src/content/pages/packages/popover.mdx
+++ b/docs/src/content/pages/packages/popover.mdx
@@ -54,7 +54,7 @@ Popover comes with the following Sass configuration options that can be set usin
   $config: (
     // Map for outputting popover--width-[key] modifier variants
     // @type map
-    "popover-width": (
+    "width": (
       "default": 14rem,
       "auto": "fit-content",
       "sm": 10rem,

--- a/docs/src/content/pages/packages/table.mdx
+++ b/docs/src/content/pages/packages/table.mdx
@@ -32,7 +32,7 @@ Table comes with the following Sass configuration options that can be set using 
   $config: (
     // Toggle for outputting table--mobile modifier breakpoint variants
     // @type boolean
-    "table-mobile": (
+    "mobile": (
       "breakpoints": true,
       "attr": "data-mobile-label"
     )

--- a/docs/src/content/pages/packages/utility.mdx
+++ b/docs/src/content/pages/packages/utility.mdx
@@ -39,28 +39,28 @@ Utility comes with the following Sass configuration options that can be set usin
     // Controls whether module styles are output. This can be overridden on a per 
     // module basis using the `utility-output-exceptions` config option.
     // @type boolean
-    "utility-output": true,
+    "output": true,
 
     // Modules to exclude from the output rule set in `utility-output`
     // @type list
-    "utility-output-exceptions": (),
+    "output-exceptions": (),
 
     // A map containing module names as keys and their preferred class selectors
     // @type map
-    "utility-classes": (),
+    "classes": (),
 
     // A prefix to apply to utility class selectors. Provided value is 
     // automatically suffixed with a "-" character when applied.
     // @type string
-    "utility-prefix": "",
+    "prefix": "",
 
     // Whether or not utility styles should be output with the !important flag
     // @type boolean
-    "utility-important": false,
+    "important": false,
 
     // A map of border-radius utilities to output
     // @type map
-    "utility-border-radius": (
+    "border-radius": (
       "": tokens.get("border-radius"),
       "lg": tokens.get("border-radius-lg"),
       "circle": tokens.get("border-radius-circle"),
@@ -69,7 +69,7 @@ Utility comes with the following Sass configuration options that can be set usin
 
     // A list of display value properties to output
     // @type list
-    "utility-display": (
+    "display": (
       "breakpoints": true,
       "inline": inline,
       "flex": flex,
@@ -83,7 +83,7 @@ Utility comes with the following Sass configuration options that can be set usin
 
     // A spacing scale used to output margin, padding, and spacing utilities
     // @type map
-    "utility-spacing": (
+    "spacing": (
       "0": 0,
       "xs": tokens.get("spacing"),
       "sm": calc(tokens.get("spacing") * 2),
@@ -94,7 +94,7 @@ Utility comes with the following Sass configuration options that can be set usin
 
     // A map of gap utilities to output
     // @type map
-    "utility-gap": (
+    "gap": (
       "0": 0,
       "xs": tokens.get("spacing"),
       "sm": tokens.get("spacing-sm"),
@@ -105,7 +105,7 @@ Utility comes with the following Sass configuration options that can be set usin
 
     // A map of max-width utilities to output
     // @type map
-    "utility-max-width": (
+    "max-width": (
       "none": none,
       "xs": 45rem,
       "sm": 60rem,
@@ -117,7 +117,7 @@ Utility comes with the following Sass configuration options that can be set usin
 
     // A map of font-weight keys and values to output
     // @type map
-    "utility-font-weight": (
+    "font-weight": (
       "thin": 100,
       "extra-light": 200,
       "light": 300,
@@ -133,7 +133,7 @@ Utility comes with the following Sass configuration options that can be set usin
 
     // The range of flex-grow and flex-shrink utilities to output
     // @type number
-    "utility-flex-range": 6
+    "flex-range": 6
   )
 );
 ```

--- a/packages/button/src/_config.scss
+++ b/packages/button/src/_config.scss
@@ -8,11 +8,11 @@ $config: () !default;
 $default: (
   // Toggle for outputting button--block modifier breakpoint variants
   // @type boolean
-  "button-block-breakpoints": true,
+  "block-breakpoints": true,
 
   // Map for outputting button--color-[key] modifier variants
   // @type map
-  "button-color": (
+  "color": (
     "default": (
       "color-contrast": white,
       "color-mix": black
@@ -24,5 +24,5 @@ $default: (
   )
 );
 
-@include config.merge-with-default($config, $default);
+@include config.merge-with-default($config, $default, "button");
 @include tokens.register("button");

--- a/packages/content/src/_config.scss
+++ b/packages/content/src/_config.scss
@@ -8,26 +8,26 @@ $default: (
   // Controls whether module styles are output. This can be overridden on a per 
   // module basis using the `content-output-exceptions` config option.
   // @type boolean
-  "content-output": true,
+  "output": true,
 
   // Modules to exclude from the output rule set in `content-output`
   // @type list
-  "content-output-exceptions": (),
+  "output-exceptions": (),
 
   // A map containing module names as keys and their preferred class selectors
   // @type map
-  "content-classes": (),
+  "classes": (),
 
   // A prefix to apply to content class selectors. Provided value is automatically 
   // suffixed with a "-" character when applied.
   // @type string
-  "content-prefix": "",
+  "prefix": "",
 
   // Used to output the heading styles and their font-size/line-height CSS 
   // variables. Should contain a key of the heading level to output and the 
   // value of a font-size and optional line-height (space separated).
   // @type map
-  "content-headings": (
+  "headings": (
     "h1": 2.75rem 1.25,
     "h2": 2rem 1.25,
     "h3": 1.75rem 1.25,
@@ -37,7 +37,7 @@ $default: (
 
   // Map modules to their preferred content selectors
   // @type map
-  "content-selectors": (
+  "selectors": (
     "h1": "> h1",
     "h2": "> h2",
     "h3": "> h3",
@@ -53,4 +53,4 @@ $default: (
   )
 );
 
-@include config.merge-with-default($config, $default);
+@include config.merge-with-default($config, $default, "content");

--- a/packages/core/src/modules/_config.scss
+++ b/packages/core/src/modules/_config.scss
@@ -231,35 +231,44 @@ $-flags: ("variants");
 ///   The config map to set in the global config object.
 /// @param {map} $default
 ///   The default map that is also used as a map signature for `$config`.
-///
-@mixin merge-with-default($config, $default) {
-  @each $key, $default-value in $default {
+/// @param {string} $namespace (null)
+///   A package namespace to prefix all provided config and default keys. This 
+///   allows omitting the package name from config options in package imports.
+/// 
+@mixin merge-with-default($config, $default, $namespace: null) {
+  @each $short-key, $default-value in $default {
+    // Create and build the $full-key if a $namespace is provided
+    $full-key: $short-key;
+    @if $namespace {
+      $full-key: "#{$namespace}-#{$short-key}";
+    }
+
     // Initialize the result with the provided default value
     $result: $default-value;
 
     // If key has already been set, either replace or merge with default
-    @if map.has-key($-config, $key) {
-      @if meta.type-of($result) == "map" and not map.has-key($-config-replace, $key) {
-        $result: map.deep-merge($result, map.get($-config, $key));
+    @if map.has-key($-config, $full-key) {
+      @if meta.type-of($result) == "map" and not map.has-key($-config-replace, $full-key) {
+        $result: map.deep-merge($result, map.get($-config, $full-key));
       } @else {
-        $result: map.get($-config, $key);
+        $result: map.get($-config, $full-key);
       }
     }
 
     // If provided config contains key, merge with the current result
-    @if map.has-key($config, $key) {
+    @if map.has-key($config, $short-key) {
       @if meta.type-of($result) == "map" {
-        $result: map.deep-merge($result, map.get($config, $key));
+        $result: map.deep-merge($result, map.get($config, $short-key));
       } @else {
-        $result: map.get($config, $key);
+        $result: map.get($config, $short-key);
       }
     }
 
     // Apply the configuration option
-    $-config: map.set($-config, $key, $result) !global;
-    $-config-replace: map.remove($-config-replace, $key) !global;
+    $-config: map.set($-config, $full-key, $result) !global;
+    $-config-replace: map.remove($-config-replace, $full-key) !global;
 
-    @include -run-watchers($key, "set");
+    @include -run-watchers($full-key, "set");
   }
 }
 

--- a/packages/core/src/modules/_config.scss
+++ b/packages/core/src/modules/_config.scss
@@ -232,13 +232,14 @@ $-flags: ("variants");
 /// @param {map} $default
 ///   The default map that is also used as a map signature for `$config`.
 /// @param {string} $namespace (null)
-///   A package namespace to prefix all provided config and default keys. This 
+///   A package namespace to prefix all provided config and default keys. This
 ///   allows omitting the package name from config options in package imports.
-/// 
+///
 @mixin merge-with-default($config, $default, $namespace: null) {
   @each $short-key, $default-value in $default {
     // Create and build the $full-key if a $namespace is provided
     $full-key: $short-key;
+
     @if $namespace {
       $full-key: "#{$namespace}-#{$short-key}";
     }

--- a/packages/core/src/modules/_config.scss
+++ b/packages/core/src/modules/_config.scss
@@ -240,7 +240,7 @@ $-flags: ("variants");
     // Create and build the $full-key if a $namespace is provided
     $full-key: $short-key;
 
-    @if $namespace {
+    @if $namespace and string.index($short-key, "#{$namespace}-") != 1 {
       $full-key: "#{$namespace}-#{$short-key}";
     }
 
@@ -256,7 +256,16 @@ $-flags: ("variants");
       }
     }
 
-    // If provided config contains key, merge with the current result
+    // If provided config contains the full key, merge with the current result
+    @if map.has-key($config, $full-key) {
+      @if meta.type-of($result) == "map" {
+        $result: map.deep-merge($result, map.get($config, $full-key));
+      } @else {
+        $result: map.get($config, $full-key);
+      }
+    }
+
+    // If provided config contains the short key, merge with the current result
     @if map.has-key($config, $short-key) {
       @if meta.type-of($result) == "map" {
         $result: map.deep-merge($result, map.get($config, $short-key));

--- a/packages/drawer/src/_config.scss
+++ b/packages/drawer/src/_config.scss
@@ -8,12 +8,12 @@ $config: () !default;
 $default: (
   // Sets the default breakpoint for drawers
   // @type string | number
-  "drawer-breakpoint": "md",
+  "breakpoint": "md",
 
   // Set the default position of modal drawers
   // @type string
-  "drawer-position": "left"
+  "position": "left"
 );
 
-@include config.merge-with-default($config, $default);
+@include config.merge-with-default($config, $default, "drawer");
 @include tokens.register("drawer");

--- a/packages/flex/src/_config.scss
+++ b/packages/flex/src/_config.scss
@@ -8,7 +8,7 @@ $config: () !default;
 $default: (
   // Map for outputting flex--gap-[key] modifier variants
   // @type map
-  "flex-gap": (
+  "gap": (
     "breakpoints": true,
     "default": tokens.get("spacing-md"),
     "0": 0,
@@ -21,7 +21,7 @@ $default: (
 
   // Map for outputting flex--wrap-[key] modifier variants
   // @type map
-  "flex-wrap": (
+  "wrap": (
     "breakpoints": true,
     "default": wrap,
     "": wrap,
@@ -31,7 +31,7 @@ $default: (
 
   // Map for outputting flex--direction-[key] modifier variants
   // @type map
-  "flex-direction": (
+  "direction": (
     "breakpoints": true,
     "default": row,
     "row": row,
@@ -43,7 +43,7 @@ $default: (
   // Map for outputting flex--items-[key] modifier and flex-item-[key] utility 
   // variants.
   // @type map
-  "flex-items": (
+  "items": (
     "breakpoints": true,
     "initial": initial, // Equivalent: 0 1 auto
     "auto": auto, // Equivalent: 1 1 auto
@@ -54,5 +54,5 @@ $default: (
   )
 );
 
-@include config.merge-with-default($config, $default);
+@include config.merge-with-default($config, $default, "flex");
 @include tokens.register("flex");

--- a/packages/grid/src/_config.scss
+++ b/packages/grid/src/_config.scss
@@ -8,7 +8,7 @@ $config: () !default;
 $default: (
   // Map for outputting grid--cols-[num] modifier and col-[num] utility variants
   // @type map
-  "grid-cols": (
+  "cols": (
     "breakpoints": true,
     "default": 1,
     "total": 6
@@ -16,7 +16,7 @@ $default: (
 
   // Map for outputting grid--rows-[num] modifier and row-[num] utility variants
   // @type map
-  "grid-rows": (
+  "rows": (
     "breakpoints": true,
     "default": 1,
     "total": 6
@@ -24,7 +24,7 @@ $default: (
 
   // Map for outputting the grid--gap-[key] modifier variants
   // @type map
-  "grid-gap": (
+  "gap": (
     "breakpoints": true,
     "default": calc(tokens.get("spacing") * 8),
     "0": 0,
@@ -37,7 +37,7 @@ $default: (
 
   // Map for outputting the grid--flow-[key] modifier variants
   // @type map
-  "grid-flow": (
+  "flow": (
     "default": dense,
     "row": row,
     "col": column,
@@ -46,5 +46,5 @@ $default: (
   )
 );
 
-@include config.merge-with-default($config, $default);
+@include config.merge-with-default($config, $default, "grid");
 @include tokens.register("grid");

--- a/packages/menu/src/_config.scss
+++ b/packages/menu/src/_config.scss
@@ -8,12 +8,12 @@ $config: () !default;
 $default: (
   // Toggle for outputting menu--inline modifier breakpoint variants
   // @type boolean
-  "menu-inline-breakpoints": true,
+  "inline-breakpoints": true,
 
   // Toggle for outputting menu--full modifier breakpoint variants
   // @type boolean
-  "menu-full-breakpoints": true
+  "full-breakpoints": true
 );
 
-@include config.merge-with-default($config, $default);
+@include config.merge-with-default($config, $default, "menu");
 @include tokens.register("menu");

--- a/packages/modal/src/_config.scss
+++ b/packages/modal/src/_config.scss
@@ -8,13 +8,13 @@ $config: () !default;
 $default: (
   // A map of CSS variable overrides to pass to the panel component if used
   // @type map
-  "modal-panel-override": (
+  "panel-override": (
     "box-shadow": tokens.get("box-shadow-xl")
   ),
 
   // Map for outputting modal--size-[key] modifier variants
   // @type map
-  "modal-size": (
+  "size": (
     "default": 32rem,
     "xs": 16rem,
     "sm": 24rem,
@@ -23,6 +23,6 @@ $default: (
   )
 );
 
-@include config.merge-with-default($config, $default);
+@include config.merge-with-default($config, $default, "modal");
 @include tokens.register("modal");
 @include tokens.register("panel");

--- a/packages/popover/src/_config.scss
+++ b/packages/popover/src/_config.scss
@@ -8,7 +8,7 @@ $config: () !default;
 $default: (
   // Map for outputting popover--width-[key] modifier variants
   // @type map
-  "popover-width": (
+  "width": (
     "default": 14rem,
     "auto": "fit-content",
     "sm": 10rem,
@@ -16,5 +16,5 @@ $default: (
   )
 );
 
-@include config.merge-with-default($config, $default);
+@include config.merge-with-default($config, $default, "popover");
 @include tokens.register("popover");

--- a/packages/table/src/_config.scss
+++ b/packages/table/src/_config.scss
@@ -9,14 +9,14 @@ $default: (
   // Toggle for outputting table--mobile modifier breakpoint variants and setting
   // data attribute for mobile labels.
   // @type map
-  "table-mobile": (
+  "mobile": (
     "breakpoints": true,
     "attr": "data-mobile-label"
   ),
 
   // Map for outputting table--padding-[key] modifier variants
   // @type map
-  "table-padding": (
+  "padding": (
     "breakpoints": true,
     "default": 0.5em 0.75em,
     "sm": 0.25em 0.5em,
@@ -25,5 +25,5 @@ $default: (
   )
 );
 
-@include config.merge-with-default($config, $default);
+@include config.merge-with-default($config, $default, "table");
 @include tokens.register("table");

--- a/packages/utility/src/_config.scss
+++ b/packages/utility/src/_config.scss
@@ -9,28 +9,28 @@ $default: (
   // Controls whether module styles are output. This can be overridden on a per 
   // module basis using the `utility-output-exceptions` config option.
   // @type boolean
-  "utility-output": true,
+  "output": true,
 
   // Modules to exclude from the output rule set in `utility-output`
   // @type list
-  "utility-output-exceptions": (),
+  "output-exceptions": (),
 
   // A map containing module names as keys and their preferred class selectors
   // @type map
-  "utility-classes": (),
+  "classes": (),
 
   // A prefix to apply to utility class selectors. Provided value is 
   // automatically suffixed with a "-" character when applied.
   // @type string
-  "utility-prefix": "",
+  "prefix": "",
 
   // Whether or not utility styles should be output with the !important flag
   // @type boolean
-  "utility-important": false,
+  "important": false,
 
   // A map of border-radius utilities to output
   // @type map
-  "utility-border-radius": (
+  "border-radius": (
     "": tokens.get("border-radius"),
     "lg": tokens.get("border-radius-lg"),
     "circle": tokens.get("border-radius-circle"),
@@ -39,7 +39,7 @@ $default: (
 
   // A list of display value properties to output
   // @type list
-  "utility-display": (
+  "display": (
     "breakpoints": true,
     "inline": inline,
     "flex": flex,
@@ -53,7 +53,7 @@ $default: (
 
   // A spacing scale used to output margin, padding, and spacing utilities
   // @type map
-  "utility-spacing": (
+  "spacing": (
     "0": 0,
     "xs": tokens.get("spacing"),
     "sm": calc(tokens.get("spacing") * 2),
@@ -64,7 +64,7 @@ $default: (
 
   // A spacing scale used to output em based spacing utilities
   // @type map
-  "utility-em-spacing": (
+  "em-spacing": (
     "xs": tokens.get("em-spacing-xs"),
     "sm": tokens.get("em-spacing-sm"),
     "": tokens.get("em-spacing-md"),
@@ -74,7 +74,7 @@ $default: (
 
   // A map of gap utilities to output
   // @type map
-  "utility-gap": (
+  "gap": (
     "0": 0,
     "xs": tokens.get("spacing-xs"),
     "sm": tokens.get("spacing-sm"),
@@ -85,7 +85,7 @@ $default: (
 
   // A map of max-width utilities to output
   // @type map
-  "utility-max-width": (
+  "max-width": (
     "none": none,
     "xs": 45rem,
     "sm": 60rem,
@@ -97,7 +97,7 @@ $default: (
 
   // A map of font-weight keys and values to output
   // @type map
-  "utility-font-weight": (
+  "font-weight": (
     "thin": 100,
     "extra-light": 200,
     "light": 300,
@@ -113,7 +113,7 @@ $default: (
 
   // The range of flex-grow and flex-shrink utilities to output
   // @type number
-  "utility-flex-range": 6
+  "flex-range": 6
 );
 
-@include config.merge-with-default($config, $default);
+@include config.merge-with-default($config, $default, "utility");

--- a/packages/vrembem/base.scss
+++ b/packages/vrembem/base.scss
@@ -1,2 +1,3 @@
+@forward "./src/config";
 @forward "@vrembem/core/base";
 @forward "@vrembem/content" as content-*;

--- a/packages/vrembem/components.scss
+++ b/packages/vrembem/components.scss
@@ -1,3 +1,4 @@
+@forward "./src/config";
 @forward "@vrembem/flex" as flex-*;
 @forward "@vrembem/grid" as grid-*;
 @forward "@vrembem/button" as button-*;

--- a/packages/vrembem/index.scss
+++ b/packages/vrembem/index.scss
@@ -1,3 +1,4 @@
+@forward "./src/config";
 @forward "@vrembem/core/layers";
 @forward "@vrembem/core/base";
 @forward "@vrembem/content" as content-*;

--- a/packages/vrembem/src/_config.scss
+++ b/packages/vrembem/src/_config.scss
@@ -1,0 +1,7 @@
+@use "@vrembem/core/config";
+
+$config: () !default;
+
+@each $key, $value in $config {
+  @include config.set($key, $value);
+}

--- a/packages/vrembem/utilities.scss
+++ b/packages/vrembem/utilities.scss
@@ -1,1 +1,2 @@
+@forward "./src/config";
 @forward "@vrembem/utility" as utility-*;


### PR DESCRIPTION
## What changed?

This PR removes the need to package specific import configuration's applying a key prefixes by giving `merge-with-defaults` mixin a namespace argument. When the namespace argument is provided, all keys within the provided config and defaults are prefixed using that namespace (usually set to the package name).

**Example Usage**

```scss
// Configuration using a direct package import
@use "@vrembem/button" with (
  $config: (
    "block-breakpoints": false
  )
);

// Configuration using the library import
@use "vrembem" with (
  $config: (
    "button-block-breakpoints": false
  )
);
```

**Notice:** Backwards compatibility has been preserved so existing package imports that use the full config key will still work.